### PR TITLE
Skip test dependent on Scrivito from forked repo PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ cache:
   - bundler
 script:
   - bundle exec rake db:migrate --trace
-  - bundle exec rake
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bundle exec rspec spec; fi
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" = "coderdojo-japan/coderdojo.jp" ]; then bundle exec rspec spec; fi
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_PULL_REQUEST_SLUG" != "coderdojo-japan/coderdojo.jp" ]; then bundle exec rspec spec --tag ~@scrivito; fi
 env:
   global:
     - TZ='Asia/Tokyo'

--- a/app/controllers/cms_controller.rb
+++ b/app/controllers/cms_controller.rb
@@ -1,5 +1,3 @@
 class CmsController < ApplicationController
   include Scrivito::ControllerActions
-
-  LoginPage.create(title: 'ログイン')
 end

--- a/app/controllers/cms_controller.rb
+++ b/app/controllers/cms_controller.rb
@@ -1,9 +1,5 @@
 class CmsController < ApplicationController
   include Scrivito::ControllerActions
 
-  title ||= ENV['SCRIVITO_WORKSPACE'] || 'DEFAULT_WORKSPACE'
-  Scrivito::Workspace.create(title: title) unless Scrivito::Workspace.find_by_title(title)
-  Scrivito::Workspace.use(title)
-
   LoginPage.create(title: 'ログイン')
 end

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -7,7 +7,7 @@ class DocsController < ApplicationController
 
   def show
     @doc = Document.new(params[:id])
-    redirect_to scrivito_path(Obj.root) if not @doc.exists?
+    redirect_to root_url unless @doc.exists?
     @content = Kramdown::Document.new(@doc.content, input: 'GFM').to_html
     @url     = request.url
   end

--- a/config/initializers/scrivito.rb
+++ b/config/initializers/scrivito.rb
@@ -25,7 +25,7 @@ Scrivito.configure do |config|
 end
 
 if ENV.key?('SCRIVITO_TENANT') && ENV.key?('SCRIVITO_API_KEY')
-  title ||= ENV['SCRIVITO_WORKSPACE'] || 'DEFAULT_WORKSPACE'
+  title = ENV.fetch('SCRIVITO_WORKSPACE', 'DEFAULT_WORKSPACE')
   Scrivito::Workspace.create(title: title) unless Scrivito::Workspace.find_by_title(title)
   Scrivito::Workspace.use(title)
 

--- a/config/initializers/scrivito.rb
+++ b/config/initializers/scrivito.rb
@@ -24,6 +24,8 @@ Scrivito.configure do |config|
   end
 end
 
-title ||= ENV['SCRIVITO_WORKSPACE'] || 'DEFAULT_WORKSPACE'
-Scrivito::Workspace.create(title: title) unless Scrivito::Workspace.find_by_title(title)
-Scrivito::Workspace.use(title)
+if ENV.key?('SCRIVITO_TENANT') && ENV.key?('SCRIVITO_API_KEY')
+  title ||= ENV['SCRIVITO_WORKSPACE'] || 'DEFAULT_WORKSPACE'
+  Scrivito::Workspace.create(title: title) unless Scrivito::Workspace.find_by_title(title)
+  Scrivito::Workspace.use(title)
+end

--- a/config/initializers/scrivito.rb
+++ b/config/initializers/scrivito.rb
@@ -23,3 +23,7 @@ Scrivito.configure do |config|
     end
   end
 end
+
+title ||= ENV['SCRIVITO_WORKSPACE'] || 'DEFAULT_WORKSPACE'
+Scrivito::Workspace.create(title: title) unless Scrivito::Workspace.find_by_title(title)
+Scrivito::Workspace.use(title)

--- a/config/initializers/scrivito.rb
+++ b/config/initializers/scrivito.rb
@@ -28,4 +28,6 @@ if ENV.key?('SCRIVITO_TENANT') && ENV.key?('SCRIVITO_API_KEY')
   title ||= ENV['SCRIVITO_WORKSPACE'] || 'DEFAULT_WORKSPACE'
   Scrivito::Workspace.create(title: title) unless Scrivito::Workspace.find_by_title(title)
   Scrivito::Workspace.use(title)
+
+  LoginPage.create(title: 'ログイン')
 end

--- a/spec/controllers/blog_post_page_controller_spec.rb
+++ b/spec/controllers/blog_post_page_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BlogPostPageController, type: :controller do
+RSpec.describe BlogPostPageController, type: :controller, scrivito: true do
   render_views
 
   describe "GET Blog Post Page" do

--- a/spec/controllers/docs_controller_spec.rb
+++ b/spec/controllers/docs_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DocsController, type: :controller do
 
     it 'when invalid filename' do
       get :show, params: { id: '../not_found' }
-      expect(response).to redirect_to controller.scrivito_path(Obj.root)
+      expect(response).to redirect_to controller.root_url
       expect(response.status).to eq 302
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SessionsController, type: :controller do
+RSpec.describe SessionsController, type: :controller, scrivito: true do
   describe "GET #create" do
     it "param match" do
       get :create, params: { email: ENV['SCRIVITO_EMAIL'],

--- a/spec/controllers/sotechsha_overview_page_controller_spec.rb
+++ b/spec/controllers/sotechsha_overview_page_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SotechshaOverviewPageController, type: :controller do
+RSpec.describe SotechshaOverviewPageController, type: :controller, scrivito: true do
   render_views
 
   describe "GET #index" do

--- a/spec/features/news_spec.rb
+++ b/spec/features/news_spec.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'rails_helper'
 
-RSpec.feature "News", type: :feature do
+RSpec.feature "News", type: :feature, scrivito: true do
   describe "GET /news/2016/12/12/new-backend" do
     scenario "Title should be formatted" do
       visit "/news/2016/12/12/new-backend"

--- a/spec/features/sotechsha_spec.rb
+++ b/spec/features/sotechsha_spec.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'rails_helper'
 
-RSpec.feature "Sotechsha", type: :feature, retry: 3  do
+RSpec.feature "Sotechsha", type: :feature, scrivito: true, retry: 3  do
 
   describe "GET /sotechsha/num" do
     scenario "Quizzes should be permalink" do

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Scrivito::ControllerHelper
 
-RSpec.feature "Users", type: :feature do
+RSpec.feature "Users", type: :feature, scrivito: true do
   subject { page }
 
   describe "log in" do

--- a/spec/requests/news_pages_spec.rb
+++ b/spec/requests/news_pages_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "NewsPages", type: :request do
+RSpec.describe "NewsPages", type: :request, scrivito: true do
   describe "GET /news/2016/12/12/new-backend" do
     it "Blog post should be rendered" do
       get '/news/2016/12/12/new-backend'

--- a/spec/requests/sotechshas_spec.rb
+++ b/spec/requests/sotechshas_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Sotechshas", type: :request do
+RSpec.describe "Sotechshas", type: :request, scrivito: true do
 
   describe "Quizzes should be permalink" do
     it "Quizzes should be permalink" do


### PR DESCRIPTION
fix #160 
ref https://github.com/coderdojo-japan/coderdojo.jp/pull/203#issuecomment-345542528

# Changes
- Scrivitoのコンポーネントに依存するテストは`scrivito: true`というRSpecのタグを付与した
- docs_controller.rbのScrivitoへの依存を取り除いた
    - `scrivito_path(Obj.root)`は`/`を意味しているので`root_url`に置き換え可能なため
- forked repoからのPRの場合、`scrivito: true`なタグが付与されているテストを除外して実行するようにした
    - Scrivitoのコンポーネントを使うのに`SCRIVITO_TENANT`と`SCRIVITO_API_KEY`の環境変数が必要なため
- ScrivitoのWorkspaceとLoginPageの設定はinitializersに移動した
    - RSpecがCmsControllerをロードしても落ちないようにするため