### PR TITLE
Scrivitoに関する環境変数がないときは関連テストをスキップする

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,12 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.around(:each, :scrivito) do |example|
+    if ENV['SCRIVITO_TENANT'].present? and ENV['SCRIVITO_API_KEY'].present?
+      example.run
+    else
+      example.skip
+    end
+  end
 end


### PR DESCRIPTION
##  issue

https://github.com/coderdojo-japan/coderdojo.jp/issues/319

## やったこと

* scrivitoに関するメタデータはすでにセットされていたのでrails_helperに環境変数がなければスキップするよう設定を追加