### PR TITLE
Rename: 倉敷 (岡山) -> 倉敷 (中国)

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1489,7 +1489,7 @@
 - id: 150
   order: '332020'
   created_at: '2018-05-29'
-  name: 倉敷 (岡山)
+  name: 倉敷 (中国)
   prefecture_id: 33
   logo: "/img/dojos/kurashiki.jpg"
   url: https://cd-kurashiki.connpass.com


### PR DESCRIPTION
よくみたら地方名ではなく都道府県名になっていたので