### PR TITLE
必要な環境変数が設定されていないときは SoundCloud のテストをスキップする

### DIFF
--- a/spec/lib/tasks/soundcloud_tracks_spec.rb
+++ b/spec/lib/tasks/soundcloud_tracks_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'rake'
 
-RSpec.describe 'soundcloud_tracks' do
+RSpec.describe 'soundcloud_tracks', soundcloud: true do
   before(:all) do
     @rake = Rake::Application.new
     Rake.application = @rake

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,5 +63,13 @@ RSpec.configure do |config|
     end
   end
 
+  config.around(:each, :soundcloud) do |example|
+    if ENV['SOUNDCLOUD_CLIENT_ID'].present?
+      example.run
+    else
+      example.skip
+    end
+  end
+
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## 背景

.travis.yml に環境変数を暗号化して設定しているが、forked repository からはセキュリティリスクの関係で暗号化したキーを使うことができず CIでエラーになるため、必要な環境変数が設定されていないときは SoundCloud のテストをスキップしたい。

https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml

cf. #319, #352

## このPRでやること

- [x] `rails_helper.rb` に環境変数 SOUNDCLOUD_CLIENT_ID が設定されていないときにケースをスキップする判定を追加
- [x] `spec/lib/tasks/soundcloud_tracks_spec.rb` にスキップ判定用のキーを追加
- [x] 環境変数 SOUNDCLOUD_CLIENT_ID が設定されていないときに、RSpec でケースをスキップするかを確認

## やらなかったこと

特になし

## 困っていること

特になし
