### PR TITLE
直近のイベント情報を格納するDBスキーマの定義

### DIFF
--- a/db/migrate/20180316062512_create_upcoming_events.rb
+++ b/db/migrate/20180316062512_create_upcoming_events.rb
@@ -1,0 +1,13 @@
+class CreateUpcomingEvents < ActiveRecord::Migration[5.1]
+  def change
+    create_table :upcoming_events do |t|
+      t.integer :dojo_event_service_id, null: false
+      t.string :event_id , null: false
+      t.string :event_url, null: false
+      t.datetime :event_at , null: false
+
+      t.index :dojo_event_service_id, name: "index_upcoming_events_on_dojo_event_service_id"
+      t.index :event_at, name: "index_upcoming_events_on_event_at"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180117164209) do
+ActiveRecord::Schema.define(version: 20180316062512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,15 @@ ActiveRecord::Schema.define(version: 20180117164209) do
     t.string "region"
     t.index ["name"], name: "index_prefectures_on_name", unique: true
     t.index ["region"], name: "index_prefectures_on_region"
+  end
+
+  create_table "upcoming_events", force: :cascade do |t|
+    t.integer "dojo_event_service_id", null: false
+    t.string "event_id", null: false
+    t.string "event_url", null: false
+    t.datetime "event_at", null: false
+    t.index ["dojo_event_service_id"], name: "index_upcoming_events_on_dojo_event_service_id"
+    t.index ["event_at"], name: "index_upcoming_events_on_event_at"
   end
 
   add_foreign_key "dojo_event_services", "dojos"


### PR DESCRIPTION
# 背景

- #270 で `events` を作るに辺り直近のイベント情報が欲しい
- 現在のDB構成は過去のイベントログしか保存しない為、直近のイベントを保存させたい
- その為不確定な参加者を除くイベントスキーマを作成したい
関連PR: https://github.com/coderdojo-japan/coderdojo.jp/pull/277


# 行ったこと

- [X] ` be rails g migration CreateFutureEvents dojo_event_service_id:integer  event_id:string event_url:string evented_ad:datetime`
- [x] 詳細なスキーマの変更
- [x] 命名規則の確認

~~今回は未来のイベントなのでFutureEventsとして定義しています~~

その後名前を `Future` から `Upcoming` に修正しました
