### PR TITLE
Implementation to aggregate statistical information #12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ deploy:
       - "bundle exec rails dojos:update_db_by_yaml"
 script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
+  - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ deploy:
 cache:
   - bundler
 script:
-  - RAILS_ENV=test bundle exec rake db:migrate --trace
+  - bundle exec rake db:migrate --trace
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ cache:
 script:
   - bundle exec rake db:migrate --trace
   - bundle exec rake
+env:
+  global:
+    - TZ='Asia/Tokyo'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ deploy:
   run:
       - "bundle exec rails db:migrate"
       - "bundle exec rails dojos:update_db_by_yaml"
-rvm:
-  - 2.4.0
 cache:
   - bundler
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ deploy:
   run:
       - "bundle exec rails db:migrate"
       - "bundle exec rails dojos:update_db_by_yaml"
+rvm:
+  - 2.4.0
 script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ deploy:
       - "bundle exec rails dojos:update_db_by_yaml"
 rvm:
   - 2.4.0
+cache:
+  - bundler
 script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ deploy:
   run:
       - "bundle exec rails db:migrate"
       - "bundle exec rails dojos:update_db_by_yaml"
-      
+script:
+  - RAILS_ENV=test bundle exec rake db:migrate --trace

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'secure_headers'
 # Rendering legal documents
 gem 'kramdown'
 
+gem 'faraday'
 # TODO: Delete this if the following issue is fixed
 # https://github.com/bundler/bundler/issues/5332
 gem 'faraday_middleware', '0.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,7 @@ DEPENDENCIES
   bootstrap-sass
   capybara
   coffee-rails
+  faraday
   faraday_middleware (= 0.10)
   font-awesome-rails
   jbuilder
@@ -315,4 +316,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.13.7
+   1.15.3

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -3,6 +3,9 @@ class Dojo < ApplicationRecord
   NUM_OF_WHOLE_DOJOS = "1,250"
   NUM_OF_JAPAN_DOJOS = Dojo.count.to_s
 
+  has_one :dojo_event_service
+  has_many :event_history
+
   serialize :tags
   default_scope -> { order(order: :asc) }
   before_save { self.email = self.email.downcase }

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -4,7 +4,7 @@ class Dojo < ApplicationRecord
   NUM_OF_JAPAN_DOJOS = Dojo.count.to_s
 
   has_one :dojo_event_service
-  has_many :event_history
+  has_many :event_histories
 
   serialize :tags
   default_scope -> { order(order: :asc) }

--- a/app/models/dojo_event_service.rb
+++ b/app/models/dojo_event_service.rb
@@ -1,0 +1,3 @@
+class DojoEventService < ApplicationRecord
+  belongs_to :dojo
+end

--- a/app/models/dojo_event_service.rb
+++ b/app/models/dojo_event_service.rb
@@ -1,3 +1,4 @@
 class DojoEventService < ApplicationRecord
   belongs_to :dojo
+  enum name: %i( connpass doorkeeper )
 end

--- a/app/models/event_history.rb
+++ b/app/models/event_history.rb
@@ -1,0 +1,11 @@
+class EventHistory < ApplicationRecord
+  belongs_to :dojo
+
+  validates :dojo_name, presence: true
+  validates :service_name, presence: true, uniqueness: { scope: :event_id  }
+  validates :service_group_id, presence: true
+  validates :event_id, presence: true
+  validates :event_url, presence: true, uniqueness: true, allow_nil: true
+  validates :participants, presence: true
+  validates :evented_at, presence: true
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,9 @@ module CoderdojoJp
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    # Timezone
+    config.time_zone = 'Asia/Tokyo'
+    ENV['TZ'] = 'Asia/Tokyo'
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,5 @@ module CoderdojoJp
 
     # Timezone
     config.time_zone = 'Asia/Tokyo'
-    ENV['TZ'] = 'Asia/Tokyo'
   end
 end

--- a/db/migrate/20170730050122_create_event_histories.rb
+++ b/db/migrate/20170730050122_create_event_histories.rb
@@ -1,0 +1,18 @@
+class CreateEventHistories < ActiveRecord::Migration[5.0]
+  def change
+    create_table :event_histories do |t|
+      t.references :dojo, foreign_key: true, index: true, null: false
+      t.string :dojo_name, null: false
+      t.string :service_name, null: false
+      t.integer :service_group_id, null: false
+      t.integer :event_id, null: false
+      t.string :event_url, unique: true, null: false
+      t.integer :participants, null: false
+      t.datetime :evented_at, null: false
+      t.timestamps
+
+      t.index [:service_name, :event_id], unique: true
+      t.index [:evented_at, :dojo_id]
+    end
+  end
+end

--- a/db/migrate/20170730114150_create_dojo_event_services.rb
+++ b/db/migrate/20170730114150_create_dojo_event_services.rb
@@ -1,0 +1,11 @@
+class CreateDojoEventServices < ActiveRecord::Migration[5.0]
+  def change
+    create_table :dojo_event_services do |t|
+      t.references :dojo, foreign_key: true, index: true, null: false
+      t.string :name
+      t.string :url
+      t.integer :group_id
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170820085052_add_not_null_to_dojo_event_services.rb
+++ b/db/migrate/20170820085052_add_not_null_to_dojo_event_services.rb
@@ -1,0 +1,6 @@
+class AddNotNullToDojoEventServices < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :dojo_event_services, :name, false
+    change_column_null :dojo_event_services, :group_id, false
+  end
+end

--- a/db/migrate/20170820090605_change_column_type_dojo_event_services.rb
+++ b/db/migrate/20170820090605_change_column_type_dojo_event_services.rb
@@ -1,0 +1,9 @@
+class ChangeColumnTypeDojoEventServices < ActiveRecord::Migration[5.0]
+  def up
+    change_column :dojo_event_services, :name, :integer, null: false
+  end
+
+  def down
+    change_column :dojo_event_services, :name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170730114150) do
+ActiveRecord::Schema.define(version: 20170820085052) do
 
   create_table "dojo_event_services", force: :cascade do |t|
     t.integer  "dojo_id",    null: false
-    t.string   "name"
+    t.string   "name",       null: false
     t.string   "url"
-    t.integer  "group_id"
+    t.integer  "group_id",   null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["dojo_id"], name: "index_dojo_event_services_on_dojo_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161217063010) do
+ActiveRecord::Schema.define(version: 20170730050122) do
 
   create_table "dojos", force: :cascade do |t|
     t.string   "name"
@@ -22,6 +22,22 @@ ActiveRecord::Schema.define(version: 20161217063010) do
     t.text     "tags"
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
+  end
+
+  create_table "event_histories", force: :cascade do |t|
+    t.integer  "dojo_id",          null: false
+    t.string   "dojo_name",        null: false
+    t.string   "service_name",     null: false
+    t.integer  "service_group_id", null: false
+    t.integer  "event_id",         null: false
+    t.string   "event_url",        null: false
+    t.integer  "participants",     null: false
+    t.datetime "evented_at",       null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.index ["dojo_id"], name: "index_event_histories_on_dojo_id"
+    t.index ["evented_at", "dojo_id"], name: "index_event_histories_on_evented_at_and_dojo_id"
+    t.index ["service_name", "event_id"], name: "index_event_histories_on_service_name_and_event_id", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170730050122) do
+ActiveRecord::Schema.define(version: 20170730114150) do
+
+  create_table "dojo_event_services", force: :cascade do |t|
+    t.integer  "dojo_id",    null: false
+    t.string   "name"
+    t.string   "url"
+    t.integer  "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dojo_id"], name: "index_dojo_event_services_on_dojo_id"
+  end
 
   create_table "dojos", force: :cascade do |t|
     t.string   "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170820085052) do
+ActiveRecord::Schema.define(version: 20170820090605) do
 
   create_table "dojo_event_services", force: :cascade do |t|
     t.integer  "dojo_id",    null: false
-    t.string   "name",       null: false
+    t.integer  "name",       null: false
     t.string   "url"
     t.integer  "group_id",   null: false
     t.datetime "created_at", null: false

--- a/lib/statistics.rb
+++ b/lib/statistics.rb
@@ -1,4 +1,4 @@
 module Statistics; end
 
 require_relative 'statistics/client'
-require_relative 'Statistics/aggregation'
+require_relative 'statistics/aggregation'

--- a/lib/statistics.rb
+++ b/lib/statistics.rb
@@ -1,0 +1,3 @@
+module Statistics; end
+
+require_relative 'statistics/client'

--- a/lib/statistics.rb
+++ b/lib/statistics.rb
@@ -1,3 +1,4 @@
 module Statistics; end
 
 require_relative 'statistics/client'
+require_relative 'Statistics/runner'

--- a/lib/statistics.rb
+++ b/lib/statistics.rb
@@ -1,4 +1,4 @@
 module Statistics; end
 
 require_relative 'statistics/client'
-require_relative 'Statistics/runner'
+require_relative 'Statistics/aggregation'

--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -22,14 +22,14 @@ module Statistics
             cnps.fetch_events(params.merge(series_id: dojo.dojo_event_service.group_id)).each do |e|
               next unless e.dig('series', 'id') == dojo.dojo_event_service.group_id
 
-              EventHistory.find_or_create_by!(dojo_id: dojo.id,
-                                              dojo_name: dojo.name,
-                                              service_name: dojo.dojo_event_service.name,
-                                              service_group_id: dojo.dojo_event_service.group_id,
-                                              event_id: e['event_id'],
-                                              event_url: e['event_url'],
-                                              participants: e['accepted'],
-                                              evented_at: Time.zone.parse(e['started_at']))
+              EventHistory.create!(dojo_id: dojo.id,
+                                   dojo_name: dojo.name,
+                                   service_name: dojo.dojo_event_service.name,
+                                   service_group_id: dojo.dojo_event_service.group_id,
+                                   event_id: e['event_id'],
+                                   event_url: e['event_url'],
+                                   participants: e['accepted'],
+                                   evented_at: Time.zone.parse(e['started_at']))
             end
           end
         end
@@ -49,14 +49,14 @@ module Statistics
             drkp.fetch_events(params.merge(group_id: dojo.dojo_event_service.group_id)).each do |e|
               next unless e['group'] == dojo.dojo_event_service.group_id
 
-              EventHistory.find_or_create_by!(dojo_id: dojo.id,
-                                              dojo_name: dojo.name,
-                                              service_name: dojo.dojo_event_service.name,
-                                              service_group_id: dojo.dojo_event_service.group_id,
-                                              event_id: e['id'],
-                                              event_url: e['public_url'],
-                                              participants: e['participants'],
-                                              evented_at: Time.zone.parse(e['starts_at']))
+              EventHistory.create!(dojo_id: dojo.id,
+                                   dojo_name: dojo.name,
+                                   service_name: dojo.dojo_event_service.name,
+                                   service_group_id: dojo.dojo_event_service.group_id,
+                                   event_id: e['id'],
+                                   event_url: e['public_url'],
+                                   participants: e['participants'],
+                                   evented_at: Time.zone.parse(e['starts_at']))
             end
           end
         end

--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -2,8 +2,8 @@ module Statistics
   class Aggregation
     class << self
       def run(date:)
-        cnps_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_service: { name: 'connpass' }).to_a
-        drkp_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_service: { name: 'doorkeeper' }).to_a
+        cnps_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_services: { name: 'connpass' }).to_a
+        drkp_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_services: { name: 'doorkeeper' }).to_a
 
         Connpass.run(cnps_dojos, date)
         Doorkeeper.run(drkp_dojos, date)
@@ -13,7 +13,7 @@ module Statistics
     class Connpass
       class << self
         def run(dojos, date)
-          cnps = Cilient::Connpass.new
+          cnps = Client::Connpass.new
           params = {
             yyyymm: "#{date.year}#{date.month}"
           }

--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -2,8 +2,8 @@ module Statistics
   class Aggregation
     class << self
       def run(date:)
-        cnps_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_services: { name: 'connpass' }).to_a
-        drkp_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_services: { name: 'doorkeeper' }).to_a
+        cnps_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_services: { name: :connpass }).to_a
+        drkp_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_services: { name: :doorkeeper }).to_a
 
         Connpass.run(cnps_dojos, date)
         Doorkeeper.run(drkp_dojos, date)

--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -1,5 +1,5 @@
 module Statistics
-  class Runner
+  class Aggregation
     class << self
       def run(date:)
         cnps_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_service: { name: 'connpass' }).to_a

--- a/lib/statistics/client.rb
+++ b/lib/statistics/client.rb
@@ -91,7 +91,7 @@ module Statistics
 
           break if part.size.zero?
 
-          events.push(*part)
+          events.push(*part.map { |e| e['event'] })
 
           break if part.size < 25   # 25 items / 1 request
 

--- a/lib/statistics/client.rb
+++ b/lib/statistics/client.rb
@@ -13,7 +13,7 @@ module Statistics
 
     private
 
-    def connection_for(endpoint, &block)
+    def connection_for(endpoint)
       Faraday.new(endpoint) do |f|
         f.response :logger if self.class.debug
         f.response :json, :content_type => /\bjson$/

--- a/lib/statistics/client.rb
+++ b/lib/statistics/client.rb
@@ -15,7 +15,7 @@ module Statistics
 
     def connection_for(endpoint, &block)
       Faraday.new(endpoint) do |f|
-        f.response :logger if self.debug
+        f.response :logger if self.class.debug
         f.response :json, :content_type => /\bjson$/
         f.response :raise_error
 

--- a/lib/statistics/client.rb
+++ b/lib/statistics/client.rb
@@ -32,11 +32,8 @@ module Statistics
         @client = Client.new(ENDPOINT)
       end
 
-      def fetch_series_id(**params)
-        @client.get('event/', params.merge(count: 1))
-          .fetch('events')
-          .first
-          .dig('series', 'id')
+      def search(keyword:)
+        @client.get('event/', { keyword: keyword, count: 100 })
       end
 
       def fetch_events(series_id:, yyyymm: nil)
@@ -77,10 +74,8 @@ module Statistics
         @default_until = Time.zone.now.end_of_day
       end
 
-      def fetch_group_id(keyword:)
-        @client.get('events', q: keyword, since: DEFAULT_SINCE)
-          .first
-          .dig('event', 'group')
+      def search(keyword:)
+        @client.get('events', q: keyword, since: @default_since)
       end
 
       def fetch_events(group_id:, since_at: @default_since, until_at: @default_until)

--- a/lib/statistics/client.rb
+++ b/lib/statistics/client.rb
@@ -1,0 +1,69 @@
+module Statistics
+  class Client
+    class_attribute :debug
+    self.debug = false
+
+    def initialize(endpoint, &block)
+      @conn = connection_for(endpoint, &block)
+    end
+
+    def get(path, params)
+      @conn.get(path, params).body
+    end
+
+    private
+
+    def connection_for(endpoint, &block)
+      Faraday.new(endpoint) do |f|
+        f.response :logger if self.debug
+        f.response :json, :content_type => /\bjson$/
+        f.response :raise_error
+
+        yield f if block_given?
+
+        f.adapter  Faraday.default_adapter
+      end
+    end
+
+    class Connpass
+      ENDPOINT = 'https://connpass.com/api/v1'.freeze
+
+      def initialize
+        @client = Client.new(ENDPOINT)
+      end
+
+      def fetch_series_id(**params)
+        @client.get('event/', params.merge(count: 1))
+          .fetch('events')
+          .first
+          .dig('series', 'id')
+      end
+
+      def fetch_events(series_id:)
+        @client.get('event/', series_id: series_id, count: 100)
+          .fetch('events')
+      end
+    end
+
+    class Doorkeeper
+      ENDPOINT = 'https://api.doorkeeper.jp'.freeze
+      DEFAULT_SINCE = Date.parse('2010-07-01')
+
+      def initialize
+        @client = Client.new(ENDPOINT) do |c|
+          c.authorization(:Bearer, ENV.fetch('DOORKEEPER_API_TOKEN'))
+        end
+      end
+
+      def fetch_group_id(keyword:)
+        @client.get('events', q: keyword, since: DEFAULT_SINCE)
+          .first
+          .dig('event', 'group')
+      end
+
+      def fetch_events(group_id:, offset: 1, since: DEFAULT_SINCE)
+        @client.get("groups/#{group_id}/events", offset: offset, since: since)
+      end
+    end
+  end
+end

--- a/lib/statistics/client.rb
+++ b/lib/statistics/client.rb
@@ -68,13 +68,13 @@ module Statistics
 
     class Doorkeeper
       ENDPOINT = 'https://api.doorkeeper.jp'.freeze
-      DEFAULT_SINCE = Time.zone.parse('2010-07-01')
-      DEFAULT_UNTIL = Time.zone.now.end_of_day
 
       def initialize
         @client = Client.new(ENDPOINT) do |c|
           c.authorization(:Bearer, ENV.fetch('DOORKEEPER_API_TOKEN'))
         end
+        @default_since = Time.zone.parse('2010-07-01')
+        @default_until = Time.zone.now.end_of_day
       end
 
       def fetch_group_id(keyword:)
@@ -83,7 +83,7 @@ module Statistics
           .dig('event', 'group')
       end
 
-      def fetch_events(group_id:, since_at: DEFAULT_SINCE, until_at: DEFAULT_UNTIL)
+      def fetch_events(group_id:, since_at: @default_since, until_at: @default_until)
         params = {
           page: 1,
           since: since_at,

--- a/lib/statistics/runner.rb
+++ b/lib/statistics/runner.rb
@@ -1,0 +1,57 @@
+module Statistics
+  class Runner
+    class << self
+      def run
+        cnps_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_service: { name: 'connpass' }).to_a
+        drkp_dojos = Dojo.joins(:dojo_event_service).where(dojo_event_service: { name: 'doorkeeper' }).to_a
+
+        Connpass.run(cnps_dojos)
+        Doorkeeper.run(drkp_dojos)
+      end
+    end
+
+    class Connpass
+      class << self
+        def run(dojos)
+          cnps = Cilient::Connpass.new
+          dojos.each do |dojo|
+            cnps.fetch_events(series_id: dojo.dojo_event_service.group_id).each do |e|
+              next unless e.dig('series', 'id') == dojo.dojo_event_service.group_id
+
+              EventHistory.create!(dojo_id: dojo.id,
+                                   dojo_name: dojo.name,
+                                   service_name: dojo.dojo_event_service.name,
+                                   service_group_id: dojo.dojo_event_service.group_id,
+                                   event_id: e['event_id'],
+                                   event_url: e['event_url'],
+                                   participants: e['accepted'],
+                                   evented_at: Time.zone.parse(e['started_at']))
+            end
+          end
+        end
+      end
+    end
+
+    class Doorkeeper
+      class << self
+        def run(dojos)
+          drkp = Client::Doorkeeper.new
+          dojos.each do |dojo|
+            drkp.fetch_events(group_id: dojo.dojo_event_service.group_id).each do |e|
+              next unless e['group'] == dojo.dojo_event_service.group_id
+
+              EventHistory.create!(dojo_id: dojo.id,
+                                   dojo_name: dojo.name,
+                                   service_name: dojo.dojo_event_service.name,
+                                   service_group_id: dojo.dojo_event_service.group_id,
+                                   event_id: e['id'],
+                                   event_url: e['public_url'],
+                                   participants: e['participants'],
+                                   evented_at: Time.zone.parse(e['starts_at']))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/statistics/runner.rb
+++ b/lib/statistics/runner.rb
@@ -22,14 +22,14 @@ module Statistics
             cnps.fetch_events(params.merge(series_id: dojo.dojo_event_service.group_id)).each do |e|
               next unless e.dig('series', 'id') == dojo.dojo_event_service.group_id
 
-              EventHistory.create!(dojo_id: dojo.id,
-                                   dojo_name: dojo.name,
-                                   service_name: dojo.dojo_event_service.name,
-                                   service_group_id: dojo.dojo_event_service.group_id,
-                                   event_id: e['event_id'],
-                                   event_url: e['event_url'],
-                                   participants: e['accepted'],
-                                   evented_at: Time.zone.parse(e['started_at']))
+              EventHistory.find_or_create_by!(dojo_id: dojo.id,
+                                              dojo_name: dojo.name,
+                                              service_name: dojo.dojo_event_service.name,
+                                              service_group_id: dojo.dojo_event_service.group_id,
+                                              event_id: e['event_id'],
+                                              event_url: e['event_url'],
+                                              participants: e['accepted'],
+                                              evented_at: Time.zone.parse(e['started_at']))
             end
           end
         end
@@ -49,14 +49,14 @@ module Statistics
             drkp.fetch_events(params.merge(group_id: dojo.dojo_event_service.group_id)).each do |e|
               next unless e['group'] == dojo.dojo_event_service.group_id
 
-              EventHistory.create!(dojo_id: dojo.id,
-                                   dojo_name: dojo.name,
-                                   service_name: dojo.dojo_event_service.name,
-                                   service_group_id: dojo.dojo_event_service.group_id,
-                                   event_id: e['id'],
-                                   event_url: e['public_url'],
-                                   participants: e['participants'],
-                                   evented_at: Time.zone.parse(e['starts_at']))
+              EventHistory.find_or_create_by!(dojo_id: dojo.id,
+                                              dojo_name: dojo.name,
+                                              service_name: dojo.dojo_event_service.name,
+                                              service_group_id: dojo.dojo_event_service.group_id,
+                                              event_id: e['id'],
+                                              event_url: e['public_url'],
+                                              participants: e['participants'],
+                                              evented_at: Time.zone.parse(e['starts_at']))
             end
           end
         end

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -17,4 +17,16 @@ namespace :statistics do
 
     Statistics::Aggregation.run(date: date)
   end
+
+  task :search, [:keyword] => :environment do |tasks, args|
+    raise ArgumentError, 'Require the keyword' if args[:keyword].nil?
+
+    require 'pp'
+
+    puts 'Searching Connpass'
+    pp Statistics::Client::Connpass.new.search(keyword: args[:keyword])
+
+    puts 'Searching Doorkeeper'
+    pp Statistics::Client::Doorkeeper.new.search(keyword: args[:keyword])
+  end
 end

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -21,6 +21,7 @@ namespace :statistics do
     Statistics::Aggregation.run(date: date)
   end
 
+  desc 'キーワードからイベント情報を検索します'
   task :search, [:keyword] => :environment do |tasks, args|
     raise ArgumentError, 'Require the keyword' if args[:keyword].nil?
 

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -15,6 +15,9 @@ namespace :statistics do
 
     raise ArgumentError, "Invalid format: #{args[:yyyymm]}" if date.nil?
 
+
+    EventHistory.where(evented_at: date.beginning_of_month..date.end_of_month).delete_all
+
     Statistics::Aggregation.run(date: date)
   end
 

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -1,0 +1,20 @@
+require_relative '../statistics.rb'
+
+namespace :statistics do
+  desc '月次のイベント履歴を集計します'
+  task :aggregation, [:yyyymm] => :environment do |tasks, args|
+    date = Time.current.prev_month.beginning_of_month
+    if args[:yyyymm].present?
+      date = %w(%Y%m %Y/%m %Y-%m).map do |fmt|
+               begin
+                 Time.zone.strptime(args[:yyyymm], fmt)
+               rescue ArgumentError
+               end
+             end.compact.first
+    end
+
+    raise ArgumentError, "Invalid format: #{args[:yyyymm]}" if date.nil?
+
+    Statistics::Aggregation.run(date: date)
+  end
+end

--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Statistics::Aggregation do
     before do
       d1 = Dojo.create(name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com')
       d2 = Dojo.create(name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com')
-      DojoEventService.create(dojo_id: d1.id, name: 'connpass', group_id: 9876)
-      DojoEventService.create(dojo_id: d2.id, name: 'doorkeeper', group_id: 5555)
+      DojoEventService.create(dojo_id: d1.id, name: :connpass, group_id: 9876)
+      DojoEventService.create(dojo_id: d2.id, name: :doorkeeper, group_id: 5555)
     end
 
     subject { Statistics::Aggregation.run(date: Time.current) }

--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+require 'statistics'
+
+RSpec.describe Statistics::Aggregation do
+  include_context 'Use stubs for Faraday'
+
+  before(:all) do
+    Dojo.delete_all
+    DojoEventService.delete_all
+    EventHistory.delete_all
+  end
+
+  after do
+    Dojo.delete_all
+    DojoEventService.delete_all
+    EventHistory.delete_all
+  end
+
+  describe '.run' do
+    before do
+      d1 = Dojo.create(name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com')
+      d2 = Dojo.create(name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com')
+      DojoEventService.create(dojo_id: d1.id, name: 'connpass', group_id: 9876)
+      DojoEventService.create(dojo_id: d2.id, name: 'doorkeeper', group_id: 5555)
+    end
+
+    subject { Statistics::Aggregation.run(date: Time.current) }
+
+    it do
+      expect{ subject }.to change{EventHistory.count}.from(0).to(2)
+    end
+  end
+end

--- a/spec/lib/statistics/client_spec.rb
+++ b/spec/lib/statistics/client_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+require 'statistics'
+
+RSpec.describe Statistics::Client do
+  include_context 'Use stubs for Faraday'
+
+  context 'Connpass' do
+    describe '#search' do
+      subject { Statistics::Client::Connpass.new.search(keyword: 'coderdojo') }
+
+      it do
+        expect(subject).to be_instance_of(Hash)
+        expect(subject['results_returned']).to eq 1
+        expect(subject['events'].size).to eq 1
+        expect(subject['events'].first['event_id']).to eq 12345
+        expect(subject['events'].first['series']['url']).to eq 'https://coderdojo-okutama.connpass.com/'
+        expect(subject['events'].first['series']['id']).to eq 9876
+      end
+    end
+
+    describe '#fetch_events' do
+      subject { Statistics::Client::Connpass.new.fetch_events(series_id: 9876) }
+
+      it do
+        expect(subject).to be_instance_of(Array)
+        expect(subject.size).to eq 1
+        expect(subject.first['event_id']).to eq 12345
+        expect(subject.first['series']['url']).to eq 'https://coderdojo-okutama.connpass.com/'
+        expect(subject.first['series']['id']).to eq 9876
+      end
+    end
+  end
+
+  context 'Doorkeeper' do
+    describe '#search' do
+      subject { Statistics::Client::Doorkeeper.new.search(keyword: 'coderdojo') }
+
+      it do
+        expect(subject).to be_instance_of(Array)
+        expect(subject.size).to eq 1
+        expect(subject.first['event']['id']).to eq 1234
+        expect(subject.first['event']['group']).to eq 5555
+      end
+    end
+
+    describe '#fetch_events' do
+      subject { Statistics::Client::Doorkeeper.new.fetch_events(group_id: 5555) }
+
+      it do
+        expect(subject).to be_instance_of(Array)
+        expect(subject.size).to eq 1
+        expect(subject.first['id']).to eq 1234
+        expect(subject.first['group']).to eq 5555
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/shared_contexts/statistics.rb
+++ b/spec/support/shared_contexts/statistics.rb
@@ -1,0 +1,35 @@
+RSpec.shared_context 'Use stubs for Faraday' do
+  let(:connpass_response) do
+    [
+      200,
+      { 'Content-Type' => 'application/json' },
+      '{"results_returned": 1, "events": [{"event_url": "https://coderdojo-okutama.connpass.com/event/12345/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama.connpass.com/", "id": 9876, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12345, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"}], "results_start": 200, "results_available": 518}'
+    ]
+  end
+
+  let(:doorkeeper_response) do
+    [
+      200,
+      { 'Content-Type' => 'application/json' },
+      '[{"event":{"title":"CoderDojo title","id":1234,"starts_at":"2017-05-28T01:00:00.000Z","ends_at":"2017-05-28T04:00:00.000Z","venue_name":"奥多摩町","address":"奥多摩町","lat":"35.801763000000","long":"139.087656000000","ticket_limit":30,"published_at":"2017-04-22T03:43:04.000Z","updated_at":"2017-05-10T11:31:21.810Z","group":5555,"banner":null,"description":"CoderDojo description","public_url":"https://coderdojo-okutama.doorkeeper.jp/events/8888","participants":12,"waitlisted":0}}]'
+    ]
+  end
+
+  let(:stub_connection) do
+    Faraday.new do |f|
+      f.response :json, :content_type => /\bjson$/
+      f.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
+        # connpass
+        stub.get('/event/') { connpass_response }
+
+        # doorkeeper
+        stub.get('/events') { doorkeeper_response }
+        stub.get('/groups/5555/events') { doorkeeper_response }
+      end
+    end
+  end
+
+  before do
+    allow_any_instance_of(Statistics::Client).to receive(:connection_for).and_return(stub_connection)
+  end
+end


### PR DESCRIPTION
https://github.com/coderdojo-japan/coderdojo.jp/issues/12

統計情報の集計のために以下の機能を実装しました。

### Features
* [x] event_historiesテーブルの作成
* [x] dojo_event_servicesテーブルの作成
* [x] APIクライアントの実装
    * [x] Connpass
    * [x] Doorkeeper
* [x] API経由のイベント開催実績をevent_historiesテーブルに流し込む実装
    * [x] Runner
    * [x] Rake Task
* [x] group_idを調べるためのRake Task

### 運用イメージ

#### 前提

- dojo毎のdojo_event_serviceレコードを作成する
    - connpassのseries.id / doorkeeperのgroupを調べる必要がある
    - `rake statistics:search[keyword]`でキーワード検索 or なんとかして調べる

#### 月次バッチ
- cronもしくはスケジューラ等で毎月月初に前月のバッチ処理を行う
    - `rake statistics:aggregation[yyyymm]`を叩く
    - yyyymmは省略可能（省略すると前月分を実行）

#### 過去分
- 年月を指定して過去分の月次バッチ処理を行う
    - `rake statistics:aggregation[yyyymm]`を叩く
    - yyyymmに集計したい年月を指定する
