### PR TITLE
Ignore static dojos from stats

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -20,8 +20,8 @@ class StaticPagesController < ApplicationController
     @range = 2012..2017
     @range.each do |year|
       @dojos[year] =
-        Dojo.where(created_at:
-                     Time.zone.local(2012).beginning_of_year..Time.zone.local(year).end_of_year).count
+        Dojo.where(created_at: Time.zone.local(2012).beginning_of_year..Time.zone.local(year)
+               .end_of_year).select{|d| d.dojo_event_services.any?}.count
       @events[year] =
         EventHistory.where(evented_at:
                      Time.zone.local(year).beginning_of_year..Time.zone.local(year).end_of_year).count

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -10,13 +10,13 @@ class StaticPagesController < ApplicationController
     @regions_and_dojos   = Dojo.eager_load(:prefecture).default_order.group_by { |dojo| dojo.prefecture.region }
 
     # TODO: 次の静的なDojoの開催数もデータベース上で集計できるようにする
-    @sum_of_events       = EventHistory.count + # 以下は2017年11月3日時点で個別に確認した数字
-      29 + # 柏の葉
-      3  + # 南柏
-      4  + # 柏湘南
-      63   # 小平
-    @sum_of_dojos        = DojoEventService.count('DISTINCT dojo_id') +
-      4    # TODO: 同上。上記の道場数を静的に足しています
+    @sum_of_events       = EventHistory.count #+ # 以下は2017年11月3日時点で個別に確認した数字
+      #29 + # 柏の葉
+      #3  + # 南柏
+      #4  + # 柏湘南
+      #63   # 小平
+    @sum_of_dojos        = DojoEventService.count('DISTINCT dojo_id') #+
+      #4    # TODO: 同上。上記の道場数を静的に足しています
     @sum_of_participants = EventHistory.sum(:participants)
 
     # 2012年1月1日〜2017年12月31日までの集計結果

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -10,13 +10,9 @@ class StaticPagesController < ApplicationController
     @regions_and_dojos   = Dojo.eager_load(:prefecture).default_order.group_by { |dojo| dojo.prefecture.region }
 
     # TODO: 次の静的なDojoの開催数もデータベース上で集計できるようにする
-    @sum_of_events       = EventHistory.count #+ # 以下は2017年11月3日時点で個別に確認した数字
-      #29 + # 柏の葉
-      #3  + # 南柏
-      #4  + # 柏湘南
-      #63   # 小平
-    @sum_of_dojos        = DojoEventService.count('DISTINCT dojo_id') #+
-      #4    # TODO: 同上。上記の道場数を静的に足しています
+    # https://github.com/coderdojo-japan/coderdojo.jp/issues/190
+    @sum_of_events       = EventHistory.count
+    @sum_of_dojos        = DojoEventService.count('DISTINCT dojo_id')
     @sum_of_participants = EventHistory.sum(:participants)
 
     # 2012年1月1日〜2017年12月31日までの集計結果

--- a/app/views/static_pages/stats.html.haml
+++ b/app/views/static_pages/stats.html.haml
@@ -22,8 +22,9 @@
     %h3 開催回数
     = @sum_of_events
     回
-    %h3 参加者数 (延べ)
-    = @sum_of_participants = EventHistory.sum(:participants)
+    %h3 参加者数
+    延べ
+    = @sum_of_participants
     人
     %h3 計測対象
     = @sum_of_dojos

--- a/app/views/static_pages/stats.html.haml
+++ b/app/views/static_pages/stats.html.haml
@@ -34,25 +34,29 @@
 
     %h3 各統計の推移
     %div{align: 'center'}
+      (計測対象のみ)
       %table
         %thead
           %tr
             %th
             - @range.each do |year|
               %td{style: 'padding: 0 5px; font-weight: bold;'} #{year}年
+            %td{style: 'padding: 0 5px; font-weight: bold;'} 合計
         %tbody{align: 'center'}
           %tr
             %td 道場数
             - @range.each do |year|
-              %td #{@dojos[year]}
+              %td= @dojos[year]
           %tr
             %td 開催回数
             - @range.each do |year|
-              %td #{@events[year]}
+              %td= @events[year]
+            %td= @events.values.inject(:+)
           %tr
             %td 参加者数
             - @range.each do |year|
-              %td #{@participants[year]}
+              %td= @participants[year]
+            %td= @participants.values.inject(:+)
 
     %h3 関連リンク
     %ul{:style => "list-style: none; margin-left: -40px;"}


### PR DESCRIPTION
> うーん、Static に追加した道場が EventHistories に追加されていないから、「開催回数の合計」が「これまでの開催回数」と一致しない問題が... 😓 Static に追加した道場は統計ページから外した方が、より信頼できる数字になりそうかな 🤔
https://github.com/coderdojo-japan/coderdojo.jp/pull/229#issuecomment-355870433

- [x] 静的な道場数を統計から外す https://github.com/coderdojo-japan/coderdojo.jp/commit/163f3a04b4647634831fe89157d32745ea8caa44
- [x] 計測対象の道場数を年次で表示する
- [x] 表の文言を調整する
  