### PR TITLE
`order` 値がCSVに書いてあるとおりの値になる用に修正

### DIFF
--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -28,7 +28,6 @@ namespace :dojos do
 
     dojos.each do |dojo|
       d = Dojo.find_or_initialize_by(id: dojo['id'])
-
       d.name        = dojo['name']
       d.email       = ''
       d.order       = dojo['order'] || search_order_number(dojo['name'])
@@ -49,7 +48,7 @@ namespace :dojos do
   def search_order_number(pre_city)
 
     if /(?<city>.+)\s\(.+\)/ =~ pre_city
-      table = CSV.table(Rails.root.join('db','city_code.csv'))
+      table = CSV.table(Rails.root.join('db','city_code.csv'), {:converters => nil})
       row = table.find{ |r| r[:city].to_s.start_with?(city)}
       row ? row[:order] : raise("Failed to detect city code by #{pre_city}
 order値の自動設定ができませんでした。お手数ですが下記URLを参考に該当する全国地方公共団体コードをorder値にご入力ください。


### PR DESCRIPTION
## 背景
> つくば で order 値を検索したら order: '82201.0' になった...?
https://idobata.io/archives/messages/26280273#message_26280273

## 行ったこと

[Qiitaのエントリ](https://qiita.com/fisherman08/items/84c0c380de96fa3ee591)によると
原因はCSVのconvertで、0始まりのデータが10進数として見られていなかった様です。
その為 :convertersをnilに変更して修正しました。
