### PR TITLE
三の丸、浜田を集計対象に追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -770,14 +770,26 @@
   group_id: 8204
   url: https://coderdojo-tamamira.connpass.com/
 
-# 三の丸 (イベントページができたらURLを追加する)
-# - dojo_id: 222
-#   name: facebook
-#   group_id:
-#   url:
+# 三の丸
+- dojo_id: 222
+  name: facebook
+  group_id: 2325334674450862
+  url: https://www.facebook.com/CoderDojo3nomaru/
 
 # 三春 (グループが作成されたら追加する)
 # - dojo_id: 223
 #   name: connpass
 #   group_id: 
 #   url: 
+
+# しまね
+# - dojo_id: 224
+#   name: google
+#   group_id: 
+#   url: 
+
+# 浜田
+- dojo_id: 225
+  name: facebook
+  group_id: 2402320846481133
+  url: https://www.facebook.com/CoderDojoHamada/


### PR DESCRIPTION
## 背景

CoderDojo 三の丸と浜田を集計対象に追加したい

cf. #498, #564

## やること

イベント対象プロバイダとして、以下の facebook ページを追加する。

- https://www.facebook.com/CoderDojo3nomaru/
- https://www.facebook.com/CoderDojoHamada/

## マージ後にやること (備忘のための 📝 )

- 9 月分の facebook イベント集計の際、今回追加した三の丸、浜田のイベントは過去分も抽出する
- 9 月分の facebook イベント集計のマージ後、追加イベントの最古の年月以降で再収集する
