### PR TITLE
Support weekly aggregation

### DIFF
--- a/lib/statistics/client.rb
+++ b/lib/statistics/client.rb
@@ -36,13 +36,14 @@ module Statistics
         @client.get('event/', { keyword: keyword, count: 100 })
       end
 
-      def fetch_events(series_id:, yyyymm: nil)
+      def fetch_events(series_id:, yyyymm: nil, yyyymmdd: nil)
         params = {
           series_id: series_id,
           start: 1,
           count: 100
         }
         params[:ym] = yyyymm if yyyymm
+        params[:ymd] = yyyymmdd if yyyymmdd
         events = []
 
         loop do

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -1,7 +1,7 @@
 require_relative '../statistics.rb'
 
 namespace :statistics do
-  desc '年次/月次/週次のイベント履歴を集計します'
+  desc '月次/週次のイベント履歴を集計します'
   task :aggregation, [:from, :to] => :environment do |tasks, args|
     date_from_str = -> (str) {
       formats = %w(%Y%m%d %Y/%m/%d %Y-%m-%d %Y%m %Y/%m %Y-%m)

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -1,7 +1,7 @@
 require_relative '../statistics.rb'
 
 namespace :statistics do
-  desc '月次のイベント履歴を集計します'
+  desc '年次/月次/週次のイベント履歴を集計します'
   task :aggregation, [:from, :to] => :environment do |tasks, args|
     date_from_str = -> (str) {
       formats = %w(%Y%m %Y/%m %Y-%m)
@@ -20,42 +20,75 @@ namespace :statistics do
       puts `curl --data-urlencode "source=#{msg}" -s #{ENV['IDOBATA_HOOK_URL']} -o /dev/null -w "idobata: %{http_code}"` if ENV.key?('IDOBATA_HOOK_URL')
     }
 
+    ym_format = -> (date) { date.strftime('%Y/%m') }
+    ymd_format = -> (date) { date.strftime('%Y/%m/%d') }
+
+    montly_aggregation = -> (from, to) {
+      loop.with_object([from]) { |_, list|
+        nm = list.last.next_month
+        raise StopIteration if nm > to
+        list << nm
+      }.each { |date|
+        puts "Aggregate for #{ym_format.call(date)}"
+        Statistics::Aggregation.run(date: date, weekly: false)
+      }
+    }
+
+    weekly_aggregation = -> (from, to) {
+      loop.with_object([from]) { |_, list|
+        nw = list.last.next_week
+        raise StopIteration if nw > to
+        list << nw
+      }.each { |date|
+        puts "Aggregate for #{ymd_format.call(date)}~#{ymd_format.call(date.end_of_week)}"
+        Statistics::Aggregation.run(date: date, weekly: true)
+      }
+    }
+
+    weekly = true
+
     from = if args[:from]
              if args[:from].length == 4
+               weekly = false
                date_from_str.call(args[:from]).beginning_of_year
-             else
+             elsif args[:from].length == 6
+               weekly = false
                date_from_str.call(args[:from]).beginning_of_month
+             else
+               date_from_str.call(args[:from]).beginning_of_week
              end
            else
-             Time.current.prev_month.beginning_of_month
+             Time.current.prev_week.beginning_of_week
            end
     to = if args[:to]
            if args[:to].length == 4
              date_from_str.call(args[:to]).end_of_year
-           else
+           elsif args[:to].length == 6
              date_from_str.call(args[:to]).end_of_month
+           else
+             date_from_str.call(args[:to]).end_of_week
            end
          else
-           Time.current.prev_month.end_of_month
+           Time.current.prev_week.end_of_week
          end
 
     Statistics::Client::Facebook.access_token = Koala::Facebook::OAuth.new(ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_APP_SECRET']).get_app_access_token
 
     EventHistory.where(evented_at: from..to).delete_all
 
-    begin
-      loop.with_object([from]) { |_, list|
-        nm = list.last.next_month
-        raise StopIteration if nm > to
-        list << nm
-      }.each { |date|
-        puts "Aggregate for #{date.strftime('%Y/%m')}"
-        Statistics::Aggregation.run(date: date)
-      }
+    from_str = weekly ? ym_format.call(from) : ymd_format.call(from)
+    to_str = weekly ? ym_format.call(to) : ymd_format.call(to)
 
-      notify_idobata.call("#{from.strftime('%Y/%m')}~#{to.strftime('%Y/%m')}のイベント履歴の集計を行いました")
+    begin
+      if weekly
+        weekly_aggregation.call(from, to)
+      else
+        montly_aggregation.call(from, to)
+      end
+
+      notify_idobata.call("#{from_str}~#{to_str}のイベント履歴の集計を行いました")
     rescue => e
-      notify_idobata.call("#{from.strftime('%Y/%m')}~#{to.strftime('%Y/%m')}のイベント履歴の集計でエラーが発生しました\n#{e.message}")
+      notify_idobata.call("#{from_str}~#{to_str}のイベント履歴の集計でエラーが発生しました\n#{e.message}")
       raise e
     end
   end

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -4,7 +4,7 @@ namespace :statistics do
   desc '年次/月次/週次のイベント履歴を集計します'
   task :aggregation, [:from, :to] => :environment do |tasks, args|
     date_from_str = -> (str) {
-      formats = %w(%Y%m %Y/%m %Y-%m)
+      formats = %w(%Y%m%d %Y/%m/%d %Y-%m-%d %Y%m %Y/%m %Y-%m)
       d = formats.map { |fmt|
         begin
           Time.zone.strptime(str, fmt)

--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Statistics::Aggregation do
       DojoEventService.create(dojo_id: d3.id, name: :facebook, group_id: 123451234512345)
     end
 
-    subject { Statistics::Aggregation.run(date: Time.current) }
+    subject { Statistics::Aggregation.run(date: Time.current, weekly: false) }
 
     it do
       expect{ subject }.to change{EventHistory.count}.from(0).to(3)


### PR DESCRIPTION
fix #193 

週次の集計をサポートしました。
引数なしのデフォルトは月次 -> 週次となりました。
月次も変わらずサポートしています。
rake taskがだいぶカオスになってきたので、別PRでリファクタリングしたいです。
  