### PR TITLE
Show the copyright of libraries in compressed sources by Uglifier

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Sprockets::UglifierCompressor.new(comments: :copyright)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
before
```
~/ghq/github.com/nalabjp/coderdojo.jp copyright  6s
$ git rev-parse HEAD
3db29bc8c2adeea5b1dccaa2c0a9f03c40afea5e
~/ghq/github.com/nalabjp/coderdojo.jp copyright
$ rm -fr public/assets
~/ghq/github.com/nalabjp/coderdojo.jp copyright
$ RAILS_ENV=production bin/rails assets:precompile >/dev/null 2>&1
~/ghq/github.com/nalabjp/coderdojo.jp copyright  6s
$ head -c 100 public/assets/application-8add2f3bf14a253e150595cc9c2206d5c1a6595bd8a164f58c7f0764ba5a8937.js
function set_dimension(t){var e=0,n=null;$.each(t,function(t,i){n=$(i).parents(".parallax"),(e=$(i).
```

after
```
~/ghq/github.com/nalabjp/coderdojo.jp copyright ⇡
$ git rev-parse HEAD
6d497c2a24bec0ec172a336b1b33e9d51a56e7c3
~/ghq/github.com/nalabjp/coderdojo.jp copyright ⇡
$ rm -fr public/assets
~/ghq/github.com/nalabjp/coderdojo.jp copyright ⇡
$ RAILS_ENV=production bin/rails assets:precompile >/dev/null 2>&1
~/ghq/github.com/nalabjp/coderdojo.jp copyright ⇡
$ head -c 400 public/assets/application-4b84b1117818fef15d407745ecc50d0012ede171458cdd8fcaf67fdb72b8c7d7.js
/*!
 * jQuery JavaScript Library v1.12.4
 * http://jquery.com/
 *
 * Includes Sizzle.js
 * http://sizzlejs.com/
 *
 * Copyright jQuery Foundation and other contributors
 * Released under the MIT license
 * http://jquery.org/license
 *
 * Date: 2016-05-20T17:17Z
 */
function set_dimension(t){var e=0,n=null;$.each(t,function(t,i){n=$(i).parents(".parallax"),(e=$(i).get(0).clientHeight/1.3)>0&&n.css(
```

see: https://github.com/rails/sprockets/blob/v3.7.1/lib/sprockets/uglifier_compressor.rb