### PR TITLE
CoderDojo 安曇野を近日開催の道場の収集対象に加える

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -231,10 +231,15 @@
   name: facebook
   group_id: 124249914820641
   url: https://www.facebook.com/pg/coderdojo.kofu/events/
+# 〜2018/02
+# - dojo_id: 87
+#   name: facebook
+#   group_id: 1634610396557264
+#   url: https://www.facebook.com/pg/CoderDojoAzumino/events/
 - dojo_id: 87
-  name: facebook
-  group_id: 1634610396557264
-  url: https://www.facebook.com/pg/CoderDojoAzumino/events/
+  name: doorkeeper
+  group_id: 9603
+  url: https://coderdojo-azumino.doorkeeper.jp
 - dojo_id: 27
   name: connpass
   group_id: 2732
@@ -611,5 +616,3 @@
   name: facebook
   group_id: 261243731229399
   url: https://www.facebook.com/pg/coderdojokuji/events/
-
-


### PR DESCRIPTION
## 背景

近日開催の道場に、CoderDojo 安曇野 のイベント情報が掲載できていなかった。

cf. #468

## やりたいこと

CoderDojo 安曇野 のイベント情報を、近日開催の道場 の掲載対象にする。

CoderDojo 安曇野
https://coderdojo-azumino.doorkeeper.jp/events/92769

## このPRでやること

- [x] 安曇野のイベント収集先を facebook から doorkeeper に変更する
