### PR TITLE
SoundCloud のユーザIDを固定値にする(環境変数 SOUNDCLOUD_USER_ID を廃止)

### DIFF
--- a/lib/tasks/soundcloud_tracks.rake
+++ b/lib/tasks/soundcloud_tracks.rake
@@ -8,7 +8,7 @@ namespace :soundcloud_tracks do
     logger.info('==== START soundcloud_tracks:upsert ====')
 
     client = SoundCloud.new(client_id: ENV['SOUNDCLOUD_CLIENT_ID'])
-    tracks = client.get("/users/#{ENV['SOUNDCLOUD_USER_ID']}/tracks", limit: 100).map(&:deep_symbolize_keys)
+    tracks = client.get('/users/626746926/tracks', limit: 100).map(&:deep_symbolize_keys)
 
     if tracks.length.zero?
       logger.info('no track')


### PR DESCRIPTION
## 背景

SoundCloud から DojoCast の tracks を取得する対象は CoderDojo Japan Association のアカウント固定なので固定値でよいはずのユーザIDに、環境変数を参照するコードが残っている。

## やりたいこと

CoderDojo Japan Association のユーザIDは環境ごとには異ならないので、環境変数 SOUNDCLOUD_USER_ID の参照でなく、 固定値 626746926 に修正する。
