### PR TITLE
Rack::Attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'koala'
 
 gem 'rack-user_agent'
 
+gem 'rack-attack'
+
 group :development do
   gem 'web-console'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,8 @@ GEM
       json
       websocket (~> 1.0)
     rack (2.0.3)
+    rack-attack (5.0.1)
+      rack
     rack-host-redirect (1.3.0)
       rack
     rack-test (0.7.0)
@@ -336,6 +338,7 @@ DEPENDENCIES
   pry-doc
   pry-rails
   pry-stack_explorer
+  rack-attack
   rack-host-redirect
   rack-user_agent
   rails (= 5.1.4)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,8 @@
+Rails.application.config.middleware.use Rack::Attack
+
+Rack::Attack.blocklist('fail2ban pentesters') do |req|
+  Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", :maxretry => 1, :findtime => 1.hour, :bantime => 24.hours) do
+    req.path.include?('wp-login') ||
+      req.params.values.include?('wp-login')
+  end
+end


### PR DESCRIPTION
# Changes
- rack-attack.gemを導入した
- wp-login.phpをリクエストに含む場合に24時間Banする設定を入れた
    - `/wp-login.php`へのリクエストが以前はあったが、最近はリクエストパラメータに含まれるケースもあるようなので、paramsもチェックするようにした

e.g.)
```
19 Nov 2017 23:27:18.017287 <158>1 2017-11-19T14:27:17.736909+00:00 heroku router - - at=info method=GET path="/" host=coderdojo.jp request_id=debd13c5-22f1-45ec-b3ba-725f9b9dd466 fwd="112.134.189.191" dyno=web.1 connect=0ms service=72ms status=200 bytes=68710 protocol=https
19 Nov 2017 23:27:18.017219 <190>1 2017-11-19T14:27:17.672438+00:00 app web.1 - - I, [2017-11-19T23:27:16.689762 #4] INFO -- : [b8099131-c120-47c5-bb9e-d10d2f0613bb] Processing by CmsController#index as */*
19 Nov 2017 23:27:18.017222 <190>1 2017-11-19T14:27:17.672450+00:00 app web.1 - - I, [2017-11-19T23:27:16.689808 #4] INFO -- : [b8099131-c120-47c5-bb9e-d10d2f0613bb] Parameters: {"permalink"=>"wp-login.php"}
19 Nov 2017 23:27:18.017249 <190>1 2017-11-19T14:27:17.672451+00:00 app web.1 - - I, [2017-11-19T23:27:16.690556 #4] INFO -- : [b8099131-c120-47c5-bb9e-d10d2f0613bb] Completed 404 Not Found in 1ms (ActiveRecord: 0.0ms | Scrivito: 0.0ms)
```