### PR TITLE
mp3 ファイルを削除

### DIFF
--- a/public/podcasts/1.mp3
+++ b/public/podcasts/1.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8460501a9ba85f7bc74efda5772edf3eecb694da9230b1c45c5ebc4c41e16579
-size 22887860

--- a/public/podcasts/10.mp3
+++ b/public/podcasts/10.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00bba5039050fa12895f08f0165a913b52ca4e403bc7c75968a8ec8b4b8c997d
-size 60465024

--- a/public/podcasts/11.mp3
+++ b/public/podcasts/11.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f992fb3359ef6065fd6215219c3d25c65f169ee179ad8ddf96eaad161d7e8229
-size 59550896

--- a/public/podcasts/2.mp3
+++ b/public/podcasts/2.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0dfea786a371d4dfc191bbdb45a0d0dbfc9b48faf88321f0df7ad00d84ee060d
-size 24148008

--- a/public/podcasts/3.mp3
+++ b/public/podcasts/3.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d757117d3fe7a4962453d76e0e8a81edbfa492b125231624ff99b05adb3373ea
-size 41211648

--- a/public/podcasts/4.mp3
+++ b/public/podcasts/4.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dcf06e5a34b9a3990b2e2805bcefcd750e3b008a95bc448c847309f5eaff75f9
-size 30532224

--- a/public/podcasts/5.mp3
+++ b/public/podcasts/5.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:931f84426cb149768c1d254639f21faf0eca0d13625eebdf872ed935200741a1
-size 52371072

--- a/public/podcasts/6.mp3
+++ b/public/podcasts/6.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5d38e36b9087dd94f241e2719dfa407198ea141ffa3c57a4f51e39cf8ada402
-size 28041089

--- a/public/podcasts/7.mp3
+++ b/public/podcasts/7.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:399e7555d8c5922acaa0af2900761f8a53a4bc6ba2fe6f667da9358c12bcb85b
-size 52468224

--- a/public/podcasts/8.mp3
+++ b/public/podcasts/8.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3fc23ce405644718cc0ef6126c5a5fd86d4512d166730f9963f8319dde81bd8
-size 27075264

--- a/public/podcasts/9.mp3
+++ b/public/podcasts/9.mp3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9fb8f12943c854d221fcf8ccb1d2f21abaec82348daf63872328aa9ccf0dcc0
-size 52018781


### PR DESCRIPTION
## 背景
CoderDojo プロジェクトファイルが Heroku Slug サイズの上限 (500MB) に迫って来た！！

## やりたいこと
mp3 ファイルの SoundCloud への移行を完了する。
CoderDojo サイト側の SoundCloud への移行はできたので、mp3 ファイルを削除する。

Fix #408

## このPRでやること
- [x] git リポジトリ内の mp3 ファイルを削除する

## やらなかったこと
なし

## 困ってること
特になし
