### PR TITLE
dojos.yamlをs/鳥取/鳥取 (中国)/した

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1226,7 +1226,7 @@
 - id: 131
   created_at: '2018-02-22'
   order: '312011'
-  name: 鳥取
+  name: 鳥取 (中国)
   prefecture_id: 31
   logo: "/img/dojos/tottori.png"
   url: https://www.facebook.com/CoderDojoTottori/


### PR DESCRIPTION
命名規則が前回のPRでは異なった"鳥取"で行ってしまったので
他と合わせて地域名を付け加えました
![screen shot 2018-02-26 at 11 54 44](https://user-images.githubusercontent.com/13062611/36651351-df0650e8-1aeb-11e8-9741-48c8f63975d0.png)
