### PR TITLE
Dojo を指定した統計情報収集

### DIFF
--- a/docs/statistics_aggregation.md
+++ b/docs/statistics_aggregation.md
@@ -1,4 +1,4 @@
-# rake statistics:aggregation[from,to,provider]
+# rake statistics:aggregation[from,to,provider,dojo_id]
 
 ## 概要
 
@@ -11,12 +11,15 @@
 |from|string|(省略可)|集計期間開始年/年月/年月日|
 |to|string|(省略可)|集計期間終了年/年月/年月日|
 |provider|string|(省略可)|集計対象プロバイダ|
+|dojo_id|integer|(省略可)|集計対象 Dojo ID|
 
 ## 説明
 
 from/to で指定された期間のイベント履歴を集計する。
 
 provider が指定されたとき、指定プロバイダに対してのみ集計を行う。
+
+dojo_id が指定されたとき、指定 Dojo に対してのみ集計を行う。
 
 + from, to を共に省略した場合、前週一週間分の履歴を集計する。
 + 全期間(2012年以降前日まで)を集計する場合、from/to 共に '-' を指定する。

--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -11,7 +11,8 @@ module Statistics
     end
 
     def run
-      puts "Aggregate for #{@from}~#{@to}"
+      dojo_info = "[#{@dojo_id}]" if @dojo_id
+      puts "Aggregate for #{@from}~#{@to}#{dojo_info}"
       with_notifying do
         delete_event_histories
         execute
@@ -91,9 +92,9 @@ module Statistics
 
     def with_notifying
       yield
-      Notifier.notify_success(date_format(@from), date_format(@to), @provider)
+      Notifier.notify_success(date_format(@from), date_format(@to), @provider, @dojo_id)
     rescue => e
-      Notifier.notify_failure(date_format(@from), date_format(@to), @provider, e)
+      Notifier.notify_failure(date_format(@from), date_format(@to), @provider, @dojo_id, e)
     end
 
     def delete_event_histories
@@ -128,18 +129,22 @@ module Statistics
 
     class Notifier
       class << self
-        def notify_success(from, to, provider)
-          notify("#{from}~#{to}#{provider_info(provider)}のイベント履歴の集計を行いました")
+        def notify_success(from, to, provider, dojo_id)
+          notify("#{from}~#{to}#{provider_info(provider)}#{dojo_info(dojo_id)}のイベント履歴の集計を行いました")
         end
 
-        def notify_failure(from, to, provider, exception)
-          notify("#{from}~#{to}#{provider_info(provider)}のイベント履歴の集計でエラーが発生しました\n#{exception.message}\n#{exception.backtrace.join("\n")}")
+        def notify_failure(from, to, provider, dojo_id, exception)
+          notify("#{from}~#{to}#{provider_info(provider)}#{dojo_info(dojo_id)}のイベント履歴の集計でエラーが発生しました\n#{exception.message}\n#{exception.backtrace.join("\n")}")
         end
 
         private
 
         def provider_info(provider)
           provider ? "(#{provider})" : nil
+        end
+
+        def dojo_info(dojo_id)
+          dojo_id ? "[#{dojo_id}]" : nil
         end
 
         def idobata_hook_url

--- a/lib/statistics/tasks/connpass.rb
+++ b/lib/statistics/tasks/connpass.rb
@@ -1,8 +1,10 @@
 module Statistics
   module Tasks
     class Connpass
-      def self.delete_event_histories(period)
-        EventHistory.for(:connpass).within(period).delete_all
+      def self.delete_event_histories(period, dojo_id)
+        histories = EventHistory.for(:connpass).within(period)
+        histories = histories.where(dojo_id: dojo_id) if dojo_id
+        histories.delete_all
       end
 
       def initialize(dojos, period)

--- a/lib/statistics/tasks/doorkeeper.rb
+++ b/lib/statistics/tasks/doorkeeper.rb
@@ -1,8 +1,10 @@
 module Statistics
   module Tasks
     class Doorkeeper
-      def self.delete_event_histories(period)
-        EventHistory.for(:doorkeeper).within(period).delete_all
+      def self.delete_event_histories(period, dojo_id)
+        histories = EventHistory.for(:doorkeeper).within(period)
+        histories = histories.where(dojo_id: dojo_id) if dojo_id
+        histories.delete_all
       end
 
       def initialize(dojos, period)

--- a/lib/statistics/tasks/facebook.rb
+++ b/lib/statistics/tasks/facebook.rb
@@ -1,8 +1,10 @@
 module Statistics
   module Tasks
     class Facebook
-      def self.delete_event_histories(period)
-        EventHistory.for(:facebook).within(period).delete_all
+      def self.delete_event_histories(period, dojo_id)
+        histories = EventHistory.for(:facebook).within(period)
+        histories = histories.where(dojo_id: dojo_id) if dojo_id
+        histories.delete_all
       end
 
       def initialize(dojos, period)

--- a/lib/statistics/tasks/static_yaml.rb
+++ b/lib/statistics/tasks/static_yaml.rb
@@ -1,8 +1,10 @@
 module Statistics
   module Tasks
     class StaticYaml
-      def self.delete_event_histories(_period)
-        EventHistory.for(:static_yaml).delete_all
+      def self.delete_event_histories(_period, dojo_id)
+        histories = EventHistory.for(:static_yaml)
+        histories = histories.where(dojo_id: dojo_id) if dojo_id
+        histories.delete_all
       end
 
       def initialize(dojos, _date)

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -2,7 +2,7 @@ require_relative '../statistics.rb'
 
 namespace :statistics do
   desc '指定期間/プロバイダのイベント履歴を集計します'
-  task :aggregation, [:from, :to, :provider] => :environment do |tasks, args|
+  task :aggregation, [:from, :to, :provider, :dojo_id] => :environment do |tasks, args|
     EventHistory.transaction do
       Statistics::Aggregation.new(args).run
     end


### PR DESCRIPTION
## 背景

現状の統計情報収集タスクで指定できるのは期間とプロバイダのみだた、Dojo を指定して収集できるようにすれば Dojo 追加時や収集プロバイダ追加時に指定した Dojo の統計情報のみ収集できると効率がよい。

fix #507

## このPRでやること

- [x] `rake statistics:aggregation` の引数で `dojo_id` を指定可能にする
- [x] `rake statistics:aggregation` で `dojo_id` を指定されたとき、指定された Dojo に対してのみ統計情報を更新するよう処理を変更
- [x] RSpec 修正(処理対象の Dojo 検索処理)
- [x] docs/statistics_aggregation.md を修正

## やらなかったこと

特になし

## 困っていること

特になし
