### PR TITLE
Apply dojo' id in `dojos:update_db_by_yaml`

### DIFF
--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -29,6 +29,7 @@ namespace :dojos do
     dojos.each do |dojo|
       d = Dojo.find_by(name: dojo['name']) || Dojo.new
 
+      d.id          = dojo['id']
       d.name        = dojo['name']
       d.email       = ''
       d.order       = dojo['order']


### PR DESCRIPTION
https://github.com/coderdojo-japan/coderdojo.jp/issues/154
https://github.com/coderdojo-japan/coderdojo.jp/pull/157#issuecomment-338891871

yamlからdbを更新する際に`Dojo#id`が適用されるように修正しました。