### PR TITLE
Dojo order

### DIFF
--- a/app/controllers/plain_page_controller.rb
+++ b/app/controllers/plain_page_controller.rb
@@ -2,6 +2,6 @@ class PlainPageController < CmsController
   #skip_before_action :verify_authenticity_token, only: [:index]
 
   def index
-    @dojos = Dojo.all
+    @dojos = Dojo.default_order.all
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,7 @@
 class StaticPagesController < ApplicationController
   def home
     @dojo_count = Dojo.count
-    @regions_and_dojos = Dojo.includes(:prefecture).group_by { |dojo| dojo.prefecture.region }
+    @regions_and_dojos = Dojo.includes(:prefecture).default_order.group_by { |dojo| dojo.prefecture.region }
   end
 
   def letsencrypt

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -9,7 +9,6 @@ class Dojo < ApplicationRecord
   has_many :event_histories,     dependent: :destroy
 
   serialize :tags
-  default_scope -> { order(order: :asc) }
   before_save { self.email = self.email.downcase }
 
   validates :name,        presence: true, length: { maximum: 50 }

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -11,6 +11,8 @@ class Dojo < ApplicationRecord
   serialize :tags
   before_save { self.email = self.email.downcase }
 
+  scope :default_order, -> { order(prefecture_id: :asc) }
+
   validates :name,        presence: true, length: { maximum: 50 }
   validates :email,       presence: false
   validates :order,       presence: false


### PR DESCRIPTION
fix #201 

# Changes
- `Dojo#order`の昇順でorderが設定されているdefault_scopeをヤメた
- prefecture_idの昇順とするorderをscopeとして定義した
- Dojoの一覧を取得していた箇所でdefault scopeを適用した

# Expected impact
```
~/ghq/github.com/nalabjp/coderdojo.jp dojo-order
$ git rev-parse HEAD
a75d348bbf4ef5fcee9766b37801325afda9e9f7
~/ghq/github.com/nalabjp/coderdojo.jp dojo-order
$ git grep Dojo app lib | grep -e where -e all -e includes -e joins -e eager_load -e preload
app/controllers/plain_page_controller.rb:5:    @dojos = Dojo.all
app/controllers/static_pages_controller.rb:4:    @regions_and_dojos = Dojo.includes(:prefecture).group_by { |dojo| dojo.prefecture.region }
lib/statistics/aggregation.rb:5:        cnps_dojos = Dojo.includes(:dojo_event_services).where(dojo_event_services: { name: :connpass }).to_a
lib/statistics/aggregation.rb:6:        drkp_dojos = Dojo.includes(:dojo_event_services).where(dojo_event_services: { name: :doorkeeper }).to_a
lib/statistics/aggregation.rb:7:        fsbk_dojos = Dojo.includes(:dojo_event_services).where(dojo_event_services: { name: :facebook }).to_a
```

# Screenshot
## Before
<img width="417" alt="2017-11-19 13 03 05" src="https://user-images.githubusercontent.com/1544172/32987399-1004e92c-cd2e-11e7-9a3a-b19571e55497.png">

## After
<img width="418" alt="2017-11-19 16 39 22" src="https://user-images.githubusercontent.com/1544172/32988447-4a360f30-cd48-11e7-9ff6-c94aea36257a.png">
