### PR TITLE
[WIP] Create new widget to display multiple CoderDojo in grid layout 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'coffee-rails', '~> 4.1.0'
 gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
 
+gem "bootstrap-sass", "~> 3.3.5"
+gem 'bootstrap-material-design'
 gem 'sass-rails', '~> 5.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,8 +38,15 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
+    autoprefixer-rails (6.3.6)
+      execjs
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootstrap-material-design (0.2.2)
+      bootstrap-sass (~> 3.0)
+    bootstrap-sass (3.3.6)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     builder (3.2.2)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -182,6 +189,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootstrap-material-design
+  bootstrap-sass (~> 3.3.5)
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,7 @@
 //= require jquery_ujs
 //= require scrivito
 //= require scrivito_section_widgets
+//= require scrivito
+//= require bootstrap-sprockets
+//= require bootstrap-material-design
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,13 +12,12 @@
  *
  *= require scrivito
  *= require scrivito_section_widgets
+ *= require bootstrap-material-design
  */
 
+@import "bootstrap-sprockets";
+@import "bootstrap";
 
 body {
-    text-align: center
-}
-
-.container{
-	background-color: blue
+	align-content: center
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,9 @@
 
 </head>
 <body>
-  <%= yield %>
-  <%= scrivito_body_tags %>
+  <div class="container">
+    <%= yield %>
+    <%= scrivito_body_tags %>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
# やりたいこと

CoderDojoをグリッドで表示し、ウェウジェトを利用して追加したり、削除したりできるようにする。

![grid-layout-coder-dojo](https://cloud.githubusercontent.com/assets/6015450/15285310/43c16d6c-1b91-11e6-8f4f-bac412ca77eb.png)
# やること
- [x] BootstrapとHTMLのクラスをマッチさせる。
- [ ] ウェジェットでCoderDojoを個別に簡単に編集できるようにする。 *_< - 技術力が足りないためPostpone *_
  - [ ]画像の編集＆追加
  - [ ]captionの編集＆追加
- [ ] <img width ="90" src="https://cloud.githubusercontent.com/assets/6015450/15285413/ec74ded0-1b91-11e6-8137-6b84ebe24fae.png"></img> の[タグ](https://github.com/kostia/scrivito-tag-editor)に追加できるようにする。
