### PR TITLE
Use eager_load instead of includes

### DIFF
--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -2,9 +2,9 @@ module Statistics
   class Aggregation
     class << self
       def run(date:)
-        cnps_dojos = Dojo.includes(:dojo_event_services).where(dojo_event_services: { name: :connpass }).to_a
-        drkp_dojos = Dojo.includes(:dojo_event_services).where(dojo_event_services: { name: :doorkeeper }).to_a
-        fsbk_dojos = Dojo.includes(:dojo_event_services).where(dojo_event_services: { name: :facebook }).to_a
+        cnps_dojos = Dojo.eager_load(:dojo_event_services).where(dojo_event_services: { name: :connpass }).to_a
+        drkp_dojos = Dojo.eager_load(:dojo_event_services).where(dojo_event_services: { name: :doorkeeper }).to_a
+        fsbk_dojos = Dojo.eager_load(:dojo_event_services).where(dojo_event_services: { name: :facebook }).to_a
 
         Connpass.run(cnps_dojos, date)
         Doorkeeper.run(drkp_dojos, date)


### PR DESCRIPTION
fix https://github.com/coderdojo-japan/coderdojo.jp/pull/186#discussion_r152173149

```
5.1.4@2.4.2 (main)> Dojo.includes(:dojo_event_services).where(dojo_event_services: { name: :connpass }).to_sql == Dojo.eager_load(:dojo_event_services).where(dojo_event_services: { name: :connpass }).to_sql
=> true
```