### PR TITLE
app.jsonのdb関連の設定変更

### DIFF
--- a/app.json
+++ b/app.json
@@ -80,7 +80,7 @@
   },
   "name": "coderdojo.jp",
   "scripts": {
-      "postdeploy": "bundle exec rails db:schema:load && bundle exec rails dojos:update_db_by_yaml && bundle exec rails dojo_event_services:upsert"
+      "postdeploy": "bundle exec rails db:schema:load && bundle exec rails db:seed && bundle exec rails dojos:update_db_by_yaml && bundle exec rails dojo_event_services:upsert"
   },
   "stack": "heroku-18"
 }

--- a/app.json
+++ b/app.json
@@ -80,7 +80,7 @@
   },
   "name": "coderdojo.jp",
   "scripts": {
-      "postdeploy": "bundle exec rails db:setup && bundle exec rails dojos:update_db_by_yaml && bundle exec rails dojo_event_services:upsert"
+      "postdeploy": "bundle exec rails db:schema:load && bundle exec rails dojos:update_db_by_yaml && bundle exec rails dojo_event_services:upsert"
   },
   "stack": "heroku-18"
 }


### PR DESCRIPTION
## 背景

#409 などでも作業をしているが、Herokuのrevie appをこちらでも使いたいが、エラーが出ている
app.jsonに問題がある可能性があるため、app.jsonの不安要素を排除したい

## 行ったこと
- postdepploy時にDBの権限でエラーが発生している事を確認した

- DBの権限がpostdeploy時に無い為に、公式ドキュメントを参照し修正した

> For Rails apps you should look to use db:schema:load, db:structure:load or db:migrate instead of db:setup.
cf. https://help.heroku.com/63D7ALXT/why-am-i-seeing-user-does-not-have-connect-privilege-error-with-heroku-postgres-on-review-apps

- この後にseedがうまく設定されていなかったので、 `rails db:seed` を追加した