### PR TITLE
直近のイベント情報の都道府県別集計の順序を修正

### DIFF
--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -18,7 +18,7 @@ class UpcomingEvent < ApplicationRecord
         group_by { |event| event.dojo_event_service.dojo.prefecture_id }
 
       result = {}
-      Prefecture.all.each do |prefecture|
+      Prefecture.order(:id).each do |prefecture|
         events = events_by_prefecture[prefecture.id]
         next if events.blank?
         result[prefecture] = events.sort_by(&:event_at).map(&:catalog).group_by { |d| d[:event_date] }


### PR DESCRIPTION
## 背景

直近の CoderDojo 開催情報を、都道府県別に 都道府県コードの昇順 で表示したいが、先頭に来るはずの北海道が最後になってしまっている。

## やりたいこと

都道府県別に 都道府県コードの昇順 に表示する。

Fix #465
