### PR TITLE
プライバシーポリシーの幅を問い合わせフォームに揃える

### DIFF
--- a/public/css/wufoo.css
+++ b/public/css/wufoo.css
@@ -30,3 +30,7 @@ footerで利用しているWufooのフォームの成形用のcss
 .wufoo .buttons {
     text-align: center;
 }
+
+.wufoo li.section.scrollText{
+  margin:7px;
+}


### PR DESCRIPTION
> https://github.com/coderdojo-japan/coderdojo.jp/blob/master/public/css/wufoo.css にあるファイルを読み込んでいるようなので、こちらの CSS ファイルをいじると調整できそうです!

「ファイルを修正後コミット & デプロイして、本番環境で修正結果を確認する必要がある」とのことで、
ローカルで確認できなかったのですが、、、
修正したのは下記の箇所だけです。

```
.wufoo li.section.scrollText{
  margin:7px;
}
```

これで、横幅が揃うと思うのですが、、、いかがでしょうか？

（ちなみに、最初に提案していた`padding:10px 0; `だとカーソルが乗った時のクリーム色の余白が不自然になってしまうので、marginの方を調整してみました）

Chromeの要素の検証のキャプチャを添付しておきます。

![image](https://user-images.githubusercontent.com/5765654/57625040-1060c180-75ce-11e9-9441-e690038cdc43.png)
