### PR TITLE
Dependabotの設定情報を .dependabot/config.yml に吐き出す

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,16 @@
+version: 1
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "daily"
+    allowed_updates:
+      - match:
+          update_type: "all"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"
+    version_requirement_updates: "off"


### PR DESCRIPTION
ひとつひとつ手動でマージしていくのは大変かなと思ったので

[Dependabotの設定ファイルを置くようにした - くりにっき](https://sue445.hatenablog.com/entry/2019/03/10/151948) を参考に `.dependabot/config.yml` を設定して自動マージするよう指定してみました。

以下の方式で Dependabot を動作させます。

- 開発で利用するGemのアップデートは（CIが通れば）メジャー、マイナー、パッチバージョンどの更新でも自動マージ
- アプリケーションで利用するGemはパッチバージョンの更新だけ自動マージ


その他

- Gemfileでバージョンを固定している場合はその範囲で更新をかける

も追加しています。