### PR TITLE
Add 'dumper' gem to backup database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 ruby '2.5.1'
 
 gem 'rails', '5.1.4'
-
 gem 'pg'
+gem 'dumper'
 
 gem 'scrivito', '~> 1.13.0'
 gem 'scrivito_section_widgets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,10 @@ GEM
     declarative (0.0.10)
     declarative-option (0.1.0)
     diff-lcs (1.3)
+    dumper (1.7.3)
+      multi_json (>= 1.0)
+      multipart-post (>= 1.1.5)
+      posix-spawn (>= 0.3.6)
     erubi (1.7.1)
     erubis (2.7.0)
     ethon (0.11.0)
@@ -193,6 +197,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     os (0.9.6)
     pg (0.18.4)
+    posix-spawn (0.3.13)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -390,6 +395,7 @@ DEPENDENCIES
   bootstrap-sass
   capybara
   coffee-rails
+  dumper
   faraday
   faraday_middleware (= 0.10)
   flamegraph

--- a/config/initializers/dumper.rb
+++ b/config/initializers/dumper.rb
@@ -1,0 +1,12 @@
+# Dumper (http://dumper.io) is an online tool that provides
+# robust database backup in your Rails applications.
+#
+# For debug logging:
+#
+# Dumper::Agent.start(app_key: 'YOUR_APP_KEY', debug: true)
+#
+# For conditional start:
+#
+Dumper::Agent.start_if(:app_key => ENV['DUMPER_APP_KEY']) do
+  Rails.env.production? && dumper_enabled_host?
+end


### PR DESCRIPTION
Fix #324 

- Web: https://dumper.io
- Gem: https://github.com/dumperhq/dumper
- Tutorial: https://dumper.io/help/rails