### PR TITLE
Multiple dojo event services

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -120,6 +120,10 @@
   group_id: 9040
   url: https://coderdojo-suginami.doorkeeper.jp
 - dojo_id: 17
+  name: facebook
+  group_id: 346407898743580
+  url: https://www.facebook.com/coderdojo.tokyo/
+- dojo_id: 17
   name: connpass
   group_id: 1862
   url: https://coderdojo-tokyo.connpass.com/


### PR DESCRIPTION
#168 
#182 
CoderDojo Tokyoが2017/04を境にfacebookからconnpassへ移行しているので、
2017/04以前のイベント履歴を集計するためにdojo_event_servicesのレコードを追加しました。

#182 がマージされたらWIPを外す