### PR TITLE
RecordNotFound, RoutingError, Exception が発生したら適切にエラーページを表示されるよう対応

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,10 @@ class ApplicationController < ActionController::Base
 
   before_action :set_request_variant
 
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
+  rescue_from Exception, with: :render_500
+
   private
 
     def store_location
@@ -20,5 +24,13 @@ class ApplicationController < ActionController::Base
 
   def set_request_variant
     request.variant = request.device_variant
+  end
+
+  def render_404
+    render template: 'errors/404', status: 404, layout: 'application', content_type: 'text/html'
+  end
+
+  def render_500
+    render template: 'errors/500', status: 500, layout: 'application', content_type: 'text/html'
   end
 end

--- a/app/views/errors/404.html.haml
+++ b/app/views/errors/404.html.haml
@@ -1,0 +1,11 @@
+#top.title.text-center
+  %i.cd.cd-logo
+  %h1 CoderDojo Japan
+  %p 子どものためのプログラミング道場
+  %br
+
+%section.introduction.text-center.list
+  %h3
+    ページが見つかりませんでした
+  %p
+    ページが削除された可能性があります。

--- a/app/views/errors/500.html.haml
+++ b/app/views/errors/500.html.haml
@@ -1,0 +1,11 @@
+#top.title.text-center
+  %i.cd.cd-logo
+  %h1 CoderDojo Japan
+  %p 子どものためのプログラミング道場
+  %br
+
+%section.introduction.text-center.list
+  %h3
+    予期しないエラーが発生しました
+  %p
+    時間をおいてから再度アクセスしてみてください。


### PR DESCRIPTION
#422 の対応。

取り急ぎ `ActiveRecord::RecordNotFound` , `ActionController::RoutingError` , `Exception` をハンドルして、エラーページを表示するよう対応してみました

RecordNotFound, RoutingError | Exception
:---: | :---:
<img width="673" alt="スクリーンショット 2019-05-18 15 37 50" src="https://user-images.githubusercontent.com/471009/57965730-fedb3900-7982-11e9-8acd-a4bd928715a9.png"> | <img width="682" alt="スクリーンショット 2019-05-18 15 34 19" src="https://user-images.githubusercontent.com/471009/57965682-73fa3e80-7982-11e9-91c4-4d75eee711ad.png">
