### PR TITLE
奈良・生駒・田原本をイベント収集対象に追加

### DIFF
--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -28,8 +28,14 @@ class UpcomingEvent < ApplicationRecord
   end
 
   def catalog
+    # NOTE: 奈良・生駒・田原本の Dojo 名は特別に加工
+    dojo_name = if dojo_event_service.name == 'connpass' && dojo_event_service.group_id == '2617'
+                  '奈良・生駒・田原本'
+                else
+                  dojo_event_service.dojo.name
+                end
     {
-      dojo_name:            dojo_event_service.dojo.name,
+      dojo_name:            dojo_name,
       dojo_prefecture_name: dojo_event_service.dojo.prefecture.name,
       event_title:          event_title,
       event_url:            event_url,

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -302,6 +302,17 @@
   name: doorkeeper
   group_id: 4052
   url: https://coderdojo-nagaokakyo.doorkeeper.jp
+- dojo_id: 35
+  name: connpass
+  group_id: 2617
+  url: https://coderdojo-nara-ikoma.connpass.com/
+  # 奈良・生駒・田原本 のイベント収集サイトは共通
+  # - dojo_id: 36
+  #   name: 生駒
+  # - dojo_id: 169
+  #   name: 明日香
+  # - dojo_id: 177
+  #   name: 田原本
 - dojo_id: 37
   name: connpass
   group_id: 2822


### PR DESCRIPTION
## 背景

奈良・生駒・田原本は、共通のイベント情報収集サイトを利用している。
https://coderdojo-nara-ikoma.connpass.com/

cf. #473

## やりたいこと

奈良・生駒・田原本をイベント収集対象に追加して、以下を実現する。
- 統計情報で開催回数、参加人数を収集できる
- 近日開催の道場情報に掲載する

## このPRでやること

- [x] db/dojo_event_services.yaml に、代表とする奈良の dojo に対して奈良・生駒・田原本の connpass サイトを追記する
- [x] 近日開催の道場情報の Dojo 名には、「奈良・生駒・田原本」と表示する

## やらなかったこと

- 複数 Dojo で共通の dojo_event_service を利用している場合の永続的＆汎用性のある対応 (まだよい方法を見付けていない)

## レビューポイント

- 対象の dojo_event_service の特定には、プロバイダ種別の 'connpass' とグループID '2617' を使用し、dojo_id や dojo_event_service_id には影響を受けないようにしました

## 困っていること

特になし