### PR TITLE
コーダー道場名護の情報について更新を提案します。

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -2462,8 +2462,8 @@
   name: 名護
   prefecture_id: 47
   logo: "/img/dojos/japan.png"
-  url: https://www.facebook.com/CoderDojo.Nago/
-  description: 沖縄県名護市で不定期開催
+  url: http://coderdojo-nago.com
+  description: 沖縄県名護市で月に２回開催
   tags:
   - Scratch
   - micro:bit


### PR DESCRIPTION
コーダー道場名護のurlを、facebookページから　http://coderdojo-nago.com に更新すること
コーダー道場名護のdescriptionを不定期開催から月２回開催に更新すること。