### PR TITLE
Facebookイベント 2019-08 を追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -661,14 +661,24 @@
   name: connpass
   group_id: 7172
   url: https://coderdojo-toyonaka.connpass.com/
+# 韮崎 Facebookイベントページなし connnpassに移行
+# - dojo_id: 195
+#   name: facebook
+#   group_id: 100032127647229
+#   url: https://www.facebook.com/CoderDojo.Nirasaki
 - dojo_id: 195
-  name: facebook
-  group_id: 100032127647229
-  url: https://www.facebook.com/CoderDojo.Nirasaki
+  name: connpass
+  group_id: 7466
+  url: https://coderdojo-nirasaki.connpass.com/
+# 北杜 Facebookイベントページなし connpassに移行
+# - dojo_id: 196
+#   name: facebook
+#   group_id: 100032055361334
+#   url: https://www.facebook.com/CoderDojo.HokutoJP
 - dojo_id: 196
-  name: facebook
-  group_id: 100032055361334
-  url: https://www.facebook.com/CoderDojo.HokutoJP
+  name: connpass
+  group_id: 7465
+  url: https://coderdojo-hokuto.connpass.com/
 - dojo_id: 198
   name: facebook
   group_id: 374114993171172
@@ -723,7 +733,7 @@
   group_id: 8197
   url: https://coderdojo-ichinomiya.connpass.com/
 
-# 大石田@PCチャレンジ倶楽部
+# 大石田@PCチャレンジ倶楽部 Facebookイベントページなし
 - dojo_id: 215
   name: facebook
   group_id: 2253119258233423

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -3875,3 +3875,97 @@
   event_id:
   participants: 1
   evented_at: 2019/07/28 13:30
+
+  # 2019/08/01 - 2019/08/31
+- dojo_id: 202
+  event_id:
+  participants: 1
+  evented_at: 2019/08/03 13:00
+- dojo_id: 209
+  event_id:
+  participants: 0
+  evented_at: 2019/08/03 13:00
+- dojo_id: 183
+  event_id:
+  participants: 3
+  evented_at: 2019/08/03 14:00
+- dojo_id: 141
+  event_id:
+  participants: 2
+  evented_at: 2019/08/04 09:30
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2019/08/04 10:00
+# - dojo_id: 12
+#   event_id:
+#   participants: 2
+#   evented_at: 2019/08/04 10:30 キャンセルのため計上せず
+- dojo_id: 187
+  event_id:
+  participants: 2
+  evented_at: 2019/08/10 10:00
+- dojo_id: 203
+  event_id:
+  participants: 2
+  evented_at: 2019/08/11 09:30
+- dojo_id: 25
+  event_id:
+  participants: 6 # 若葉若松合同
+  evented_at: 2019/08/11 10:00
+- dojo_id: 186
+  event_id:
+  participants: 1
+  evented_at: 2019/08/11 13:30
+- dojo_id: 6
+  event_id:
+  participants: 1
+  evented_at: 2019/08/16 17:00
+- dojo_id: 191
+  event_id:
+  participants: 6
+  evented_at: 2019/08/17 10:00
+- dojo_id: 87
+  event_id:
+  participants: 3
+  evented_at: 2019/08/17 14:00
+- dojo_id: 94
+  event_id:
+  participants: 2
+  evented_at: 2019/08/18 10:00
+- dojo_id: 86
+  event_id:
+  participants: 3
+  evented_at: 2019/08/18 10:30
+- dojo_id: 10
+  event_id:
+  participants: 1
+  evented_at: 2019/08/18 13:30
+- dojo_id: 6
+  event_id:
+  participants: 1
+  evented_at: 2019/08/23 17:00
+- dojo_id: 203
+  event_id:
+  participants: 1
+  evented_at: 2019/08/24 09:30
+- dojo_id: 97
+  event_id:
+  participants: 2
+  evented_at: 2019/08/24 10:00
+- dojo_id: 23
+  event_id:
+  participants: 0
+  evented_at: 2019/08/25 10:00
+- dojo_id: 10
+  event_id:
+  participants: 1
+  evented_at: 2019/08/25 13:30
+- dojo_id: 186
+  event_id:
+  participants: 2
+  evented_at: 2019/08/25 13:30
+- dojo_id: 6
+  event_id:
+  participants: 1
+  evented_at: 2019/08/30 17:00


### PR DESCRIPTION
2019-08 分の Facebook イベントを集計しました📑

### 🤔気になる点
- [キャンセルになりました](https://www.facebook.com/events/467690174020118/)の集計の扱い。
- [合同開催](https://www.facebook.com/events/371702046868084/)の集計の扱い。
- [韮崎Dojo](https://www.facebook.com/CoderDojo.Nirasaki.Yamanashi/)と、[北杜Dojo](https://www.facebook.com/CoderDojo.HokutoJP)には Facebook にイベントページが無く、connpass で運用している様子なのですが、connpass の URL を載せてしまっても良いかどうか。

@chicaco お手隙の際にご確認よろしくお願いします📄✨