### PR TITLE
Fix not null constraint on group_id

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -145,7 +145,7 @@
   url:
 - dojo_id: 20
   # coderdojo以外にも募集しているのでそのまま集計できない
-  name: facebook
+  name: #facebook
   group_id:
   url:
 - dojo_id: 114


### PR DESCRIPTION
ref #140
 
dojo_event_servicesのgroup_idカラムはNOT NULL制約がある。
facebookの場合はレコード作成対象になるので、group_idがnullだとレコードが作れない。
現時点で、このdojoのイベント数のカウントが難しいため、
一旦有効なレコードにならないようにしてしまう。