### PR TITLE
SoundCloudTrack T に published_date を追加

### DIFF
--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -2,7 +2,7 @@ class PodcastsController < ApplicationController
   def index
     @title          = 'DojoCast'
     @description    = 'Highlight people around CoderDojo community by Podcast.'
-    @episodes       = SoundCloudTrack.all.sort_by{ |episode| episode.published_at }
+    @episodes       = SoundCloudTrack.order(:published_date)
     @url            = request.url
     @next_live_date = ENV['NEXT_LIVE_DATE'] || '未定'
 

--- a/app/models/sound_cloud_track.rb
+++ b/app/models/sound_cloud_track.rb
@@ -4,16 +4,15 @@ class SoundCloudTrack < ApplicationRecord
   DIR_PATH  = 'public/podcasts'
   URL_PATH  = 'podcasts'
 
-  validates :track_id,              presence: false, uniqueness: true
-  validates :title,                 presence: false
-  validate  :description
-  validates :original_content_size, presence: false
-  validates :duration,              presence: false
-  validate  :tag_list
-  validates :download_url,          presence: false
-  validates :permalink,             presence: false
-  validates :permalink_url,         presence: false
-  validates :uploaded_at,           presence: false
+  validates :track_id,              presence: true, uniqueness: true
+  validates :title,                 presence: true
+  validates :original_content_size, presence: true
+  validates :duration,              presence: true
+  validates :download_url,          presence: true
+  validates :permalink,             presence: true
+  validates :permalink_url,         presence: true
+  validates :uploaded_at,           presence: true
+  validates :published_date,        presence: true
 
   # instance methods
   def path
@@ -27,10 +26,6 @@ class SoundCloudTrack < ApplicationRecord
   def exists?(offset: 0)
     return false if path.include?("\u0000")
     File.exists?("#{DIR_PATH}/#{id + offset}.md")
-  end
-
-  def published_at
-    exists? ? Time.parse(content.lines.second.gsub(/<.+?>/, '').delete('収録日: ')) : nil
   end
 
   def content

--- a/app/views/podcasts/feed.rss.builder
+++ b/app/views/podcasts/feed.rss.builder
@@ -40,7 +40,7 @@ xml.rss :version => '2.0',
         xml.link         episode.permalink_url
         xml.guid         episode.permalink_url
         xml.itunes       :explicit, 'clean'
-        xml.pubDate      episode.published_at.rfc2822
+        xml.pubDate      episode.published_date.rfc2822
         xml.enclosure({
           url:    "http://feeds.soundcloud.com/stream/#{episode.track_id}-#{@soundcloud_user}-#{episode.permalink}.mp3",
           length: episode.original_content_size,

--- a/app/views/podcasts/index.html.erb
+++ b/app/views/podcasts/index.html.erb
@@ -24,7 +24,7 @@
     <h3 id="episodes" style="text-align: center; padding-bottom: 10px;">📻 これまでの収録</h3>
     <ul style="font-size: 120%">
       <% @episodes.each do |episode| %>
-        <li><!-- <small><%#= episode.published_at.try(:strftime, '%Y/%m/%d') || '----/--/--' %></small> -->
+        <li><!-- <small><%#= episode.published_date.try(:strftime, '%Y/%m/%d') || '----/--/--' %></small> -->
           <%= link_to episode.title, episode.url %></li>
       <% end %>
     </ul>

--- a/db/migrate/20190812033029_add_published_date_to_sound_cloud_tracks.rb
+++ b/db/migrate/20190812033029_add_published_date_to_sound_cloud_tracks.rb
@@ -1,0 +1,28 @@
+class AddPublishedDateToSoundCloudTracks < ActiveRecord::Migration[5.1]
+  def up
+    add_column :soundcloud_tracks, :published_date, :date, null: false, default: -> { "CURRENT_DATE" }
+
+    execute <<-SQL
+      UPDATE soundcloud_tracks SET published_date = '2017/03/25' WHERE track_id = 614641407;
+      UPDATE soundcloud_tracks SET published_date = '2017/04/13' WHERE track_id = 614642385;
+      UPDATE soundcloud_tracks SET published_date = '2017/04/15' WHERE track_id = 614792823;
+      UPDATE soundcloud_tracks SET published_date = '2017/04/16' WHERE track_id = 614799783;
+      UPDATE soundcloud_tracks SET published_date = '2017/04/22' WHERE track_id = 614981916;
+      UPDATE soundcloud_tracks SET published_date = '2017/04/24' WHERE track_id = 614981952;
+      UPDATE soundcloud_tracks SET published_date = '2017/04/25' WHERE track_id = 614981976;
+      UPDATE soundcloud_tracks SET published_date = '2017/07/07' WHERE track_id = 614982066;
+      UPDATE soundcloud_tracks SET published_date = '2017/09/16' WHERE track_id = 614982087;
+      UPDATE soundcloud_tracks SET published_date = '2018/12/05' WHERE track_id = 614982105;
+      UPDATE soundcloud_tracks SET published_date = '2019/03/25' WHERE track_id = 614982114;
+      UPDATE soundcloud_tracks SET published_date = '2019/05/18' WHERE track_id = 625063656;
+      UPDATE soundcloud_tracks SET published_date = '2019/05/30' WHERE track_id = 630718164;
+      UPDATE soundcloud_tracks SET published_date = '2019/08/13' WHERE track_id = 665969993;
+    SQL
+
+    change_column_default :soundcloud_tracks, :published_date, from: -> { "CURRENT_DATE" }, to: nil
+  end
+
+  def down
+    remove_column :soundcloud_tracks, :published_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190616142422) do
+ActiveRecord::Schema.define(version: 20190812033029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 20190616142422) do
     t.datetime "uploaded_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "published_date", null: false
     t.index ["track_id"], name: "index_soundcloud_tracks_on_track_id", unique: true
   end
 

--- a/lib/tasks/soundcloud_tracks.rake
+++ b/lib/tasks/soundcloud_tracks.rake
@@ -23,6 +23,11 @@ namespace :soundcloud_tracks do
           is_new = true
           track = SoundCloudTrack.new(track_id: d[:id])
         end
+        if d[:release_year] && d[:release_month] && d[:release_day]
+          published_date = "#{d[:release_year]}-#{d[:release_month]}-#{d[:release_day]}".to_date
+        else
+          raise 'No Release Date'
+        end
         track.update!(
           title:                 d[:title],
           description:           d[:description],
@@ -32,7 +37,8 @@ namespace :soundcloud_tracks do
           download_url:          d[:download_url],
           permalink:             d[:permalink],
           permalink_url:         d[:permalink_url],
-          uploaded_at:           d[:created_at]
+          uploaded_at:           d[:created_at],
+          published_date:        published_date
         )
         logger.info("added [#{track.id}] #{track.title}") if is_new
       end

--- a/spec/factories/soundcloud_tracks.rb
+++ b/spec/factories/soundcloud_tracks.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
     permalink             { 'title' }
     permalink_url         { 'http://aaa.bbb/title' }
     uploaded_at           { '2019/01/01 09:00:00'.in_time_zone }
+    published_date        { Time.zone.today }
   end
 end

--- a/spec/lib/tasks/soundcloud_tracks_spec.rb
+++ b/spec/lib/tasks/soundcloud_tracks_spec.rb
@@ -20,13 +20,106 @@ RSpec.describe 'soundcloud_tracks' do
   describe 'soundcloud_tracks:upsert' do
     before :each do
       @sct_1 = create(:soundcloud_track, track_id: 111001, title: 'podcast 001', duration: '00:16:40', permalink: 'podcast-001')
-      @sct_2 = create(:soundcloud_track, track_id: 111002, title: 'podcast 002', duration: '00:33:20', permalink: 'podcast-002')
+      @sct_2 = create(:soundcloud_track, track_id: 111002, title: 'podcast 002', duration: '00:33:20', permalink: 'podcast-002', published_date: '2018-07-01'.to_date)
       @sct_3 = create(:soundcloud_track, track_id: 111003, title: 'podcast 003', duration: '00:50:00', permalink: 'podcast-003')
     end
 
     let(:task) { 'soundcloud_tracks:upsert' }
 
-    it '単純追加' do
+    it '単純追加(Release date あり)' do
+      allow_any_instance_of(SoundCloud::Client).to receive(:get).and_return(
+        [
+          { 'id'                    => 123456001,
+            'created_at'            => '2019/01/23 01:00:00 +0000',
+            'description'           => '説明 001',
+            'original_content_size' => 124542711,
+            'title'                 => 'podcast title 001',
+            'duration'              => 5189815,
+            'original_format'       => 'mp3',
+            'tag_list'              => 'coderdojo',
+            'genre'                 => 'Technology',
+            'download_url'          => 'https://api.soundcloud.com/tracks/123456001/download',
+            'last_modified'         => '2019/01/24 03:00:00 +0000',
+            'uri'                   => 'https://api.soundcloud.com/tracks/123456001',
+            'attachments_uri'       => 'https://api.soundcloud.com/tracks/123456001/attachments',
+            'license'               => 'cc-by-nc-sa',
+            'user_id'               => 123456789,
+            'permalink'             => 'podcast-001',
+            'permalink_url'         => 'https://soundcloud.com/coderdojojp/podcast-001',
+            'release_year'          => 2019,
+            'release_month'         => 8,
+            'release_day'           => 12 }
+        ]
+      )
+
+      # before
+      expect(SoundCloudTrack.count).to eq(3)
+      before_ids = SoundCloudTrack.ids
+
+      # exec
+      expect(@rake[task].invoke).to be_truthy
+
+      # after
+      expect(SoundCloudTrack.count).to eq(4)
+      new_records = SoundCloudTrack.where.not(id: before_ids)
+      expect(new_records.count).to eq(1)
+
+      expect(new_records.first.track_id).to eq(123456001)
+      expect(new_records.first.uploaded_at).to eq('2019-01-23 10:00:00'.in_time_zone)
+
+      expect(new_records.first.title).to eq('podcast title 001')
+      expect(new_records.first.description).to eq('説明 001')
+      expect(new_records.first.original_content_size).to eq(124542711)
+      expect(new_records.first.duration).to eq(Time.at(5189815/1000).utc.strftime('%H:%M:%S'))
+      expect(new_records.first.tag_list).to eq('coderdojo')
+      expect(new_records.first.download_url).to eq('https://api.soundcloud.com/tracks/123456001/download')
+      expect(new_records.first.permalink).to eq('podcast-001')
+      expect(new_records.first.permalink_url).to eq('https://soundcloud.com/coderdojojp/podcast-001')
+      expect(new_records.first.published_date).to eq('2019-08-12'.to_date)
+    end
+
+    it '単純更新(Release date あり)' do
+      allow_any_instance_of(SoundCloud::Client).to receive(:get).and_return(
+        [
+          { 'id'                    => @sct_2.track_id,
+            'created_at'            => '2019/01/23 01:00:00 +0000',
+            'description'           => 'podcast 説明 002',
+            'original_content_size' => 124542711,
+            'title'                 => 'podcast title 002',
+            'duration'              => 6000000,
+            'original_format'       => 'mp3',
+            'tag_list'              => 'coderdojo',
+            'genre'                 => 'Technology',
+            'download_url'          => 'https://api.soundcloud.com/tracks/123456001/download',
+            'last_modified'         => '2019/01/24 03:00:00 +0000',
+            'uri'                   => 'https://api.soundcloud.com/tracks/123456001',
+            'attachments_uri'       => 'https://api.soundcloud.com/tracks/123456001/attachments',
+            'license'               => 'cc-by-nc-sa',
+            'user_id'               => 123456789,
+            'permalink'             => 'podcast-002',
+            'permalink_url'         => 'https://soundcloud.com/coderdojojp/podcast-002',
+            'release_year'          => 2019,
+            'release_month'         => 8,
+            'release_day'           => 12 }
+        ]
+      )
+
+      # before
+      expect(SoundCloudTrack.count).to eq(3)
+
+      # exec
+      expect(@rake[task].invoke).to be_truthy
+
+      # after
+      expect(SoundCloudTrack.count).to eq(3)
+      mod_record = SoundCloudTrack.find_by(track_id: @sct_2.track_id)
+      expect(mod_record.title).to eq('podcast title 002')
+      expect(mod_record.description).to eq('podcast 説明 002')
+      expect(mod_record.duration).to eq(Time.at(6000000/1000).utc.strftime('%H:%M:%S'))
+      expect(mod_record.published_date).to eq('2019-08-12'.to_date)
+    end
+
+    it '単純追加(Release date なし) ⇒ エラー' do
       allow_any_instance_of(SoundCloud::Client).to receive(:get).and_return(
         [
           { 'id'                    => 123456001,
@@ -54,27 +147,15 @@ RSpec.describe 'soundcloud_tracks' do
       before_ids = SoundCloudTrack.ids
 
       # exec
-      expect(@rake[task].invoke).to be_truthy
+      expect { @rake[task].invoke }.to raise_error('No Release Date')
 
       # after
-      expect(SoundCloudTrack.count).to eq(4)
+      expect(SoundCloudTrack.count).to eq(3)
       new_records = SoundCloudTrack.where.not(id: before_ids)
-      expect(new_records.count).to eq(1)
-
-      expect(new_records.first.track_id).to eq(123456001)
-      expect(new_records.first.uploaded_at).to eq('2019-01-23 10:00:00'.in_time_zone)
-
-      expect(new_records.first.title).to eq('podcast title 001')
-      expect(new_records.first.description).to eq('説明 001')
-      expect(new_records.first.original_content_size).to eq(124542711)
-      expect(new_records.first.duration).to eq(Time.at(5189815/1000).utc.strftime('%H:%M:%S'))
-      expect(new_records.first.tag_list).to eq('coderdojo')
-      expect(new_records.first.download_url).to eq('https://api.soundcloud.com/tracks/123456001/download')
-      expect(new_records.first.permalink).to eq('podcast-001')
-      expect(new_records.first.permalink_url).to eq('https://soundcloud.com/coderdojojp/podcast-001')
+      expect(new_records.count).to eq(0)
     end
 
-    it '単純更新' do
+    it '単純更新(Release date なし) ⇒ エラー' do
       allow_any_instance_of(SoundCloud::Client).to receive(:get).and_return(
         [
           { 'id'                    => @sct_2.track_id,
@@ -101,14 +182,14 @@ RSpec.describe 'soundcloud_tracks' do
       expect(SoundCloudTrack.count).to eq(3)
 
       # exec
-      expect(@rake[task].invoke).to be_truthy
+      expect { @rake[task].invoke }.to raise_error('No Release Date')
 
       # after
       expect(SoundCloudTrack.count).to eq(3)
       mod_record = SoundCloudTrack.find_by(track_id: @sct_2.track_id)
-      expect(mod_record.title).to eq('podcast title 002')
-      expect(mod_record.description).to eq('podcast 説明 002')
-      expect(mod_record.duration).to eq(Time.at(6000000/1000).utc.strftime('%H:%M:%S'))
+      expect(mod_record.title).to eq('podcast 002')
+      expect(mod_record.duration).to eq('00:33:20')
+      expect(mod_record.published_date).to eq('2018-07-01'.to_date)
     end
 
     it '複数 (追加/更新)' do
@@ -123,7 +204,10 @@ RSpec.describe 'soundcloud_tracks' do
             'tag_list'              => @sct_2.tag_list,
             'download_url'          => @sct_2.download_url,
             'permalink'             => @sct_2.permalink,
-            'permalink_url'         => @sct_2.permalink_url },
+            'permalink_url'         => @sct_2.permalink_url,
+            'release_year'          => 2019,
+            'release_month'         => 8,
+            'release_day'           => 1 },
           { 'id'                    => 123456001,
             'created_at'            => '2019/01/23 01:00:00 +0000',
             'description'           => '説明 001',
@@ -133,7 +217,101 @@ RSpec.describe 'soundcloud_tracks' do
             'tag_list'              => 'coderdojo',
             'download_url'          => 'https://api.soundcloud.com/tracks/123456001/download',
             'permalink'             => 'podcast-004',
-            'permalink_url'         => 'https://soundcloud.com/coderdojojp/podcast-004' },
+            'permalink_url'         => 'https://soundcloud.com/coderdojojp/podcast-004',
+            'release_year'          => 2019,
+            'release_month'         => 8,
+            'release_day'           => 2 },
+          { 'id'                    => @sct_1.track_id,
+            'created_at'            => @sct_1.uploaded_at.to_s,
+            'description'           => @sct_1.description,
+            'original_content_size' => @sct_1.original_content_size,
+            'title'                 => 'podcast 001 mod',
+            'duration'              => calc_duration(@sct_1.duration),
+            'tag_list'              => @sct_1.tag_list,
+            'download_url'          => @sct_1.download_url,
+            'permalink'             => @sct_1.permalink,
+            'permalink_url'         => @sct_1.permalink_url,
+            'release_year'          => 2019,
+            'release_month'         => 8,
+            'release_day'           => 3 },
+          { 'id'                    => @sct_3.track_id,
+            'created_at'            => @sct_3.uploaded_at.to_s,
+            'description'           => @sct_3.description,
+            'original_content_size' => @sct_3.original_content_size,
+            'title'                 => 'podcast 003 mod',
+            'duration'              => calc_duration(@sct_3.duration),
+            'tag_list'              => @sct_3.tag_list,
+            'download_url'          => @sct_3.download_url,
+            'permalink'             => @sct_3.permalink,
+            'permalink_url'         => @sct_3.permalink_url,
+            'release_year'          => 2019,
+            'release_month'         => 8,
+            'release_day'           => 4 }
+          ]
+      )
+
+      # before
+      expect(SoundCloudTrack.count).to eq(3)
+      before_ids = SoundCloudTrack.ids
+
+      # exec
+      expect(@rake[task].invoke).to be_truthy
+
+      # after
+      expect(SoundCloudTrack.count).to eq(4)
+      new_records = SoundCloudTrack.where.not(id: before_ids)
+      expect(new_records.count).to eq(1)
+      expect(new_records.first.track_id).to eq(123456001)
+      expect(new_records.first.published_date).to eq('2019-08-02'.to_date)
+
+      after_sct_1 = SoundCloudTrack.find_by(id: @sct_1.id)
+      expect(after_sct_1.track_id).to eq(111001)
+      expect(after_sct_1.title).to eq('podcast 001 mod')
+      expect(calc_duration(after_sct_1.duration)).to eq(1000000)
+      expect(after_sct_1.published_date).to eq('2019-08-03'.to_date)
+
+      after_sct_2 = SoundCloudTrack.find_by(id: @sct_2.id)
+      expect(after_sct_2.track_id).to eq(111002)
+      expect(after_sct_2.title).to eq('podcast 002 mod')
+      expect(calc_duration(after_sct_2.duration)).to eq(2000000)
+      expect(after_sct_2.published_date).to eq('2019-08-01'.to_date)
+
+      after_sct_3 = SoundCloudTrack.find_by(id: @sct_3.id)
+      expect(after_sct_3.track_id).to eq(111003)
+      expect(after_sct_3.title).to eq('podcast 003 mod')
+      expect(calc_duration(after_sct_3.duration)).to eq(3000000)
+      expect(after_sct_3.published_date).to eq('2019-08-04'.to_date)
+    end
+
+    it '複数 (追加/更新/Release date なし含む) ⇒ エラー' do
+      allow_any_instance_of(SoundCloud::Client).to receive(:get).and_return(
+        [
+          { 'id'                    => @sct_2.track_id,
+            'created_at'            => @sct_2.uploaded_at.to_s,
+            'description'           => @sct_2.description,
+            'original_content_size' => @sct_2.original_content_size,
+            'title'                 => 'podcast 002 mod',
+            'duration'              => calc_duration(@sct_2.duration),
+            'tag_list'              => @sct_2.tag_list,
+            'download_url'          => @sct_2.download_url,
+            'permalink'             => @sct_2.permalink,
+            'permalink_url'         => @sct_2.permalink_url,
+            'release_year'          => 2019,
+            'release_month'         => 8,
+            'release_day'           => 1 },
+          { 'id'                    => 123456001,
+            'created_at'            => '2019/01/23 01:00:00 +0000',
+            'description'           => '説明 001',
+            'original_content_size' => 124542711,
+            'title'                 => 'podcast title 001',
+            'duration'              => 5189815,
+            'tag_list'              => 'coderdojo',
+            'download_url'          => 'https://api.soundcloud.com/tracks/123456001/download',
+            'permalink'             => 'podcast-004',
+            'permalink_url'         => 'https://soundcloud.com/coderdojojp/podcast-004',
+            'release_year'          => 2019,
+            'release_month'         => 8,
+            'release_day'           => 2 },
           { 'id'                    => @sct_1.track_id,
             'created_at'            => @sct_1.uploaded_at.to_s,
             'description'           => @sct_1.description,
@@ -153,7 +331,10 @@ RSpec.describe 'soundcloud_tracks' do
             'tag_list'              => @sct_3.tag_list,
             'download_url'          => @sct_3.download_url,
             'permalink'             => @sct_3.permalink,
-            'permalink_url'         => @sct_3.permalink_url }
+            'permalink_url'         => @sct_3.permalink_url,
+            'release_year'          => 2019,
+            'release_month'         => 8,
+            'release_day'           => 4 }
           ]
       )
 
@@ -162,28 +343,30 @@ RSpec.describe 'soundcloud_tracks' do
       before_ids = SoundCloudTrack.ids
 
       # exec
-      expect(@rake[task].invoke).to be_truthy
+      expect { @rake[task].invoke }.to raise_error('No Release Date')
 
       # after
-      expect(SoundCloudTrack.count).to eq(4)
+      expect(SoundCloudTrack.count).to eq(3)
       new_records = SoundCloudTrack.where.not(id: before_ids)
-      expect(new_records.count).to eq(1)
-      expect(new_records.first.track_id).to eq(123456001)
+      expect(new_records.count).to eq(0)
 
       after_sct_1 = SoundCloudTrack.find_by(id: @sct_1.id)
       expect(after_sct_1.track_id).to eq(111001)
-      expect(after_sct_1.title).to eq('podcast 001 mod')
+      expect(after_sct_1.title).to eq('podcast 001')
       expect(calc_duration(after_sct_1.duration)).to eq(1000000)
+      expect(after_sct_1.published_date).to eq(Time.zone.today)
 
       after_sct_2 = SoundCloudTrack.find_by(id: @sct_2.id)
       expect(after_sct_2.track_id).to eq(111002)
-      expect(after_sct_2.title).to eq('podcast 002 mod')
+      expect(after_sct_2.title).to eq('podcast 002')
       expect(calc_duration(after_sct_2.duration)).to eq(2000000)
+      expect(after_sct_2.published_date).to eq('2018-07-01'.to_date)
 
       after_sct_3 = SoundCloudTrack.find_by(id: @sct_3.id)
       expect(after_sct_3.track_id).to eq(111003)
-      expect(after_sct_3.title).to eq('podcast 003 mod')
+      expect(after_sct_3.title).to eq('podcast 003')
       expect(calc_duration(after_sct_3.duration)).to eq(3000000)
+      expect(after_sct_3.published_date).to eq(Time.zone.today)
     end
   end
 end

--- a/spec/models/sound_cloud_track_spec.rb
+++ b/spec/models/sound_cloud_track_spec.rb
@@ -54,25 +54,6 @@ RSpec.describe SoundCloudTrack, :type => :model do
     end
   end
 
-  describe 'published_at' do
-    before :each do
-      @content_body = "Podcast Title\n収録日: 2019/05/10\n概要説明..."
-      allow(@soundcloud_track).to receive(:content) { @content_body }
-    end
-
-    it 'ファイル存在' do
-      allow(@soundcloud_track).to receive(:exists?) { true }
-
-      expect(@soundcloud_track.published_at).to eq('2019-05-10'.in_time_zone)
-    end
-
-    it 'ファイルなし ⇒ nil' do
-      allow(@soundcloud_track).to receive(:exists?) { false }
-
-      expect(@soundcloud_track.published_at).to eq(nil)
-    end
-  end
-
   describe 'content' do
     before :each do
       @content_body = "Podcast Title\n収録日: 2019/05/10\n概要説明..."


### PR DESCRIPTION
## 背景

現状 `<id>.md` のコンテンツデータから「収録日: yyyy/MM/DD」をパースして取得している収録日情報を、SoundCloud の track 情報から取得して DB に格納→表示という流れにしたい。

cf. #458

## このPRでやること

- [x] SoundCloudTrack T に収録日(published_date) カラムを追加
- [x] `rake soundcloud_tracks:upsert` で、SoundCloud の track 情報 Release Date (release_year, release_month, release_day) も取得して、published_date に登録
- [x] SoundCloudTrack レコードから published_at メソッドで参照されていた収録日を、published_date カラムから取得するよう変更
- [x] `rake soundcloud_tracks:upsert` の RSpec 追加/変更

## やらなかったこと

- public/podcasts の `<id>.md` からの「収録日: yyyy/MM/DD」削除

## 困っていること

特になし