### PR TITLE
Migrate kodaira' event service

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -99,10 +99,9 @@
   group_id: 617011185103868
   url: https://www.facebook.com/pg/CoderDojoTokorozawa/events/?ref=page_internal
 - dojo_id: 13
-  name: connpass
-  group_id: 2396
-  # https://coderdojokodaira-ninja.connpass.com/event/ もあるが2017/06~のみ
-  url: https://coderdojo-kodaira.connpass.com/
+  name: static_yaml
+  group_id:
+  url:
 - dojo_id: 14
   name: peatix
   group_id:

--- a/lib/statistics/tasks/static_yaml.rb
+++ b/lib/statistics/tasks/static_yaml.rb
@@ -17,7 +17,7 @@ module Statistics
           next unless dojo
 
           evented_at = Time.zone.parse(e['evented_at'])
-          event_id = "#{dojo.id}_#{evented_at.to_i}"
+          event_id = "#{SecureRandom.uuid}"
 
           EventHistory.create!(dojo_id: dojo.id,
                                dojo_name: dojo.name,


### PR DESCRIPTION
# Changes
- 小平dojoのstatic event historiesを有効にするために、db/dojo_event_services.yaml内のデータを変更した。
- 「2017/07/12 18:30」の同時刻に別のデータがあることが判明したのでevent_idの重複を避けるためにUUIDを使用する修ようにした。

# Migration
- `bin/rails dojo_event_services:upsert`を実行してdojo_event_servicesを更新する
- `bin/rails r "DojoEventService.where(dojo_id: 13, name: :connpass).first.destroy"`を実行して、小平dojoの古いdojo_event_serivceを削除する
- `bin/rails r "EventHistory.where(dojo_id: 13, service_name: :connpass).destroy_all"`を実行して、小平dojoのconnpass版のevent_historiesを削除する
- statice_event_historiesは次回集計時に自動でインポートされる