### PR TITLE
日吉を集計対象に追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -685,6 +685,13 @@
   name: doorkeeper
   group_id: 10019
   url: https://coderdojo-suita.doorkeeper.jp/
+
+# 日吉(福岡県久留米市)
+- dojo_id: 207
+  name: connpass
+  group_id: 7561
+  url: https://coderdojo-hiyoshi.connpass.com/
+
 - dojo_id: 208
   name: connpass
   group_id: 7500


### PR DESCRIPTION
## 背景

CoderDojo 日吉を集計対象に追加したい

fix #505

## やること

イベント収集プロバイダとして https://coderdojo-hiyoshi.connpass.com/ を登録する

##  デプロイ後にやること

- 2019/04 以降の統計情報を再収集する
