### PR TITLE
[WIP] Enhance cover section by enabling user to change bg color

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,4 +18,12 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 
-.bg-blue{background-color:blue;}
+.widget.red {
+  background-color: #ff0000;
+}
+.widget.green {
+  background-color: #00ff00;
+}
+.widget.blue {
+  background-color: #0000ff;
+}

--- a/app/models/paragraph_widget.rb
+++ b/app/models/paragraph_widget.rb
@@ -2,5 +2,5 @@ class ParagraphWidget < Widget
   attribute :image, :reference
   attribute :headline, :string
   attribute :text, :string
-  attribute :color, :enum, values: %w[red green blue], default: 'blue'
+  attribute :background_color_select, :enum, values: ["red","green","blue"], default: "red" 
 end

--- a/app/views/paragraph_widget/details.html.erb
+++ b/app/views/paragraph_widget/details.html.erb
@@ -2,4 +2,5 @@
   <%= scrivito_details_for ParagraphWidget.description_for_editor do %>
     A cover with head, text and image
   <% end %>
+  <%= scrivito_tag(:div, widget, :background_color_select) %>
 <% end %>


### PR DESCRIPTION
# やりたいこと

ユーザーが自在にバックグラウンドの背景の色を変更できる様にする。
#3 で問い合わせた内容の対応
## PR #3 で問い合わせた内容の返事

> Hey YassLab,
> I think I described it a bit short. Lets assume you have in your model the following attribute:
> attribute: background_color_select, :enum, values: ["red","green","blue"], default: "red" 
> Then in your details view you would offer this attribute for editing as follows:
> scrivito_tag(:div, widget, :background_color_select)
> Finally in your widgets view you would have something along the following lines:
> 
> <div class="widget <%= widget.background_color_select %>"> ... </div>
> 
> 
> This way the background colour of your widget is changeable by your used. 
> Bartek from Scrivito
> PS: Did you know that there's a one-hour Google Hangout with our developers called "Ask Scrivito" every Monday, starting at 4:00 pm CET (Berlin Time) / 10:00 am EST?
> https://plus.google.com/hangouts/_/infopark.de/ask-scrivito
# やること
- [ ] Codeが実際に動くか確認する。
- [ ] ユーザー側の入力の誤認を対応できる様にする。
