### PR TITLE
北九州、諏訪野の dojo_event_service の group_id を修正

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -558,7 +558,7 @@
   url: https://www.facebook.com/pg/coderdojokitakyushu/events/
 - dojo_id: 144
   name: connpass
-  group_id: 8670
+  group_id: 6482
   url: https://coderdojokitaq.connpass.com/
 - dojo_id: 145
   name: connpass
@@ -604,7 +604,7 @@
   url: https://coderdojo-kitakata.doorkeeper.jp/
 - dojo_id: 172
   name: facebook
-  group_id: 542546935853207
+  group_id: 227758594569000
   url: https://www.facebook.com/pg/coderdojo.fukuoka.kurume.suwano/events/
 - dojo_id: 173
   name: connpass


### PR DESCRIPTION
## 背景

`rails statistics:aggregation[201910,201911]` で下記のエラーが発生

````
Aggregate of connpass
2019/10/01~2019/11/25(connpass)のイベント履歴の集計でエラーが発生しました
バリデーションに失敗しました: Service nameはすでに存在します, Event urlはすでに存在します
````

## このPRでやること

- [x] db/dojo_event_services.yaml の group_id の棚卸し
- [x] 重複している group_id の確認 → 8670,  542546935853207 が重複
- [x] connpass の 8670、facebook の 542546935853207 に登録されている各 dojo_event_service について、group_id を再確認 → 北九州、諏訪野の group_id が誤り
- [x] 北九州、諏訪野の group_id を修正

## やらなかったこと

特になし

## 困っていること

特になし

## この PR マージ後にやること

- 2018/11 以降の北九州のイベント履歴再収集
