### PR TITLE
staging環境のassets.compileを修正

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
## 背景

CoderDojo.jpでも、PRのたびにHeroku review appを作成したい。
DB関連のバグは修正することができた。
画像が表示されないバグが、以前のheroku review apps作成時に存在していた。

## 原因
原因となっていそうなのが、railsのfinger print関連の assets pipelineだった。

## 対応
今回はStaging環境を使うために、stagingでのassets pipelineの動的コンパイルオプションを有効化した。

## 確認状況
PRでは、初回ログイン時にはメモリリークでログインできなくなるが、2回目以降のログインでは、CoderDojoのページが表示されることを確認した。