### PR TITLE
Reset pk sequence before `dojos:update_db_by_yaml`

### DIFF
--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -45,6 +45,8 @@ namespace :dojos do
     end
   end
 
+  Rake::Task['dojos:update_db_by_yaml'].enhance(['postgresql:reset_pk_sequence'])
+
   # search order number for google spred sheets
   # 'yamlファイルのnameからorderの値を生成します'
   def search_order_number(pre_city)

--- a/lib/tasks/postgresql.rake
+++ b/lib/tasks/postgresql.rake
@@ -1,0 +1,11 @@
+namespace :postgresql do
+  # https://github.com/coderdojo-japan/coderdojo.jp/blob/master/docs/how-to-update-db-id.md
+  # https://github.com/rails/rails/blob/ec8697bf0bfafff7d897fb50e322afe42ddc1623/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L289-L315
+  desc '全てのテーブルのsequenceを既存のidの最大値に設定しなおす'
+  task reset_pk_sequence: :environment do
+    ignore_rails_tables = %w(schema_migrations ar_internal_metadata).freeze
+    ApplicationRecord.connection.tap do |c|
+      (c.tables - ignore_rails_tables).each { |t| c.reset_pk_sequence!(t) }
+    end
+  end
+end

--- a/spec/lib/tasks/dojos_spec.rb
+++ b/spec/lib/tasks/dojos_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'dojos' do
   before(:all) do
     @rake = Rake::Application.new
     Rake.application = @rake
+    Rake.application.rake_require 'tasks/postgresql'
     Rake.application.rake_require 'tasks/dojos'
     Rake::Task.define_task(:environment)
   end


### PR DESCRIPTION
Fix #484
PostgreSQLのアダプターに実装されているメソッドを使いました。
https://github.com/rails/rails/blob/v5.1.6.2/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L289-L315
`dojos:update_db_by_yqml`のタスクが実行される前に、毎回sequenceをリセットします。