### PR TITLE
Use ruby 2.6.0 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.6.0
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
https://github.com/coderdojo-japan/coderdojo.jp/commit/c032c971c8cc677ce34d39fb0a580bf63c92dc8e を受けてDocker imageを更新しました。