### PR TITLE
UpcomingEvent にイベント終了日時カラムを追加して「近日開催の道場」への表示条件を終了日時による判定に変更

### DIFF
--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -6,10 +6,11 @@ class UpcomingEvent < ApplicationRecord
   validates :event_url,    presence: true
   validates :event_at,     presence: true
   validates :participants, presence: true
+  validates :event_end_at, presence: true
 
   scope :for, ->(service) { where(dojo_event_service: DojoEventService.for(service)) }
-  scope :since, ->(date) { where('event_at >= ?', date.beginning_of_day) }
-  scope :until, ->(date) { where('event_at < ?', date.beginning_of_day) }
+  scope :since, ->(date) { where('event_end_at >= ?', date.beginning_of_day) }
+  scope :until, ->(date) { where('event_end_at < ?', date.beginning_of_day) }
 
   class << self
     def group_by_prefecture_and_date

--- a/db/migrate/20190616142422_add_event_end_at_to_upcoming_event.rb
+++ b/db/migrate/20190616142422_add_event_end_at_to_upcoming_event.rb
@@ -1,0 +1,5 @@
+class AddEventEndAtToUpcomingEvent < ActiveRecord::Migration[5.1]
+  def change
+    add_column :upcoming_events, :event_end_at, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190602092528) do
+ActiveRecord::Schema.define(version: 20190616142422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 20190602092528) do
     t.string "service_name", null: false
     t.integer "participants", null: false
     t.string "event_title", null: false
+    t.datetime "event_end_at", null: false
     t.index ["dojo_event_service_id"], name: "index_upcoming_events_on_dojo_event_service_id"
     t.index ["service_name", "event_id"], name: "index_upcoming_events_on_service_name_and_event_id", unique: true
   end

--- a/lib/upcoming_events/aggregation.rb
+++ b/lib/upcoming_events/aggregation.rb
@@ -1,8 +1,10 @@
 module UpcomingEvents
   class Aggregation
     def initialize(args)
-      @from = Time.zone.today
-      @to = @from + 2.months
+      # NOTE: 1 ヶ月前 〜 2 ヶ月後のイベント情報を対象に収集
+      today = Time.zone.today
+      @from = today - 1.months + 1.day
+      @to = today + 2.months
       @provider = args[:provider]
       # NOTE: 対象は一旦収集可能な connpass, doorkeeper のみにする
       @externals = fetch_dojos(@provider)

--- a/lib/upcoming_events/tasks/connpass.rb
+++ b/lib/upcoming_events/tasks/connpass.rb
@@ -18,6 +18,7 @@ module UpcomingEvents
                              event_title:  e['title'],
                              event_url:    e['event_url'],
                              event_at:     Time.zone.parse(e['started_at']),
+                             event_end_at: Time.zone.parse(e['ended_at']),
                              participants: e['accepted'])
             end
           end

--- a/lib/upcoming_events/tasks/doorkeeper.rb
+++ b/lib/upcoming_events/tasks/doorkeeper.rb
@@ -15,10 +15,11 @@ module UpcomingEvents
 
               record = dojo_event_service.upcoming_events.find_or_initialize_by(event_id: e['id'])
               record.update!(service_name: dojo_event_service.name,
-                             event_title: e['title'],
-                             event_url: e['public_url'],
+                             event_title:  e['title'],
+                             event_url:    e['public_url'],
                              participants: e['participants'],
-                             event_at: Time.zone.parse(e['starts_at']))
+                             event_at:     Time.zone.parse(e['starts_at']),
+                             event_end_at: Time.zone.parse(e['ends_at']))
             end
           end
         end

--- a/spec/factories/upcoming_events.rb
+++ b/spec/factories/upcoming_events.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     event_title  { 'event title' }
     event_url    { 'http:/www.aaa.com/events/1224' }
     event_at     { '2019-05-01 10:00'.in_time_zone }
+    event_end_at { '2019-05-01 13:00'.in_time_zone }
     participants { 1 }
   end
 end

--- a/spec/lib/upcoming_events/aggregation_spec.rb
+++ b/spec/lib/upcoming_events/aggregation_spec.rb
@@ -25,12 +25,22 @@ RSpec.describe UpcomingEvents::Aggregation do
       expect{ UpcomingEvents::Aggregation.new(provider: 'doorkeeper').run }.to change{ UpcomingEvent.count }.from(0).to(2)
     end
 
-    it '昨日分までは削除' do
-      create(:upcoming_event, dojo_event_service_id: @es1.id, service_name: 'connpass', event_id: '1111', event_title: 'title 1111', event_at: "#{Time.zone.today - 3.days} 13:00:00".in_time_zone)
-      create(:upcoming_event, dojo_event_service_id: @es1.id, service_name: 'connpass', event_id: '2222', event_title: 'title 2222', event_at: "#{Time.zone.today - 2.days} 14:00:00".in_time_zone)
-      create(:upcoming_event, dojo_event_service_id: @es1.id, service_name: 'connpass', event_id: '3333', event_title: 'title 3333', event_at: "#{Time.zone.today - 1.days} 15:00:00".in_time_zone)
-      create(:upcoming_event, dojo_event_service_id: @es2.id, service_name: 'doorkeeper', event_id: '4444', event_title: 'title 4444', event_at: "#{Time.zone.today - 2.days} 10:00:00".in_time_zone)
-      create(:upcoming_event, dojo_event_service_id: @es2.id, service_name: 'doorkeeper', event_id: '5555', event_title: 'title 5555', event_at: "#{Time.zone.today - 1.days} 11:00:00".in_time_zone)
+    it '1 ヶ月前までは削除' do
+      create(:upcoming_event, dojo_event_service_id: @es1.id, service_name: 'connpass', event_id: '1111', event_title: 'title 1111',
+                              event_at: "#{Time.zone.today - 1.month - 2.day} 13:00:00".in_time_zone,
+                              event_end_at: "#{Time.zone.today - 1.month - 2.day} 15:00:00".in_time_zone)
+      create(:upcoming_event, dojo_event_service_id: @es1.id, service_name: 'connpass', event_id: '2222', event_title: 'title 2222',
+                              event_at: "#{Time.zone.today - 1.month - 1.day} 14:00:00".in_time_zone,
+                              event_end_at: "#{Time.zone.today - 1.month - 1.day} 16:00:00".in_time_zone)
+      create(:upcoming_event, dojo_event_service_id: @es1.id, service_name: 'connpass', event_id: '3333', event_title: 'title 3333',
+                              event_at: "#{Time.zone.today - 1.month} 15:00:00".in_time_zone,
+                              event_end_at: "#{Time.zone.today - 1.month} 17:00:00".in_time_zone)
+      create(:upcoming_event, dojo_event_service_id: @es2.id, service_name: 'doorkeeper', event_id: '4444', event_title: 'title 4444',
+                              event_at: "#{Time.zone.today - 1.month - 1.day} 10:00:00".in_time_zone,
+                              event_end_at: "#{Time.zone.today - 1.month - 1.day} 12:00:00".in_time_zone)
+      create(:upcoming_event, dojo_event_service_id: @es2.id, service_name: 'doorkeeper', event_id: '5555', event_title: 'title 5555',
+                              event_at: "#{Time.zone.today - 1.month} 11:00:00".in_time_zone,
+                              event_end_at: "#{Time.zone.today - 1.month} 13:00:00".in_time_zone)
 
       expect{ UpcomingEvents::Aggregation.new({}).run }.to change{ UpcomingEvent.count }.from(5).to(3)
     end


### PR DESCRIPTION
## 背景
複数開催分のイベントを 1 つのイベント募集にまとめている Dojo についても、「近日開催の道場」に掲載したい。
cf #472

### 掲載できていない理由

- 1 ヶ月分の複数回のイベントを 1 つのイベントとし、イベント開始日時に初回の開始日時、イベント終了日時に最終回の終了日時を設定して登録しているケースがある
- 直近のイベント情報収集タスクで、「イベント開始日時」が実行日より前のレコードを削除している
- 「近日開催の道場」には「イベント開始日時」が当日 0:00 より後のレコードを表示している

## やりたいこと

- UpcomingEvent に「イベント終了日時」カラムを追加し、直近のイベント情報収集タスクで「イベント終了日時」にも情報を採取する
- 前回までに収集した直近のイベント情報で、「イベント終了日時」が 1 ヶ月より前のレコードを削除するように変更
- 「近日開催の道場」には「イベント終了日時」が当日 0:00 より後のレコードを表示する

## このPRでやること

- [x] UpcomingEvent に「イベント終了日時」カラムを追加する
- [x] 直近のイベント情報収集タスクで「イベント終了日時」も保存する
- [x] 直近のイベント情報収集タスクで削除するレコードを、「イベント終了日時」が 1 ヶ月より前のレコードに変更する
- [x] 「近日開催の道場」に表示する UpcomingEvent の条件を、「イベント開始日時」が当日 0:00 より後のレコードに変更する
- [x] Rspec 修正

## やらなかったこと

特になし

## 困ってること

特になし

## ⚠️ 注意 ⚠️ 

- マージ前に、本番環境の UpcomingEvent のレコードを削除すること