### PR TITLE
モバイル端末の場合は、Dojo一覧を2カラムで表示する

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -409,8 +409,9 @@ a {
 
 .dojo {
     display: inline-block;
-    width: 85%;
-    margin: 10px;
+    height: 300px;
+    width: 45%;
+    margin: 5px;
     padding: 15px 0;
     background: #fff;
     position: relative;
@@ -442,7 +443,8 @@ a {
 @media only screen and (min-width:560px) {
     .dojo {
         width: 220px;
-        height: 275px
+        height: 275px;
+        margin: 10px;
     }
 }
 


### PR DESCRIPTION
close #150

- iPhoneなどスマホの場合は、Dojo一覧を2カラムで表示します
- heightは一旦300pxでfixしてます。Dojoの説明書きなどが長いところが出てきたときには調整が必要かもしれないですが、現状はきれいに高さは揃ってそうです。