### PR TITLE
Temporary fix 2nd sort key of `Dojo.default_order`

### DIFF
--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -12,7 +12,7 @@ class Dojo < ApplicationRecord
   serialize :tags
   before_save { self.email = self.email.downcase }
 
-  scope :default_order, -> { order(prefecture_id: :asc, id: :asc) }
+  scope :default_order, -> { order(prefecture_id: :asc, order: :asc) }
 
   validates :name,        presence: true, length: { maximum: 50 }
   validates :email,       presence: false


### PR DESCRIPTION
https://github.com/coderdojo-japan/coderdojo.jp/issues/201#issuecomment-347014627

Dojoの並び順が意図していない順に並んでいたので一時的に`Dojo.order`を使ってソートしておく。

ref: #58 #219 