### PR TITLE
Show error message

### DIFF
--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -54,8 +54,9 @@ namespace :statistics do
       }
 
       notify_idobata.call("#{from.strftime('%Y/%m')}~#{to.strftime('%Y/%m')}のイベント履歴の集計を行いました")
-    rescue
-      notify_idobata.call("#{from.strftime('%Y/%m')}~#{to.strftime('%Y/%m')}のイベント履歴の集計でエラーが発生しました")
+    rescue => e
+      notify_idobata.call("#{from.strftime('%Y/%m')}~#{to.strftime('%Y/%m')}のイベント履歴の集計でエラーが発生しました\n#{e.message}")
+      raise e
     end
   end
 


### PR DESCRIPTION
エラーを握りつぶしたままエラー内容を表示していなかったので、
通知するとともにraiseしなおすようにしました。