### PR TITLE
稲城を集計対象に追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -511,6 +511,10 @@
   name: connpass
   group_id: 5408
   url: https://coderdojo-nisshin.connpass.com/
+- dojo_id: 147
+  name: doorkeeper
+  group_id: 9690
+  url: https://coderdojo-inagi.doorkeeper.jp/
 #- dojo_id: 149
 #  name: connpass
 #  group_id: # TODO: connpass の series id ができたら追加する


### PR DESCRIPTION
## 背景

CoderDojo 稲城を集計対象に追加したい

Fixed #482

## やること

イベント収集プロバイダとして https://coderdojo-inagi.doorkeeper.jp/ を登録する
