### PR TITLE
Add aggregation

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -324,9 +324,9 @@
   group_id: 281889288840369
   url: https://www.facebook.com/pg/coderdojo.nishinari.osaka/events/?ref=page_internal
 - dojo_id: 101
-  name: none
-  group_id:
-  url:
+  name: connpass
+  group_id: 2777
+  url: https://coderdojo-higashiosaka.connpass.com/
 - dojo_id: 46
   name: connpass
   group_id: 2620

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -397,9 +397,9 @@
   group_id:
   url:
 - dojo_id: 111
-  name: google
-  group_id:
-  url:
+  name: facebook
+  group_id: 1507281716025249
+  url: https://www.facebook.com/pg/coderdojomiyoshi/events/?ref=page_internal
 - dojo_id: 102
   name: facebook
   group_id: 495711777474589

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -444,3 +444,7 @@
   name: doorkeeper
   group_id: 9496
   url: https://coderdojo-anjo.doorkeeper.jp/
+- dojo_id: 121
+  name: doorkeeper
+  group_id: 9491
+  url: https://coderdojo-ochanomizu.doorkeeper.jp/

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -185,9 +185,9 @@
   group_id:
   url:
 - dojo_id: 25
-  name: google
-  group_id:
-  url:
+  name: facebook
+  group_id: 238346276578113
+  url: https://www.facebook.com/pg/coderdojowakaba/events/?ref=page_internal
 - dojo_id: 86
   name: facebook
   group_id: 880706025404127

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -296,9 +296,9 @@
   group_id: 3325
   url: https://coderdojo-takatsuki.connpass.com
 - dojo_id: 108
-  name: none
-  group_id:
-  url:
+  name: connpass
+  group_id: 4559
+  url: https://coderdojo-minoh.connpass.com/
 - dojo_id: 40
   name: connpass
   group_id: 2248

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -436,3 +436,7 @@
   name: connpass
   group_id: 4692
   url: https://coderdojo-tachikawa.connpass.com/
+- dojo_id: 116
+  name: doorkeeper
+  group_id: 9482
+  url: https://coderdojo-abeno.doorkeeper.jp/

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -157,9 +157,9 @@
   group_id:
   url:
 - dojo_id: 60
-  name: google
-  group_id:
-  url:
+  name: connpass
+  group_id: 3461
+  url: https://coderdojo-ichikawa.connpass.com/
 - dojo_id: 82
   name: connpass
   group_id: 3835

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -432,3 +432,7 @@
   name: none
   group_id:
   url:
+- dojo_id: 117
+  name: connpass
+  group_id: 4692
+  url: https://coderdojo-tachikawa.connpass.com/

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -440,3 +440,7 @@
   name: doorkeeper
   group_id: 9482
   url: https://coderdojo-abeno.doorkeeper.jp/
+- dojo_id: 118
+  name: doorkeeper
+  group_id: 9496
+  url: https://coderdojo-anjo.doorkeeper.jp/


### PR DESCRIPTION
https://github.com/coderdojo-japan/coderdojo.jp/issues/236#issuecomment-356167624

# changes
connpass, doorkeeper, facebookを使用しているdojo_event_services.yamlを更新しました。

## connpass
- ID: 60 - 市川 (関東) - connpass https://coderdojo-ichikawa.connpass.com/
- ID: 101 - 八尾 (近畿) - connpass https://coderdojo-higashiosaka.connpass.com/
- ID: 108 - みのお (近畿) - connpass https://coderdojo-minoh.connpass.com/
- ID: 117 - 立川 (関東) - connpass https://coderdojo-tachikawa.connpass.com/
  
## doorkeeper
- ID: 116 - 阿倍野 (近畿) - Doorkeeper https://coderdojo-abeno.doorkeeper.jp/
- ID: 118 - 安城 (中部) - Doorkeeper https://coderdojo-anjo.doorkeeper.jp/
- ID: 121 - 御茶ノ水 (関東) - Doorkeeper https://coderdojo-ochanomizu.doorkeeper.jp/

## facebook
- ID: 25 - 若葉 (関東) - Facebook Event https://www.facebook.com/pg/coderdojowakaba/events/?ref=page_internal
ID: 111 - 三好 (四国) - Facebook Event https://www.facebook.com/pg/coderdojomiyoshi/events/?ref=page_internal