### PR TITLE
Sleep and retry if raise API rate limit exceeded

### DIFF
--- a/lib/statistics/client.rb
+++ b/lib/statistics/client.rb
@@ -1,5 +1,7 @@
 module Statistics
   class Client
+    class APIRateLimitError < ::StandardError; end
+
     class_attribute :debug
     self.debug = false
 
@@ -99,6 +101,12 @@ module Statistics
         end
 
         events
+      rescue Faraday::ClientError => e
+        if e.response[:status] == 429
+          raise Client::APIRateLimitError
+        else
+          raise e
+        end
       end
     end
   end

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -42,7 +42,15 @@ namespace :statistics do
       raise StopIteration if nm > to
       list << nm
     }.each { |date|
-      Statistics::Aggregation.run(date: date)
+      begin
+        puts "Aggregate for #{date.strftime('%Y/%m')}"
+        Statistics::Aggregation.run(date: date)
+      rescue Statistics::Client::APIRateLimitError
+        puts 'API rate limit exceeded.'
+        puts "This task will retry in 60 seconds from now(#{Time.zone.now})."
+        sleep 60
+        retry
+      end
     }
   end
 


### PR DESCRIPTION
DoorkeeperのAPIは300 reqs / 5 minutesというレートリミットが設定されており、
3年分弱のイベント履歴の集計を行うとレートリミットに引っかかる可能性がある。
そのため、60秒スリープしてからリトライするようにした。
レートリミットに引っかかることが複数回連続で発生する場合があるが、
概ね3回程度のリトライで継続可能な模様。