### PR TITLE
Add thousands separator with HighCharts global options

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -17,6 +17,7 @@ class StatsController < ApplicationController
     @events = stat.annual_count_of_event_histories
     @participants = stat.annual_sum_of_participants
 
+    @high_charts_globals = HighChartsBuilder.global_options
     @annual_dojos_chart = stat.annual_dojos_chart
     @annual_event_histories_chart = stat.annual_event_histories_chart
     @annual_participants_chart = stat.annual_participants_chart

--- a/app/models/high_charts_builder.rb
+++ b/app/models/high_charts_builder.rb
@@ -1,5 +1,11 @@
 class HighChartsBuilder
   class << self
+    def global_options
+      LazyHighCharts::HighChartGlobals.new do |f|
+        f.lang(thousandsSep: ',')
+      end
+    end
+
     def build_annual_dojos(source)
       data = annual_chart_data_from(source)
 

--- a/app/views/stats/show.html.haml
+++ b/app/views/stats/show.html.haml
@@ -12,6 +12,7 @@
     %br
     %h3 推移グラフ  
     %div{align: 'center'}
+      = high_chart_globals(@high_charts_globals)
       = high_chart("annual_dojos",           @annual_dojos_chart)
       = high_chart("annual_event_histories", @annual_event_histories_chart)
       = high_chart("annual_participants",    @annual_participants_chart)


### PR DESCRIPTION
チャート内の数値にカンマが無いことに気付いたので追加しました。

# Before

<img width="164" alt="2018-03-25 21 18 20" src="https://user-images.githubusercontent.com/1544172/37874866-1b31f3a6-3072-11e8-9d33-87063ab040e5.png">

# After

<img width="163" alt="2018-03-25 21 19 14" src="https://user-images.githubusercontent.com/1544172/37874872-369ee662-3072-11e8-8f20-33dbf34b385c.png">
