### PR TITLE
道場を非表示にする仕組みの追加

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def show
-    @dojo_count        = Dojo.count
-    @regions_and_dojos = Dojo.group_by_region
+    @dojo_count        = Dojo.active.count
+    @regions_and_dojos = Dojo.group_by_region_on_active
   end
 end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -2,7 +2,7 @@ class StatsController < ApplicationController
   def show
     @url                 = request.url
     @dojo_count          = Dojo.count
-    @regions_and_dojos   = Dojo.group_by_region
+    @regions_and_dojos   = Dojo.group_by_region_on_active
 
     # TODO: 次の静的なDojoの開催数もデータベース上で集計できるようにする
     # https://github.com/coderdojo-japan/coderdojo.jp/issues/190

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
   def full_description(description)
     description = kata_description if @obj && @obj.permalink == "kata"
     if description.empty?
-      "CoderDojo は子どものためのプログラミング道場です。2011年にアイルランドで始まり、全国では#{Dojo::NUM_OF_JAPAN_DOJOS}ヶ所以上、世界では#{Dojo::NUM_OF_COUNTRIES}ヶ国・#{Dojo::NUM_OF_WHOLE_DOJOS}ヶ所で開催されています。" # Default description
+      "CoderDojo は子どものためのプログラミング道場です。2011年にアイルランドで始まり、全国では#{Dojo.active.count}ヶ所以上、世界では#{Dojo::NUM_OF_COUNTRIES}ヶ国・#{Dojo::NUM_OF_WHOLE_DOJOS}ヶ所で開催されています。" # Default description
     else
       description
     end

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -1,7 +1,6 @@
 class Dojo < ApplicationRecord
   NUM_OF_COUNTRIES    = "85"
   NUM_OF_WHOLE_DOJOS  = "1,600"
-  NUM_OF_JAPAN_DOJOS  = Dojo.count.to_s
   YAML_FILE           = Rails.root.join('db', 'dojos.yaml')
 
   belongs_to :prefecture
@@ -12,6 +11,7 @@ class Dojo < ApplicationRecord
   before_save { self.email = self.email.downcase }
 
   scope :default_order, -> { order(prefecture_id: :asc, order: :asc) }
+  scope :active, -> { where(is_active: true) }
 
   validates :name,        presence: true, length: { maximum: 50 }
   validates :email,       presence: false
@@ -33,6 +33,10 @@ class Dojo < ApplicationRecord
 
     def group_by_region
       eager_load(:prefecture).default_order.group_by { |dojo| dojo.prefecture.region }
+    end
+
+    def group_by_region_on_active
+      active.group_by_region
     end
 
     def aggregatable_annual_count(period)

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -295,6 +295,7 @@
   description: 埼玉県所沢市小手指にて毎月開催
   tags:
   - Scratch
+  is_active: false
 - id: 11
   order: '112097'
   created_at: '2015-05-13'

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -410,6 +410,7 @@
   description: 千葉県野田市で不定期開催
   tags:
   - Scratch
+  is_active: false
 - id: 23
   order: '122173'
   created_at: '2014-09-22'
@@ -1105,6 +1106,7 @@
   tags:
   - Scratch
   - ラズベリーパイ
+  is_active: false
 - id: 46
   order: '271403'
   created_at: '2016-03-22'

--- a/db/migrate/20180604070534_add_is_active_to_dojos.rb
+++ b/db/migrate/20180604070534_add_is_active_to_dojos.rb
@@ -1,0 +1,5 @@
+class AddIsActiveToDojos < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dojos, :is_active, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180316062512) do
+ActiveRecord::Schema.define(version: 20180604070534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20180316062512) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "prefecture_id"
+    t.boolean "is_active", default: true, null: false
   end
 
   create_table "event_histories", id: :serial, force: :cascade do |t|

--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -38,6 +38,7 @@ namespace :dojos do
       d.created_at  = d.new_record? ? Time.zone.now : dojo['created_at'] || d.created_at
       d.updated_at  = Time.zone.now
       d.prefecture_id = dojo['prefecture_id']
+      d.is_active   = dojo['is_active'].nil? ? true : dojo['is_active']
 
       d.save!
     end

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Dojo, :type => :model do
   it { should respond_to(:tags) }
 
   it { should be_valid }
+  it { expect(Dojo.new.is_active?).to be(true) }
 
   describe "when name is not present" do
     before { @dojo.name = " " }


### PR DESCRIPTION
close #310,#314,#333 

# やりたいこと

休止や廃止などの道場に対応して道場一覧などからは非表示にしたい。

- 休止の場合は復活があるので、復活できる状態にしたい
- イベント履歴としては実績なのでそのまま残す(休止中/廃止中のいづれの場合でも)

# 今回のアプローチ

dojos テーブルに状態管理のフィールドを追加することで対応する。

zen.coderdojo.com では非アクティブな情報を持っているため、API 連携ができると手動で対応する必要がなくなるが (#330)、実装に時間がかかりそうだった。

また、既にいくつかの休止依頼 (#333 ) がきていることもあり、今回はワークアラウンドで対応する。

# TODO
- [x] 仕様確認
   - 道場一覧から非アクティブは除外する
   - 集計値にて「道場数」に非アクティブは含めない(ただし、統計情報は過去の実績とみなし、含める)
- [x] 実装
- [x] 道場が非表示になる事の確認([トップ画面](https://coderdojo.jp/)と[統計情報画面](https://coderdojo.jp/stats))
- [x] 非表示な道場のイベント履歴が集計対象になっている事の確認
- [x] dojos.yaml でアクティブ/非アクティブ情報が正しく取り込まれる事の確認

# 関連情報
cf. #310
cf. #314
cf. #330
cf. #333
