### PR TITLE
bin/setup タスクに統計情報収集と近日開催イベント情報収集処理を追加

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'pathname'
 require 'fileutils'
+require 'date'
 include FileUtils
 
 # path to your application root.
@@ -8,6 +9,22 @@ APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+def doorkeeper_message
+  <<~MESSAGE
+
+  環境変数 DOORKEEPER_API_TOKEN が設定されていないため、
+  Doorkeeper API を使ったイベント情報の取得をスキップします。
+
+  Doorkeeper のイベントを取得するためには、
+  下記ページから Doorkeeper API Token を取得し、
+  環境変数 DOORKEEPER_API_TOKEN に設定してください。
+  https://manage.doorkeeper.jp/user/oauth/applications
+
+  環境変数設定後に、bin/setup を再実行してください！
+
+  MESSAGE
 end
 
 chdir APP_ROOT do
@@ -21,7 +38,6 @@ chdir APP_ROOT do
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
 
-
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')
   #   cp 'config/database.yml.sample', 'config/database.yml'
@@ -33,6 +49,20 @@ chdir APP_ROOT do
   puts "\n== Upserting application data =="
   system! 'bin/rails dojos:update_db_by_yaml'
   system! 'bin/rails dojo_event_services:upsert'
+
+  today = Date.today
+  from = (today - 90).strftime('%Y%m')
+  to   = today.prev_month.strftime('%Y%m')
+
+  if ENV['DOORKEEPER_API_TOKEN']
+    system! "bin/rails statistics:aggregation[#{from},#{to}]"
+    system! 'bin/rails upcoming_events:aggregation'
+  else
+    puts doorkeeper_message
+    system! "bin/rails statistics:aggregation[#{from},#{to},connpass]"
+    system! "bin/rails statistics:aggregation[#{from},#{to},facebook]"
+    system! 'bin/rails upcoming_events:aggregation[connpass]'
+  end
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'


### PR DESCRIPTION
## 背景
./bin/setup タスクで Dojo 関連のレコードもまとめて作成したい

## やりたいこと

「レコードがないことにより○○ページ、ページのコンテンツが表示できない」ことをなくすため、`./bin/setup` で統計情報収集、近日開催イベント情報の収集も行う

fixes #491

## このPRでやること

- [x] `./bin/setup` で直近 3 ヶ月分程度の統計情報収集を行う
- [x] `./bin/setup` で近日開催イベント情報の収集を行う
- [x] Doorkeeper のイベント情報収集に必要な環境変数 DOORKEEPER_API_TOKEN が設定されていないときは、メッセージを表示して Doorkeeper からのイベント情報収集は行わない

## やらなかったこと

- SoundCloud は開発する人が増えるとは想像しにくいので、CoderDojo 側に SoundCloud のトラックデータを取り込む処理は `./bin/setup` に追加しない (cf. [#491 のコメント](https://github.com/coderdojo-japan/coderdojo.jp/issues/491#issuecomment-503360656))

## レビューポイント

- 環境変数 DOORKEEPER_API_TOKEN の設定有無による分岐

## 困ってること

特になし