### PR TITLE
dojo_event_service に、name と group_id の組み合わせで重複を NG とするバリデーションを追加

### DIFF
--- a/app/models/dojo_event_service.rb
+++ b/app/models/dojo_event_service.rb
@@ -8,6 +8,7 @@ class DojoEventService < ApplicationRecord
   enum name: EXTERNAL_SERVICES + INTERNAL_SERVICES
 
   validates :name, presence: true
+  validates :group_id, uniqueness: { scope: :name }, unless: Proc.new { |a| a.group_id.blank? }
 
   scope :for, ->(service) { where(name: service) }
 end

--- a/spec/lib/tasks/dojo_event_services_spec.rb
+++ b/spec/lib/tasks/dojo_event_services_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'dojo_event_services' do
     end
 
     it '余剰データ削除 & 更新' do
-      create(:dojo_event_service, dojo_id: @dojo_1.id, name: :doorkeeper, group_id: '10002', url: 'https://coder-dojo-12.doorkeeper.jp/abc')
+      create(:dojo_event_service, dojo_id: @dojo_1.id, name: :doorkeeper, group_id: '10003', url: 'https://coder-dojo-12.doorkeeper.jp/abc')
 
       allow(YAML).to receive(:load_file).and_return([
         { 'dojo_id' => @dojo_1.id, "name" => 'doorkeeper', 'group_id' => '10001', 'url' => 'https://coder-dojo-11.doorkeeper.jp/' },
@@ -78,13 +78,14 @@ RSpec.describe 'dojo_event_services' do
 
       # before
       expect(DojoEventService.count).to eq(4)
-      expect(DojoEventService.where(dojo_id: @dojo_1.id, name: :doorkeeper, group_id: '10002').size).to eq(2)
+      expect(DojoEventService.where(dojo_id: @dojo_1.id, name: :doorkeeper).size).to eq(3)
 
       # exec
       expect(@rake[task].invoke).to be_truthy
 
       # after
       expect(DojoEventService.count).to eq(3)
+      expect(DojoEventService.where(dojo_id: @dojo_1.id, name: :doorkeeper).size).to eq(2)
       mod_records = DojoEventService.where(dojo_id: @dojo_1.id, name: :doorkeeper, group_id: '10002')
       expect(mod_records.count).to eq(1)
       expect(mod_records.first.url).to eq('https://coder-dojo-12.doorkeeper.jp/12345')

--- a/spec/models/dojo_event_service_spec.rb
+++ b/spec/models/dojo_event_service_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe DojoEventService, :type => :model do
+  describe 'validation' do
+    context 'name & group_id : group_id が nil でないとき、組み合わせで unique' do
+      before :each do
+        @dojo_1 = create(:dojo, name: 'dojo_1', prefecture_id: 14, order: '14201', created_at: '2019-11-01', tags: %w(Scratch ラズベリーパイ))
+        @dojo_2 = create(:dojo, name: 'dojo_2', prefecture_id: 12, order: '12204', created_at: '2019-11-05', tags: %w(Scratch))
+      end
+
+      it 'group_id が nil ⇒ 同じ name があっても OK' do
+        create(:dojo_event_service, dojo_id: @dojo_1.id, name: :doorkeeper, group_id: nil)
+        des = DojoEventService.new
+        des.dojo_id  = @dojo_2.id
+        des.name     = :doorkeeper
+        des.group_id = nil
+        expect(des.valid?).to eq(true)
+      end
+
+      context 'group_id が nil でない' do
+        before :each do
+          create(:dojo_event_service, dojo_id: @dojo_1.id, name: :connpass, group_id: '1111')
+        end
+
+        it '同じ name あり ＆ 同じ group_id なし ⇒ OK' do
+          des = DojoEventService.new
+          des.dojo_id  = @dojo_2.id
+          des.name     = :connpass
+          des.group_id = '2222'
+          expect(des.valid?).to eq(true)
+        end
+
+        it '同じ name なし ＆ 同じ group_id あり ⇒ OK' do
+          des = DojoEventService.new
+          des.dojo_id  = @dojo_2.id
+          des.name     = :doorkeeper
+          des.group_id = '1111'
+          expect(des.valid?).to eq(true)
+        end
+
+        it 'name & group_id で同じ組み合わせあり ⇒ NG' do
+          des = DojoEventService.new
+          des.dojo_id  = @dojo_2.id
+          des.name     = :connpass
+          des.group_id = '1111'
+          expect(des.valid?).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 背景

`rails statistics:aggregation[201910,201911]` で下記のエラーが発生した。

```
Aggregate of connpass
2019/10/01~2019/11/25(connpass)のイベント履歴の集計でエラーが発生しました
バリデーションに失敗しました: Service nameはすでに存在します, Event urlはすでに存在します
```

`db/dojo_event_services.yaml` で複数の dojo に同じ name & group_id の組み合わせを誤って設定しており、これを元にイベント履歴を収集したため、別 dojo で同じイベントの情報を登録しようとしてエラーになっていた。#644 では `db/dojo_event_services.yaml` を修正して対処したが、`rails dojo_event_services:upsert` で name & group_id の組み合わせで重複があるときはエラーにするのが望ましい。

cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/644#issue-345779380

## やりたいこと

- dojo_event_service のモデルで、group_id が nil でないときのみ name と group_id の組み合わせで重複を NG とするバリデーションを追加する

## このPRでやること

- [x] dojo_event_service にバリデーション定義を追加
- [x] RSpec 追加

## やらなかったこと

特になし

## 困ってること

特になし