### PR TITLE
Refactor dojo count

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -20,8 +20,11 @@ class StaticPagesController < ApplicationController
     @range = 2012..2017
     @range.each do |year|
       @dojos[year] =
-        Dojo.where(created_at: Time.zone.local(2012).beginning_of_year..Time.zone.local(year)
-               .end_of_year).select{|d| d.dojo_event_services.any?}.count
+        Dojo
+          .distinct
+          .joins(:dojo_event_services)
+          .where(created_at: Time.zone.local(2012).beginning_of_year..Time.zone.local(year).end_of_year)
+          .count
       @events[year] =
         EventHistory.where(evented_at:
                      Time.zone.local(year).beginning_of_year..Time.zone.local(year).end_of_year).count

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -23,7 +23,7 @@ class StaticPagesController < ApplicationController
         Dojo
           .distinct
           .joins(:dojo_event_services)
-          .where(created_at: Time.zone.local(2012).beginning_of_year..Time.zone.local(year).end_of_year)
+          .where(created_at: Time.zone.local(@range.first).beginning_of_year..Time.zone.local(year).end_of_year)
           .count
       @events[year] =
         EventHistory.where(evented_at:


### PR DESCRIPTION
https://github.com/coderdojo-japan/coderdojo.jp/pull/234#discussion_r160070618

dojo_event_servicesテーブルをINNER JOINしてDISTINCTするとSQLだけで集計できそうです。
道場数が最新ではないんですが、rails consoleで試してみるとこんな感じになるでしょうか。
```
5.1.4@2.4.2 (main)> Dojo.where(created_at: Time.zone.local(2012).beginning_of_year..Time.zone.local(2017).end_of_year).count
   (0.2ms)  SELECT COUNT(*) FROM "dojos" WHERE ("dojos"."created_at" BETWEEN ? AND ?)  [["created_at", "2011-12-31 15:00:00"], ["created_at", "2017-12-31 14:59:59.999999"]]
=> 113
5.1.4@2.4.2 (main)> Dojo.where(created_at: Time.zone.local(2012).beginning_of_year..Time.zone.local(2017).end_of_year).eager_load(:dojo_event_services).select{|d| d.dojo_event_services.any?}.count

  SQL (1.8ms)  SELECT "dojos"."id" AS t0_r0, "dojos"."name" AS t0_r1, "dojos"."email" AS t0_r2, "dojos"."order" AS t0_r3, "dojos"."description" AS t0_r4, "dojos"."logo" AS t0_r5, "dojos"."url" AS t0_r6, "dojos"."tags" AS t0_r7, "dojos"."created_at" AS t0_r8, "dojos"."updated_at" AS t0_r9, "dojos"."prefecture_id" AS t0_r10, "dojo_event_services"."id" AS t1_r0, "dojo_event_services"."dojo_id" AS t1_r1, "dojo_event_services"."name" AS t1_r2, "dojo_event_services"."url" AS t1_r3, "dojo_event_services"."group_id" AS t1_r4, "dojo_event_services"."created_at" AS t1_r5, "dojo_event_services"."updated_at" AS t1_r6 FROM "dojos" LEFT OUTER JOIN "dojo_event_services" ON "dojo_event_services"."dojo_id" = "dojos"."id" WHERE ("dojos"."created_at" BETWEEN ? AND ?)  [["created_at", "2011-12-31 15:00:00"], ["created_at", "2017-12-31 14:59:59.999999"]]
=> 70
5.1.4@2.4.2 (main)> res1 = Dojo.where(created_at: Time.zone.local(2012).beginning_of_year..Time.zone.local(2017).end_of_year).eager_load(:dojo_event_services).select{|d| d.dojo_event_services.any?}.map(&:id);

  SQL (1.9ms)  SELECT "dojos"."id" AS t0_r0, "dojos"."name" AS t0_r1, "dojos"."email" AS t0_r2, "dojos"."order" AS t0_r3, "dojos"."description" AS t0_r4, "dojos"."logo" AS t0_r5, "dojos"."url" AS t0_r6, "dojos"."tags" AS t0_r7, "dojos"."created_at" AS t0_r8, "dojos"."updated_at" AS t0_r9, "dojos"."prefecture_id" AS t0_r10, "dojo_event_services"."id" AS t1_r0, "dojo_event_services"."dojo_id" AS t1_r1, "dojo_event_services"."name" AS t1_r2, "dojo_event_services"."url" AS t1_r3, "dojo_event_services"."group_id" AS t1_r4, "dojo_event_services"."created_at" AS t1_r5, "dojo_event_services"."updated_at" AS t1_r6 FROM "dojos" LEFT OUTER JOIN "dojo_event_services" ON "dojo_event_services"."dojo_id" = "dojos"."id" WHERE ("dojos"."created_at" BETWEEN ? AND ?)  [["created_at", "2011-12-31 15:00:00"], ["created_at", "2017-12-31 14:59:59.999999"]]
5.1.4@2.4.2 (main)> Dojo.distinct.where(created_at: Time.zone.local(2012).beginning_of_year..Time.zone.local(2017).end_of_year).joins(:dojo_event_services).count
   (0.3ms)  SELECT COUNT(DISTINCT "dojos"."id") FROM "dojos" INNER JOIN "dojo_event_services" ON "dojo_event_services"."dojo_id" = "dojos"."id" WHERE ("dojos"."created_at" BETWEEN ? AND ?)  [["created_at", "2011-12-31 15:00:00"], ["created_at", "2017-12-31 14:59:59.999999"]]
=> 70
5.1.4@2.4.2 (main)> res2 = Dojo.distinct.where(created_at: Time.zone.local(2012).beginning_of_year..Time.zone.local(2017).end_of_year).joins(:dojo_event_services).pluck(:id);
   (0.2ms)  SELECT DISTINCT "dojos"."id" FROM "dojos" INNER JOIN "dojo_event_services" ON "dojo_event_services"."dojo_id" = "dojos"."id" WHERE ("dojos"."created_at" BETWEEN ? AND ?)  [["created_at", "2011-12-31 15:00:00"], ["created_at", "2017-12-31 14:59:59.999999"]]
5.1.4@2.4.2 (main)> res1 == res2
=> true
```