### PR TITLE
Herokuの脆弱性の対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-attack (5.1.0)
       rack
     rack-host-redirect (1.3.0)
@@ -345,7 +345,7 @@ GEM
     simple_grid_rails (0.1.0)
     spring (2.0.2)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
Herokuの脆弱性の対応を行った
今回は bundle update sprocketsで対応した
cf. https://blog.heroku.com/rails-asset-pipeline-vulnerability