### PR TITLE
Use ruby 2.6.2 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.0
+FROM ruby:2.6.2
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
cef5309c0d53c9c1c4e0f9d8a0e32e1c377374ad を受けてDocker imageを更新しました。