### PR TITLE
Sprockets 4へのアップグレードを一時的にやめる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'jquery-rails'
 
 gem 'simple_grid_rails'
 gem "bootstrap-sass"
-gem 'sass-rails'
+gem 'sass-rails', '>= 5'
 gem 'uglifier'
 gem 'font-awesome-rails'
 gem 'haml-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,7 +456,7 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   rspec-retry
   ruby-mp3info
-  sass-rails
+  sass-rails (>= 5)
   scrivito (~> 1.15.0)
   scrivito_section_widgets
   scrivito_teaser_widget


### PR DESCRIPTION
`sass-rails` Gemのバージョンを5.x.xに固定することで Sprockets 4 へのアップグレードを一時的に停止します。 [参考](https://github.com/rails/sprockets/blob/c4b191e70d89e9d70f19ade5faf0692054a3bd1b/UPGRADING.md#upgrading-as-a-rails-dependency)

