### PR TITLE
add_2019-10_Facebook_event

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -66,12 +66,12 @@
   name: google
   group_id:
   url:
-- dojo_id: 73 # 第１回〜第６回・第１２回は Facebook イベントで運用
-  name: facebook
+- dojo_id: 73
+  name: facebook # 第１回〜第６回・第１２回は Facebook イベントで運用
   group_id: 193975261081844
   url: https://www.facebook.com/pg/coderdojo.hitachinaka/events/
-- dojo_id: 73 # 第７回〜
-  name: connpass
+- dojo_id: 73
+  name: connpass # 第７回〜
   group_id: 4704
   url: https://coderdojo-hitachinaka.connpass.com/
 - dojo_id: 65
@@ -131,7 +131,7 @@
   group_id: 4985
   url: https://coderdojo-ikebukuro.connpass.com/
 - dojo_id: 17
-  name: facebook
+  name: facebook # 2016年4月からは connpass
   group_id: 346407898743580
   url: https://www.facebook.com/coderdojo.tokyo/
 - dojo_id: 17
@@ -209,9 +209,13 @@
   url: https://www.facebook.com/pg/coderdojofunabashi/events/
  # 木更津 
 - dojo_id: 83
-  name: facebook
+  name: facebook #2019年6月からは connpass
   group_id: 1273279189459638
   url: https://www.facebook.com/pg/coderdojokisarazu/events/
+- dojo_id: 83
+  name: connpass
+  group_id: 8670
+  url: https://coderdojo-kisarazu.connpass.com/
 - dojo_id: 68
   name: connpass
   group_id: 3430
@@ -240,11 +244,11 @@
   name: facebook
   group_id: 124249914820641
   url: https://www.facebook.com/pg/coderdojo.kofu/events/
-- dojo_id: 87 # 〜2018/02
-  name: facebook
+- dojo_id: 87
+  name: facebook # 2018年03月からは doorkeeper
   group_id: 1634610396557264
   url: https://www.facebook.com/pg/CoderDojoAzumino/events/
-- dojo_id: 87 # 2018/03〜
+- dojo_id: 87
   name: doorkeeper
   group_id: 9603
   url: https://coderdojo-azumino.doorkeeper.jp
@@ -354,7 +358,7 @@
   group_id: 9012
   url: https://coderdojo-hommachi.doorkeeper.jp
 - dojo_id: 45
-  name: facebook
+  name: facebook # 休止中
   group_id: 281889288840369
   url: https://www.facebook.com/pg/coderdojo.nishinari.osaka/events/
 # 東大阪 (近畿) と合同開催のため八尾の集計は不要
@@ -439,8 +443,8 @@
   name: facebook
   group_id: 1507281716025249
   url: https://www.facebook.com/pg/coderdojomiyoshi/events/
-- dojo_id: 102 # 第１回〜第３回は Facebook イベントで運用
-  name: facebook
+- dojo_id: 102 
+  name: facebook # 第4回からは connpass
   group_id: 495711777474589
   url: https://www.facebook.com/pg/CoderDojoFukuoka/events/
 - dojo_id: 102
@@ -549,9 +553,13 @@
   url: https://www.facebook.com/CoderDojoKURE/
 # 北九州
 - dojo_id: 144
-  name: facebook
+  name: facebook # 第3回からは connpass
   group_id: 2023006987974014
   url: https://www.facebook.com/pg/coderdojokitakyushu/events/
+- dojo_id: 144
+  name: connpass
+  group_id: 8670
+  url: https://coderdojokitaq.connpass.com/
 - dojo_id: 145
   name: connpass
   group_id: 5408
@@ -630,19 +638,19 @@
   name: doorkeeper
   group_id: 9906
   url: https://coderdojo-gotanda.doorkeeper.jp/
-- dojo_id: 186 # 第１回〜第３回は Facebook イベントで運用
-  name: facebook
+- dojo_id: 186
+  name: facebook # 第4回からは connpass で運用
   group_id: 318691575631474
   url: https://www.facebook.com/CoderDojo.Nago/
-- dojo_id: 186 # 第４回〜
+- dojo_id: 186
   name: connpass
   group_id: 7455
   url: https://coderdojo-nago.connpass.com/
-- dojo_id: 187 # 第１回は Facebook イベントで運用
-  name: facebook
+- dojo_id: 187
+  name: facebook # 第2回からは connpass で運用
   group_id: 569968173442983
   url: https://www.facebook.com/CoderDojoKagoshima/
-- dojo_id: 187 # 第２回〜
+- dojo_id: 187
   name: connpass
   group_id: 7373
   url: https://coderdojo-kagoshima.connpass.com/
@@ -804,15 +812,19 @@
 
 # 浜田
 - dojo_id: 225
-  name: facebook
+  name: facebook # 第4回からは connpass
   group_id: 2402320846481133
   url: https://www.facebook.com/CoderDojoHamada/
+- dojo_id: 225
+  name: connpass
+  group_id: 9168
+  url: https://coderdojohamada.connpass.com/
 
 # 伊予
 - dojo_id: 226
-  name: facebook
-  group_id: 110748170321557
-  url: https://www.facebook.com/CoderDojoIyo/
+  name: connpass
+  group_id: 8962
+  url: https://coderdojo-iyo.connpass.com/
 
 # 戸田公園
 - dojo_id: 227

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -3351,14 +3351,6 @@
   event_id:
   participants: 10
   evented_at: 2018/08/05 14:00
-- dojo_id: 144
-  event_id:
-  participants: 9
-  evented_at: 2018/11/23 14:00
-- dojo_id: 144
-  event_id:
-  participants: 6
-  evented_at: 2019/02/16 10:00
 - dojo_id: 210
   event_id:
   participants: 4
@@ -3654,10 +3646,6 @@
   evented_at: 2019/05/31 17:00
 
   # 2019/06/01 - 2019/06/30
-- dojo_id: 144
-  event_id:
-  participants: 5
-  evented_at: 2019/06/01 14:00
 - dojo_id: 12
   event_id:
   participants: 3
@@ -3956,3 +3944,73 @@
   event_id:
   participants: 6
   evented_at: 2019/09/29 13:30
+
+  # 2019/10/01 - 2019/10/31
+- dojo_id: 6
+  event_id:
+  participants: 2
+  evented_at: 2019/10/04 17:00
+- dojo_id: 183
+  event_id:
+  participants: 3
+  evented_at: 2019/10/05 14:00
+- dojo_id: 12
+  event_id:
+  participants: 4
+  evented_at: 2019/10/06 10:30
+- dojo_id: 6
+  event_id:
+  participants: 2
+  evented_at: 2019/10/11 17:00
+- dojo_id: 225
+  event_id:
+  participants: 1
+  evented_at: 2019/10/12 15:00
+# - dojo_id: 23 台風により中止
+#   event_id:
+#   participants: 3
+#   evented_at: 2019/10/13 10:00
+# - dojo_id: 25 台風により中止
+#   event_id:
+#   participants: 5
+#   evented_at: 2019/10/13 10:00
+# - dojo_id: 10 台風により中止
+#   event_id:
+#   participants: 2
+#   evented_at: 2019/10/13 13:30
+- dojo_id: 73
+  event_id:
+  participants: 2
+  evented_at: 2019/10/13 13:30
+- dojo_id: 191
+  event_id:
+  participants: 3
+  evented_at: 2019/10/13 14:00
+- dojo_id: 6
+  event_id:
+  participants: 1
+  evented_at: 2019/10/18 17:00
+- dojo_id: 97
+  event_id:
+  participants: 3
+  evented_at: 2019/10/19 10:00
+- dojo_id: 94
+  event_id:
+  participants: 3
+  evented_at: 2019/10/20 10:00
+- dojo_id: 86
+  event_id:
+  participants: 2
+  evented_at: 2019/10/20 10:30
+- dojo_id: 6
+  event_id:
+  participants: 1
+  evented_at: 2019/10/25 17:00
+- dojo_id: 23
+  event_id:
+  participants: 0
+  evented_at: 2019/10/27 10:00
+- dojo_id: 131
+  event_id:
+  participants: 2
+  evented_at: 2019/10/27 10:00


### PR DESCRIPTION
### やった事
- 2019年10月分の Facebook イベントを追加しました🎉
- `name: facebook` で検索して作業しているので、私が見やすいようにコメントの位置をいくつか変更しました。
- CoderDojo北九州 は第三回から connpass で運用されているようなので、第二回までの Facebook event は残して、それ以降は connpass に移行します。

### 気になった事
台風で中止になった Dojo が３つありました。イベントページはあるのでコメントアウトにしています。 API 復活したら集計対象になってしまうのですが、ここの対応はどうしましょう...