### PR TITLE
那覇を集計対象に追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -659,6 +659,6 @@
   url: https://www.facebook.com/DojoPcc/
 # 那覇
 - dojo_id: 216
- name: doorkeeper
- group_id: 10300
- url: https://coderdojo-naha.doorkeeper.jp/
+  name: doorkeeper
+  group_id: 10300
+  url: https://coderdojo-naha.doorkeeper.jp/

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -652,15 +652,13 @@
   name: connpass
   group_id: 7924
   url: https://volunteer-r.connpass.com/
-
 # 大石田@PCチャレンジ倶楽部
 - dojo_id: 215
   name: facebook
   group_id: 2253119258233423
   url: https://www.facebook.com/DojoPcc/
-
 # 那覇
-#- dojo_id: 216
-#  name: doorkeeper
-#  group_id: # TODO: イベントが公開されたらAPIを叩いてGroup IDを取得する
-#  url: https://coderdojo-naha.doorkeeper.jp/
+- dojo_id: 216
+ name: doorkeeper
+ group_id: 10300
+ url: https://coderdojo-naha.doorkeeper.jp/


### PR DESCRIPTION
## 背景

CoderDojo 那覇を集計対象に追加したい

fix #489

## やること

イベント収集プロバイダとして https://coderdojo-naha.doorkeeper.jp/ を登録する
