### PR TITLE
たまみらと昭島はイベント収集サイト共用

### DIFF
--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -32,6 +32,8 @@ class UpcomingEvent < ApplicationRecord
     # NOTE: 奈良・生駒・田原本の Dojo 名は特別に加工
     dojo_name = if dojo_event_service.name == 'connpass' && dojo_event_service.group_id == '2617'
                   '奈良・生駒・田原本'
+                elsif dojo_event_service.name == 'connpass' && dojo_event_service.group_id == '8204'
+                  '昭島・たまみら'
                 else
                   dojo_event_service.dojo.name
                 end

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -833,10 +833,11 @@
   url: https://corderdojo-todakoen.connpass.com/
 
 # 昭島
-- dojo_id: 228
-  name: connpass
-  group_id: 8204
-  url: https://coderdojo-tamamira.connpass.com/
+# たまみらとイベント収集サイトが共通のためこちらでの収集はなし 
+# - dojo_id: 228
+#   name: connpass
+#   group_id: 8204
+#   url: https://coderdojo-tamamira.connpass.com/
 
 # ナカマ
 - dojo_id: 229


### PR DESCRIPTION
## 背景

たまみら(dojo_id: 221)と昭島(dojo_id: 228)がイベント管理サイトを共用しているため、イベント履歴収集時に重複エラーが発生した。
https://coderdojo-tamamira.connpass.com/
⇒ 奈良・生駒・田原本と同様の処理にする

(cf. #632)

## このPRでやること

- [x] db/dojo_event_services.yaml で、代表とするたまみらの情報を有効とし、昭島 の情報を削除
- [x] 近日開催の道場情報の Dojo 名には、「昭島・たまみら」と表示する

## やらなかったこと

特になし

## 困っていること

特になし
