### PR TITLE
トップページの「各地の道場」を見やすくする

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -539,6 +539,7 @@ a {
 .dojo-name {
     display: block;
     margin: .5em 0;
+    font-weight: bold;
 }
 
 .dojo-private {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -578,7 +578,7 @@ a {
     font-size: 80%;
     color: #fff;
     border-radius: .3em;
-    padding: .2em;
+    padding: .2em .8em;
     margin: .1em;
     background: #2275CA
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -576,11 +576,12 @@ a {
 .tags > li {
     display: inline-block;
     font-size: 80%;
-    color: #fff;
+    color: #777;
     border-radius: .3em;
+    border:1px solid #e8e8e8;
     padding: .2em .8em;
     margin: .1em;
-    background: #2275CA
+    /*background: #2275CA*/
 }
 
 .title > h1 {


### PR DESCRIPTION
一目で地名が目に入るように、色や余白などを変更してみました。

## Before
![image](https://user-images.githubusercontent.com/5765654/57621656-f66fb080-75c6-11e9-800b-8ecba9b103bf.png)

## After
![image](https://user-images.githubusercontent.com/5765654/57621671-02f40900-75c7-11e9-8f5b-f8289e6db99c.png)


close #442 