### PR TITLE
2019_09 facebook イベントを追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -66,10 +66,14 @@
   name: google
   group_id:
   url:
-- dojo_id: 73
+- dojo_id: 73 # 第１回〜第６回・第１２回は Facebook イベントで運用
   name: facebook
   group_id: 193975261081844
   url: https://www.facebook.com/pg/coderdojo.hitachinaka/events/
+- dojo_id: 73 # 第７回〜
+  name: connpass
+  group_id: 4704
+  url: https://coderdojo-hitachinaka.connpass.com/
 - dojo_id: 65
   name: connpass
   group_id: 2972
@@ -236,13 +240,11 @@
   name: facebook
   group_id: 124249914820641
   url: https://www.facebook.com/pg/coderdojo.kofu/events/
-# 〜2018/02
-- dojo_id: 87
+- dojo_id: 87 # 〜2018/02
   name: facebook
   group_id: 1634610396557264
   url: https://www.facebook.com/pg/CoderDojoAzumino/events/
-# 2018/03〜
-- dojo_id: 87
+- dojo_id: 87 # 2018/03〜
   name: doorkeeper
   group_id: 9603
   url: https://coderdojo-azumino.doorkeeper.jp
@@ -628,14 +630,22 @@
   name: doorkeeper
   group_id: 9906
   url: https://coderdojo-gotanda.doorkeeper.jp/
-- dojo_id: 186
+- dojo_id: 186 # 第１回〜第３回は Facebook イベントで運用
   name: facebook
   group_id: 318691575631474
   url: https://www.facebook.com/CoderDojo.Nago/
-- dojo_id: 187
+- dojo_id: 186 # 第４回〜
+  name: connpass
+  group_id: 7455
+  url: https://coderdojo-nago.connpass.com/
+- dojo_id: 187 # 第１回は Facebook イベントで運用
   name: facebook
   group_id: 569968173442983
   url: https://www.facebook.com/CoderDojoKagoshima/
+- dojo_id: 187 # 第２回〜
+  name: connpass
+  group_id: 7373
+  url: https://coderdojo-kagoshima.connpass.com/
 - dojo_id: 188
   name: facebook
   group_id: 760136447660371
@@ -680,10 +690,14 @@
   name: connpass
   group_id: 7465
   url: https://coderdojo-hokuto.connpass.com/
+# - dojo_id: 198 connpass に移行
+#   name: facebook
+#   group_id: 374114993171172
+#   url: https://www.facebook.com/CoderDojoKOZA
 - dojo_id: 198
-  name: facebook
-  group_id: 374114993171172
-  url: https://www.facebook.com/CoderDojoKOZA
+  name: connpass
+  group_id: 8377
+  url: https://koza.connpass.com/
 - dojo_id: 202
   name: facebook
   group_id: 2109347109378340

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -2434,22 +2434,6 @@
   participants: 5
   evented_at: 2017/10/01 13:15
 - dojo_id: 73
-  event_id: 142819799676689
-  participants: 6
-  evented_at: 2017/11/26 13:30
-- dojo_id: 73
-  event_id: 310152299475301
-  participants: 4
-  evented_at: 2018/01/14 13:30
-- dojo_id: 73
-  event_id: 1743561269015700
-  participants: 8
-  evented_at: 2018/02/18 13:30
-- dojo_id: 73
-  event_id: 169038793900038
-  participants: 8
-  evented_at: 2018/03/25 13:30
-- dojo_id: 73
   event_id: 675550939464493
   participants: 9
   evented_at: 2018/04/08 13:30
@@ -3066,42 +3050,6 @@
   event_id: 196236491237990
   participants: 4
   evented_at: 2018/08/04 13:30
-- dojo_id: 73
-  event_id: 1600474296728643
-  participants: 6
-  evented_at: 2018/05/06 13:30
-- dojo_id: 73
-  event_id: 2050527055199864
-  participants: 6
-  evented_at: 2018/06/10 13:30
-- dojo_id: 73
-  event_id: 229873607802747
-  participants: 4
-  evented_at: 2018/07/01 13:30
-- dojo_id: 73
-  event_id: 495391340910164
-  participants: 4
-  evented_at: 2018/08/12 13:30
-- dojo_id: 73
-  event_id: 724939291180649
-  participants: 7
-  evented_at: 2018/09/16 13:30
-- dojo_id: 73
-  event_id: 261879051136431
-  participants: 2
-  evented_at: 2018/11/04 13:30
-- dojo_id: 73
-  event_id: 723307981372919
-  participants: 3
-  evented_at: 2018/12/09 13:30
-- dojo_id: 73
-  event_id: 355491578366248
-  participants: 6
-  evented_at: 2019/01/13 13:30
-- dojo_id: 73
-  event_id: 2438595696213784
-  participants: 8
-  evented_at: 2019/02/17 13:30
 - dojo_id: 86
   event_id: 1939742072714754
   participants: 2
@@ -3363,14 +3311,6 @@
   event_id: 766781693674723
   participants: 2
   evented_at: 2019/01/27 13:30
-- dojo_id: 186
-  event_id: 639913849738762
-  participants: 2
-  evented_at: 2019/02/17 13:30
-- dojo_id: 186
-  event_id: 1153923628097026
-  participants: 2
-  evented_at: 2019/02/24 13:30
 - dojo_id: 187
   event_id:
   participants: 7
@@ -3486,10 +3426,6 @@
   event_id:
   participants: 5
   evented_at: 2019/03/02 14:00
-- dojo_id: 187
-  event_id:
-  participants: 5
-  evented_at: 2019/03/02 14:00
 - dojo_id: 12
   event_id:
   participants: 6
@@ -3502,14 +3438,6 @@
   event_id:
   participants: 2
   evented_at: 2019/03/10 09:30
-- dojo_id: 73
-  event_id:
-  participants: 7
-  evented_at: 2019/03/10 13:30
-- dojo_id: 186
-  event_id:
-  participants: 2
-  evented_at: 2019/03/10 13:30
 - dojo_id: 111
   event_id:
   participants: 0
@@ -3555,10 +3483,6 @@
   event_id:
   participants: 1
   evented_at: 2019/03/24 13:30
-- dojo_id: 186
-  event_id:
-  participants: 1
-  evented_at: 2019/03/24 13:30
 - dojo_id: 6
   event_id:
   participants: 10
@@ -3584,10 +3508,6 @@
 - dojo_id: 10
   event_id:
   participants: 2
-  evented_at: 2019/04/07 13:30
-- dojo_id: 73
-  event_id:
-  participants: 5
   evented_at: 2019/04/07 13:30
 - dojo_id: 5
   event_id:
@@ -3617,10 +3537,6 @@
   event_id:
   participants: 9
   evented_at: 2019/04/14 10:00
-- dojo_id: 186
-  event_id:
-  participants: 1
-  evented_at: 2019/04/14 13:30
 - dojo_id: 188
   event_id:
   participants: 0
@@ -3658,10 +3574,6 @@
   event_id:
   participants: 2
   evented_at: 2019/04/21 13:30
-- dojo_id: 186
-  event_id:
-  participants: 1
-  evented_at: 2019/04/21 13:30
 - dojo_id: 6
   event_id:
   participants: 1
@@ -3670,10 +3582,6 @@
   event_id:
   participants: 11
   evented_at: 2019/04/27 10:00
-- dojo_id: 187
-  event_id:
-  participants: 3
-  evented_at: 2019/04/27 14:00
 - dojo_id: 23
   event_id:
   participants: 2
@@ -3684,10 +3592,6 @@
   event_id:
   participants: 4
   evented_at: 2019/05/05 10:30
-- dojo_id: 73
-  event_id:
-  participants: 4
-  evented_at: 2019/05/05 13:30
 - dojo_id: 183
   event_id:
   participants: 3
@@ -3728,10 +3632,6 @@
   event_id:
   participants: 4
   evented_at: 2019/05/19 10:00
-- dojo_id: 186
-  event_id:
-  participants: 1
-  evented_at: 2019/05/19 13:30
 - dojo_id: 86
   event_id:
   participants: 2
@@ -3762,10 +3662,6 @@
   event_id:
   participants: 3
   evented_at: 2019/06/02 10:30
-- dojo_id: 186
-  event_id:
-  participants: 2
-  evented_at: 2019/06/02 13:30
 - dojo_id: 6
   event_id:
   participants: 1
@@ -3790,14 +3686,6 @@
   event_id:
   participants: 2
   evented_at: 2019/06/09 13:30
-- dojo_id: 73
-  event_id:
-  participants: 7
-  evented_at: 2019/06/09 13:30
-- dojo_id: 186
-  event_id:
-  participants: 0
-  evented_at: 2019/06/09 13:30
 - dojo_id: 6
   event_id:
   participants: 1
@@ -3805,10 +3693,6 @@
 - dojo_id: 87
   event_id:
   participants: 4
-  evented_at: 2019/06/15 14:00
-- dojo_id: 187
-  event_id:
-  participants: 5
   evented_at: 2019/06/15 14:00
 - dojo_id: 141
   event_id:
@@ -3864,18 +3748,10 @@
   event_id:
   participants: 3
   evented_at: 2019/07/06 14:00
-- dojo_id: 187
-  event_id:
-  participants: 3
-  evented_at: 2019/07/06 14:00
 - dojo_id: 12
   event_id:
   participants: 6
   evented_at: 2019/07/07 10:30
-- dojo_id: 186
-  event_id:
-  participants: 1
-  evented_at: 2019/07/07 13:30
 - dojo_id: 198
   event_id:
   participants: 0
@@ -3900,10 +3776,6 @@
   event_id:
   participants: 5
   evented_at: 2019/07/20 14:00
-- dojo_id: 186
-  event_id:
-  participants: 0
-  evented_at: 2019/07/21 09:30
 - dojo_id: 203
   event_id:
   participants: 0
@@ -3912,10 +3784,6 @@
   event_id:
   participants: 3
   evented_at: 2019/07/21 10:30
-- dojo_id: 73
-  event_id:
-  participants: 2
-  evented_at: 2019/07/21 13:30
 - dojo_id: 6
   event_id:
   participants: 1
@@ -3958,10 +3826,6 @@
 #   event_id:
 #   participants: 2
 #   evented_at: 2019/08/04 10:30 キャンセルのため計上せず
-- dojo_id: 187
-  event_id:
-  participants: 2
-  evented_at: 2019/08/10 10:00
 - dojo_id: 203
   event_id:
   participants: 2
@@ -3970,10 +3834,6 @@
   event_id:
   participants: 6 # 若葉若松合同
   evented_at: 2019/08/11 10:00
-- dojo_id: 186
-  event_id:
-  participants: 1
-  evented_at: 2019/08/11 13:30
 - dojo_id: 6
   event_id:
   participants: 1
@@ -4018,11 +3878,77 @@
   event_id:
   participants: 1
   evented_at: 2019/08/25 13:30
-- dojo_id: 186
-  event_id:
-  participants: 2
-  evented_at: 2019/08/25 13:30
 - dojo_id: 6
   event_id:
   participants: 1
   evented_at: 2019/08/30 17:00
+
+  # 2019/09/01 - 2019/09/30
+- dojo_id: 210
+  event_id:
+  participants: 0
+  evented_at: 2019/09/01 13:20
+- dojo_id: 6
+  event_id:
+  participants: 1
+  evented_at: 2019/09/06 17:00
+- dojo_id: 225
+  event_id:
+  participants: 1
+  evented_at: 2019/09/07 10:00
+- dojo_id: 183
+  event_id:
+  participants: 2
+  evented_at: 2019/09/07 14:00
+- dojo_id: 203
+  event_id:
+  participants: 2
+  evented_at: 2019/09/08 09:30
+- dojo_id: 25
+  event_id:
+  participants: 6
+  evented_at: 2019/09/08 10:00
+- dojo_id: 6
+  event_id:
+  participants: 1
+  evented_at: 2019/09/13 17:00
+- dojo_id: 94
+  event_id:
+  participants: 3
+  evented_at: 2019/09/15 10:00
+- dojo_id: 86
+  event_id:
+  participants: 1
+  evented_at: 2019/09/15 10:30
+- dojo_id: 6
+  event_id:
+  participants: 1
+  evented_at: 2019/09/20 17:00
+- dojo_id: 23
+  event_id:
+  participants: 0
+  evented_at: 2019/09/22 10:00
+- dojo_id: 131
+  event_id:
+  participants: 6
+  evented_at: 2019/09/22 10:00
+- dojo_id: 6
+  event_id:
+  participants: 1
+  evented_at: 2019/09/27 17:00
+- dojo_id: 97
+  event_id:
+  participants: 3
+  evented_at: 2019/09/28 10:00
+- dojo_id: 191
+  event_id:
+  participants: 3
+  evented_at: 2019/09/28 10:00
+- dojo_id: 10
+  event_id:
+  participants: 1
+  evented_at: 2019/09/29 13:30
+- dojo_id: 222
+  event_id:
+  participants: 6
+  evented_at: 2019/09/29 13:30


### PR DESCRIPTION
### やった事
- 2019-09 の facebook イベントを追加しました📄
- 以下の dojo で connpass の運用が確認できたため、それぞれ対応しました✅
  - dojo_id: 73 ひたちなか dojo を connpass に移行 (第1〜6・12回は facebook で運用)
  - dojo_id: 186 名護 dojo を connpass に移行 (第1〜3回は facebook で運用)
  - dojo_id: 186 名護 dojo を connpass に移行 (第1回は facebook で運用)
  - dojo_id: 198 コザ dojo を connpass に移行

@chicaco 変更が多く大変ですが、 お手隙の際にご確認よろしくお願いします📄✨