### PR TITLE
Use locals in partial templates

### DIFF
--- a/app/views/static_pages/_dojos.html+smartphone.erb
+++ b/app/views/static_pages/_dojos.html+smartphone.erb
@@ -1,6 +1,6 @@
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
 
-  <% @regions_and_dojos.each_with_index do |(region, dojos), index| %>
+  <% regions_and_dojos.each_with_index do |(region, dojos), index| %>
     <div class="panel panel-default">
       <div class="panel-heading" role="tab" id="<%= "heading#{index}" %>">
         <h4 class="panel-title">

--- a/app/views/static_pages/_dojos.html.erb
+++ b/app/views/static_pages/_dojos.html.erb
@@ -1,3 +1,3 @@
 <ul class="loaded">
-  <%= render partial: 'dojo', collection: @regions_and_dojos.values.flatten %>
+  <%= render partial: 'dojo', collection: regions_and_dojos.values.flatten %>
 </ul>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -85,7 +85,7 @@
   <h2>全国の道場</h2>
   <br />
 
-  <%= render 'dojos' %>
+  <%= render partial: 'dojos', locals: { regions_and_dojos: @regions_and_dojos } %>
 
 </section>
 


### PR DESCRIPTION
Partial templateではインスタンス変数を使わずローカル変数を使うようにする。
インスタンス変数を使うとコントローラとの結合度があがってしまうため。
（variantを使った出し分けなので特に使いまわすこともなさそうだがお作法的なニュアンスで）

cf: https://github.com/flyerhzm/rails_best_practices/wiki/Replace-instance-variable-with-local-variable