### PR TITLE
Fix to change column type with PostgreSQL in production

### DIFF
--- a/db/migrate/20170820090605_change_column_type_dojo_event_services.rb
+++ b/db/migrate/20170820090605_change_column_type_dojo_event_services.rb
@@ -1,6 +1,12 @@
 class ChangeColumnTypeDojoEventServices < ActiveRecord::Migration[5.0]
-  def up
-    change_column :dojo_event_services, :name, :integer, null: false
+  if connection.adapter_name == 'PostgreSQL'
+    def up
+      change_column :dojo_event_services, :name, 'integer USING CAST(name AS integer)', null: false
+    end
+  else
+    def up
+      change_column :dojo_event_services, :name, :integer, null: false
+    end
   end
 
   def down

--- a/db/migrate/20171029065909_integer_to_string_on_group_id_in_dojo_event_services.rb
+++ b/db/migrate/20171029065909_integer_to_string_on_group_id_in_dojo_event_services.rb
@@ -3,7 +3,13 @@ class IntegerToStringOnGroupIdInDojoEventServices < ActiveRecord::Migration[5.0]
     change_column :dojo_event_services, :group_id, :string, null: false
   end
 
-  def down
-    change_column :dojo_event_services, :group_id, :integer, null: false
+  if connection.adapter_name == 'PostgreSQL'
+    def down
+      change_column :dojo_event_services, :group_id, 'integer USING CAST(group_id AS integer)', null: false
+    end
+  else
+    def down
+      change_column :dojo_event_services, :group_id, :integer, null: false
+    end
   end
 end

--- a/db/migrate/20171029071514_integer_to_string_on_service_group_id_and_event_id_in_event_histories.rb
+++ b/db/migrate/20171029071514_integer_to_string_on_service_group_id_and_event_id_in_event_histories.rb
@@ -4,8 +4,15 @@ class IntegerToStringOnServiceGroupIdAndEventIdInEventHistories < ActiveRecord::
     change_column :event_histories, :event_id, :string, null: false
   end
 
-  def down
-    change_column :event_histories, :service_group_id, :integer, null: false
-    change_column :event_histories, :event_id, :integer, null: false
+  if connection.adapter_name == 'PostgreSQL'
+    def down
+      change_column :event_histories, :service_group_id, 'integer USING CAST(service_group_id AS integer)', null: false
+      change_column :event_histories, :event_id, 'integer USING CAST(event_id AS integer)', null: false
+    end
+  else
+    def down
+      change_column :event_histories, :service_group_id, :integer, null: false
+      change_column :event_histories, :event_id, :integer, null: false
+    end
   end
 end


### PR DESCRIPTION
https://github.com/coderdojo-japan/coderdojo.jp/issues/12#issuecomment-341628828

postgresql (in production) でmigrationを流すとカラムの型変更時に落ちる。

postgresqlの仕様のようで、タイプキャストを明示的に実行してやる必要がある模様。
cf: https://makandracards.com/makandra/18691-postgresql-vs-rails-migration-how-to-change-columns-from-string-to-integer

ということで、migrationファイル内で`connection.adapter_name`をチェックして、postgresqlの時はタイプキャストするように修正しました。