### PR TITLE
イベント履歴収集スクリプトでプロバイダ指定を可能に

### DIFF
--- a/docs/statistics_aggregation.md
+++ b/docs/statistics_aggregation.md
@@ -1,8 +1,8 @@
-# rake statistics:aggregation[from,to]
+# rake statistics:aggregation[from,to,provider]
 
 ## 概要
 
-指定期間のイベント履歴を集計する
+指定期間/プロバイダのイベント履歴を集計する
 
 ## 引数
 
@@ -10,15 +10,18 @@
 |--|--|--|--|
 |from|string|(省略可)|集計期間開始年/年月/年月日|
 |to|string|(省略可)|集計期間終了年/年月/年月日|
+|provider|string|(省略可)|集計対象プロバイダ|
 
 ## 説明
 
 from/to で指定された期間のイベント履歴を集計する。
 
+provider が指定されたとき、指定プロバイダに対してのみ集計を行う。
+
 + from, to を共に省略した場合、前週一週間分の履歴を集計する。
 + 全期間(2012年以降前日まで)を集計する場合、from/to 共に '-' を指定する。
 ```
-rake statistics:aggregation[-,-]
+rake statistics:aggregation[-,-,]
 ```
 + from/to に期間を指定する場合、それぞれ以下の形式で指定可能。
 ```
@@ -27,3 +30,5 @@ rake statistics:aggregation[-,-]
 + to は前日、前日の年月、もしくは前日の年を最大とする。これより未来を指定された場合でも、最大以降は集計対象外とする。
 
 + from, to いずれかを省略した場合、指定された他方の年/年月/年月日の履歴を集計する。
+
++ provider には、connpass, doorkeeper, facebook, static_yaml が指定可能。

--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -2,7 +2,7 @@ module Statistics
   class Aggregation
     def initialize(args)
       @from, @to = aggregation_period(args[:from], args[:to])
-      dojos = fetch_dojos
+      dojos = fetch_dojos(args[:provider])
       @externals = dojos[:externals]
       @internals = dojos[:internals]
     end
@@ -56,12 +56,27 @@ module Statistics
       d
     end
 
-    def fetch_dojos
+    def fetch_dojos(provider)
+      if provider.blank?
+        # 全プロバイダ対象
+        external_services = DojoEventService::EXTERNAL_SERVICES
+        internal_services = DojoEventService::INTERNAL_SERVICES
+      else
+        external_services = []
+        internal_services = []
+        case provider
+        when 'connpass', 'doorkeeper', 'facebook'
+          external_services = [provider]
+        when 'static_yaml'
+          internal_services = [provider]
+        end
+      end
+
       {
-        externals: find_dojos_by(DojoEventService::EXTERNAL_SERVICES),
-        internals: find_dojos_by(DojoEventService::INTERNAL_SERVICES)
+        externals: find_dojos_by(external_services),
+        internals: find_dojos_by(internal_services)
       }
-    end
+  end
 
     def find_dojos_by(services)
       services.each.with_object({}) do |name, hash|

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -1,9 +1,8 @@
 require_relative '../statistics.rb'
 
 namespace :statistics do
-  desc '月次/週次のイベント履歴を集計します'
-  task :aggregation, [:from, :to] => :environment do |tasks, args|
-    # EventService::Providers::Facebook.access_token = Koala::Facebook::OAuth.new(ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_APP_SECRET']).get_app_access_token
+  desc '指定期間/プロバイダのイベント履歴を集計します'
+  task :aggregation, [:from, :to, :provider] => :environment do |tasks, args|
     EventHistory.transaction do
       Statistics::Aggregation.new(args).run
     end

--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -104,5 +104,43 @@ RSpec.describe Statistics::Aggregation do
         expect{ sa.send(:date_from, 'abc') }.to raise_error(ArgumentError)
       end
     end
+
+    context 'fetch_dojos(provider)' do
+      it '指定なし' do
+        dojos = sa.send(:fetch_dojos, nil)
+        expect(dojos[:externals].keys).to eq(DojoEventService::EXTERNAL_SERVICES)
+        expect(dojos[:internals].keys).to eq(DojoEventService::INTERNAL_SERVICES)
+      end
+
+      it 'connpass' do
+        dojos = sa.send(:fetch_dojos, 'connpass')
+        expect(dojos[:externals].keys).to eq(['connpass'])
+        expect(dojos[:internals].keys).to eq([])
+      end
+
+      it 'doorkeeper' do
+        dojos = sa.send(:fetch_dojos, 'doorkeeper')
+        expect(dojos[:externals].keys).to eq(['doorkeeper'])
+        expect(dojos[:internals].keys).to eq([])
+      end
+
+      it 'facebook' do
+        dojos = sa.send(:fetch_dojos, 'facebook')
+        expect(dojos[:externals].keys).to eq(['facebook'])
+        expect(dojos[:internals].keys).to eq([])
+      end
+
+      it 'static_yaml' do
+        dojos = sa.send(:fetch_dojos, 'static_yaml')
+        expect(dojos[:externals].keys).to eq([])
+        expect(dojos[:internals].keys).to eq(['static_yaml'])
+      end
+
+      it 'other' do
+        dojos = sa.send(:fetch_dojos, 'abc')
+        expect(dojos[:externals].keys).to eq([])
+        expect(dojos[:internals].keys).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
## 背景
毎週月曜に前週分のイベント履歴を収集しているが、**facebook のみ 2018/04 以降収集できていなかった。**
このような場合、対象期間とプロバイダを指定してイベント履歴を収集し直したい。

## やりたいこと
+ イベント履歴収集スクリプトで期間だけでなくプロバイダを指定して実行可能にする
+ rake タスクの usage を修正する ＋ ファイル配置を見直す

Fix #378 

## このPRでやること
+ [x] タスクの引数にプロバイダを追加し、対象プロバイダのみイベント履歴を収集できるようにする
+ [x] usage を修正する
+ [x] 対象プロバイダ判定の rspec 追加する

## やらなかったこと
特になし

## レビューポイント
+ 対象プロバイダの判定

## 困ってること
特になし

## 継続検討すること
+ Facebook イベント履歴収集の自動化 (→ #393)