### PR TITLE
岐阜Dojo のイベントサービスをconnpassで追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -706,6 +706,12 @@
   name: connpass
   group_id: 8377
   url: https://koza.connpass.com/
+
+# 岐阜
+- dojo_id: 200
+  name: connpass
+  group_id: 9330
+  url: https://coderdojo-gifu.connpass.com/
 - dojo_id: 202
   name: facebook
   group_id: 2109347109378340


### PR DESCRIPTION
### 背景
岐阜Dojo がイベント申し込み方法を、オリジナルサイトのフォーム → connpass へ変更しました🔄
次回の第7回からが connpass に変更となっており、過去のイベントは connpass に載っていない為、収集不可です。

### やった事
dojo_event_services.yaml に connpass で追加しました 🎉

### 気になった事
dojos.yaml の url は connpass に変更すべきかどうかが気になりました。[オリジナルサイト](https://coderdojo-gifu.org/)の[「参加申し込みはこちらから」](https://coderdojo-gifu.org/blog/2019/11/coderdojo-gifu-007)のボタンのリンク先として connpass を利用されています。