### PR TITLE
add kodaira connpass

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -99,9 +99,9 @@
   group_id: 617011185103868
   url: https://www.facebook.com/pg/CoderDojoTokorozawa/events/
 - dojo_id: 13
-  name: static_yaml
-  group_id:
-  url:
+  name: connpass
+  group_id: 3809
+  url: https://coderdojokodaira-ninja.connpass.com/
 - dojo_id: 14
   name: peatix
   group_id:

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -99,6 +99,10 @@
   group_id: 617011185103868
   url: https://www.facebook.com/pg/CoderDojoTokorozawa/events/
 - dojo_id: 13
+  name: static_yaml
+  group_id:
+  url:
+- dojo_id: 13
   name: connpass
   group_id: 3809
   url: https://coderdojokodaira-ninja.connpass.com/


### PR DESCRIPTION
cf #470
※ ⚠️ 「近日開催の道場」への掲載は行いますが、過去イベントの統計情報収集をどうするかはまだ決まっていないので、fixed → cf に変更します。

小平の connpass を追加しました！
@chicaco 確認よろしくお願いします🙇‍♀️