### PR TITLE
開催回数の推移グラフ/１目盛の単位をtickInterval: 300に設定し見やすく

### DIFF
--- a/app/models/high_charts_builder.rb
+++ b/app/models/high_charts_builder.rb
@@ -15,7 +15,7 @@ class HighChartsBuilder
         f.series(type: 'column', name: '増加数', yAxis: 0, data: data[:increase_nums])
         f.series(type: 'line', name: '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
-          { title: { text: '増加数' } },
+          { title: { text: '増加数' }},
           { title: { text: '累積合計' }, opposite: true }
         ]
         f.chart(width: 600)
@@ -32,7 +32,7 @@ class HighChartsBuilder
         f.series(type: 'column', name: '開催回数', yAxis: 0, data: data[:increase_nums])
         f.series(type: 'line',   name: '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
-          { title: { text: '開催回数' } },
+          { title: { text: '開催回数' }, tickInterval: 300 },
           { title: { text: '累積合計' }, opposite: true }
         ]
         f.chart(width: 600)


### PR DESCRIPTION
⚠️すみません、スペース消しはミスです😢
Fix #413 
### やりたいこと
グラフの上限をそれぞれ、開催回数1500、累計回数3kにして、上部の空間を無くして見やすくする。

### 困っていること
min:0, max:3000 などと記載しても、自動で変わってくれない。
どうやら、グラフの横線４段で半端な数字になるとうまくいかないよう。（１目盛当たりを４で割れる数にしないといけない？）

### やったこと
開催回数の１目盛を300にしてみると、以前より見栄えが良くなった。
<img width="636" alt="スクリーンショット 2019-04-08 8 47 12" src="https://user-images.githubusercontent.com/48109243/55700138-14b32100-5a09-11e9-86d4-8ce45358f14b.png">
