### PR TITLE
DojoEventService から奈良の情報を削除

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -293,11 +293,6 @@
   name: doorkeeper
   group_id: 4052
   url: https://coderdojo-nagaokakyo.doorkeeper.jp
-- dojo_id: 35
-  # 生駒 (近畿)と合同
-  name: connpass
-  group_id: 2617
-  url: https://coderdojo-nara-ikoma.connpass.com
 - dojo_id: 37
   name: connpass
   group_id: 2822


### PR DESCRIPTION
#427 で coderdjo.jp から奈良、明日香、田原本の情報を掲載を取り下げたことに基づき、
イベントサービスのレコードも削除する。
明日香、田原本のレコードは登録されていなかったため、奈良のレコードのみ削除する。