### PR TITLE
dojoの情報を最新にしました

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1,35 +1,51 @@
+# 札幌
 - dojo_id: 64
   name: connpass
   group_id: 3316
   url: https://coderdojo-sapporo.connpass.com
+
+# 札幌東
 - dojo_id: 104
   name: connpass
   group_id: 3594
   url: https://coderdojo-sapporo-east.connpass.com
+
+# 恵庭
 - dojo_id: 100
-  name: none
-  group_id:
-  url:
+  name: facebook
+  group_id: 223141421550880
+  url: https://www.facebook.com/CoderDojoEniwa/
+
+# 秋田
 - dojo_id: 75
   name: doorkeeper
   group_id: 9319
   url: https://coder-dojo-akita.doorkeeper.jp/
+
+# 滝沢
 - dojo_id: 109
   name: kokucheese
-  group_id: 
+  group_id:
   url: http://kokucheese.com/main/host/codoMe/
+
+# きたかみ
 - dojo_id: 107
   name: connpass
   group_id: 4288
   url: https://coderdojoktm.connpass.com
+
+# 泉
 - dojo_id: 3
   name: facebook
   group_id: 542546935853207
   url: https://www.facebook.com/pg/CoderdojoIzumi/events/
+
+# 愛子
 - dojo_id: 90
   name: none
   group_id:
   url:
+
 - dojo_id: 85
   name: facebook
   group_id: 1379707208756830
@@ -102,6 +118,8 @@
   name: facebook
   group_id: 617011185103868
   url: https://www.facebook.com/pg/CoderDojoTokorozawa/events/
+
+# 小平
 - dojo_id: 13
   name: static_yaml
   group_id:
@@ -138,10 +156,14 @@
   name: connpass
   group_id: 1862
   url: https://coderdojo-tokyo.connpass.com/
+
+# 吉祥寺
 - dojo_id: 105
   name: doorkeeper
   group_id: 9422
   url: https://coderdojo-kichijoji.doorkeeper.jp
+
+# 調布
 - dojo_id: 18
   name: doorkeeper
   group_id: 9033
@@ -154,19 +176,13 @@
   name: connpass
   group_id: 3037
   url: https://coderdojo-shibuya.connpass.com
-- dojo_id: 97
-  name: none
-  group_id:
-  url:
+
 - dojo_id: 20
   # coderdojo以外にも募集しているのでそのまま集計できない
   name: #facebook
   group_id:
   url:
-- dojo_id: 114
-  name: google
-  group_id:
-  url:
+
 - dojo_id: 60
   name: connpass
   group_id: 3461
@@ -207,7 +223,8 @@
   name: facebook
   group_id: 880706025404127
   url: https://www.facebook.com/pg/coderdojofunabashi/events/
- # 木更津 
+
+ # 木更津
 - dojo_id: 83
   name: facebook #2019年6月からは connpass
   group_id: 1273279189459638
@@ -220,14 +237,20 @@
   name: connpass
   group_id: 3430
   url: https://coderdojo-nippa.connpass.com
+
+# 長津田
 - dojo_id: 76
   name: connpass
   group_id: 3733
   url: https://coderdojo-nagatsuta.connpass.com
+
+# 横浜
 - dojo_id: 70
   name: connpass
   group_id: 3470
   url: https://coderdojo-yokohama.connpass.com
+
+# 戸部
 - dojo_id: 126
   name: connpass
   group_id: 5072
@@ -244,6 +267,8 @@
   name: facebook
   group_id: 124249914820641
   url: https://www.facebook.com/pg/coderdojo.kofu/events/
+
+# 安曇野
 - dojo_id: 87
   name: facebook # 2018年03月からは doorkeeper
   group_id: 1634610396557264
@@ -264,24 +289,34 @@
   name: kokucheese
   group_id:
   url: http://kokucheese.com/main/host/CoderDojo+福井/
+
+# 浜松
 - dojo_id: 98
   name: connpass
   group_id: 2431
   url: https://coderdojo-hamamatsu.connpass.com
+
+# 名古屋
 - dojo_id: 31
   name: connpass
   group_id: 2532
   url: https://coderdojo-nagoya.connpass.com
-- dojo_id: 2 # CoderDojo 瑞穂
+
+# 瑞穂
+- dojo_id: 2
   name: connpass
   group_id: 6681
   url: https://coderdojo-mizuho.connpass.com
+
+# 天白
 - dojo_id: 32
   name: connpass
   group_id: 2546
   url: https://tempaku.connpass.com
   # group_id: 3930
   # url: https://coderdojo-tempaku.doorkeeper.jp/
+
+# 尾張
 - dojo_id: 71
   name: connpass
   group_id: 3518
@@ -290,26 +325,38 @@
   name: connpass
   group_id: 2609
   url: https://coderdojo-oharu.connpass.com
+
+# 新城
 - dojo_id: 84
-  name: none
+  name: facebook #イベントページなし
   group_id:
-  url:
+  url: https://www.facebook.com/coderdojo.shinshiro/
+
+# 豊橋
 - dojo_id: 30
   name: doorkeeper
   group_id: 8735
   url: https://coderdojo-toyohashi.doorkeeper.jp
+
+# 海津
 - dojo_id: 96
-  name: none
-  group_id:
-  url:
+  name: facebook #イベントページなし
+  group_id: 402271523520911
+  url: https://www.facebook.com/CoderDojo.Kaizu
+
+# 伊勢
 - dojo_id: 62
   name: connpass
   group_id: 3434
   url: https://coderdojo-ise.connpass.com
+
+# 長岡京
 - dojo_id: 34
   name: doorkeeper
   group_id: 4052
   url: https://coderdojo-nagaokakyo.doorkeeper.jp
+
+# 奈良
 - dojo_id: 35
   name: connpass
   group_id: 2617
@@ -329,10 +376,14 @@
   name: peatix
   group_id:
   url: http://coderdojo-kyoto-fushimi.peatix.com
+
+# 高槻
 - dojo_id: 66
   name: connpass
   group_id: 3325
   url: https://coderdojo-takatsuki.connpass.com
+
+# みのお
 - dojo_id: 108
   name: connpass
   group_id: 4559
@@ -345,6 +396,8 @@
   name: connpass
   group_id: 2777
   url: https://coderdojo-higashiosaka.connpass.com/
+
+# 西宮・梅田
 - dojo_id: 42
   name: doorkeeper
   group_id: 1993
@@ -353,6 +406,8 @@
   name: facebook
   group_id: 122178467942470
   url: https://www.facebook.com/pg/CoderDojoNamba/events/
+
+# 大阪狭山・本町
 - dojo_id: 44
   name: doorkeeper
   group_id: 9012
@@ -366,6 +421,8 @@
 #   name: connpass
 #   group_id: 2777
 #   url: https://coderdojo-higashiosaka.connpass.com/
+
+# 堺
 - dojo_id: 46
   name: connpass
   group_id: 2620
@@ -382,10 +439,13 @@
   name: facebook
   group_id: 254235038032617
   url: https://www.facebook.com/pg/coderdojo.kumano/events/
+
+# 南紀田辺
 - dojo_id: 99
-  name: none
-  group_id:
-  url:
+  name: facebook
+  group_id: 773267359523217
+  url: https://www.facebook.com/CoderDojoNankiTanabe/
+
 - dojo_id: 47
   name: facebook
   group_id: 1794762964139814
@@ -394,6 +454,8 @@
   name: connpass
   group_id: 2932
   url: https://kitakobedojo.connpass.com/
+
+# 灘
 - dojo_id: 124
   name: connpass
   group_id: 5067
@@ -406,9 +468,10 @@
   name: connpass
   group_id: 2710
   url: https://coderdojo-akashi.connpass.com/
+
+# 姫路
 - dojo_id: 50
-  # 閉鎖？
-  name: none
+  name: google
   group_id:
   url:
 - dojo_id: 81
@@ -419,6 +482,8 @@
   name: connpass
   group_id: 2847
   url: https://coderdojo-fukuyama.connpass.com/
+
+# 紙屋町
 - dojo_id: 52
   name: doorkeeper
   group_id: 8417
@@ -435,15 +500,20 @@
   name: google
   group_id:
   url:
+
+# 徳島
 - dojo_id: 103
-  name: none
-  group_id:
-  url:
+  name: facebook
+  group_id: 693901040807095
+  url: https://www.facebook.com/CDTokushima/
+
 - dojo_id: 111
   name: facebook
   group_id: 1507281716025249
   url: https://www.facebook.com/pg/coderdojomiyoshi/events/
-- dojo_id: 102 
+
+# 福岡
+- dojo_id: 102
   name: facebook # 第4回からは connpass
   group_id: 495711777474589
   url: https://www.facebook.com/pg/CoderDojoFukuoka/events/
@@ -455,6 +525,8 @@
   name: facebook
   group_id: 1928416637480111
   url: https://www.facebook.com/%E3%82%B3%E3%83%BC%E3%83%80%E3%83%BC%E9%81%93%E5%A0%B4%E3%82%82%E3%82%82%E3%81%A1Coderdojo-momochi-1928416637480111/
+
+# 久留米
 - dojo_id: 54
   name: connpass
   group_id: 3045
@@ -475,40 +547,54 @@
   name: connpass
   group_id: 3332
   url: https://coderdojo-kadena.connpass.com/
+
+# 宮古島
 - dojo_id: 56
-  name: none
+  name: facebook # イベントページなし
   group_id:
-  url:
+  url: https://www.facebook.com/coderdojo.miyakojima/
 
 # 会津
 - dojo_id: 79
   name: doorkeeper
   group_id: 9583
   url: https://coderdojo-aizu.doorkeeper.jp/
+
 # 光
 - dojo_id: 92
   name: connpass
   group_id: 5606
   url: https://coderdojo-hikari.connpass.com/
+
 # 末広町
 - dojo_id: 97
-  name: facebook
+  name: facebook # 第6回から connpass でも運用
   group_id: 333403467110518
   url: https://www.facebook.com/pg/coderdojosuehirocho/events/
+- dojo_id: 97
+  name: connpass
+  group_id: 8400
+  url: https://coderdojosuehirocho.connpass.com/
+
 # 松戸
 - dojo_id: 114
   name: connpass
   group_id: 5893
   url: https://coderdojomatsudo.connpass.com/
 
+# 立川
 - dojo_id: 117
   name: connpass
   group_id: 4692
   url: https://coderdojo-tachikawa.connpass.com/
+
+# 阿倍野
 - dojo_id: 116
   name: doorkeeper
   group_id: 9482
   url: https://coderdojo-abeno.doorkeeper.jp/
+
+# 安城
 - dojo_id: 118
   name: doorkeeper
   group_id: 9496
@@ -517,6 +603,7 @@
   name: doorkeeper
   group_id: 9491
   url: https://coderdojo-ochanomizu.doorkeeper.jp/
+
 # 三島・沼津
 - dojo_id: 129
   name: connpass
@@ -530,10 +617,14 @@
   name: facebook
   group_id: 209274086317393
   url: https://www.facebook.com/CoderDojoTottori/
+
+# 香椎
 - dojo_id: 136
   name: connpass
   group_id: 5069
   url: https://coderdojo-kashii.connpass.com/
+
+# 保土ヶ谷
 - dojo_id: 137
   name: connpass
   group_id: 5362
@@ -560,28 +651,38 @@
   name: connpass
   group_id: 6482
   url: https://coderdojokitaq.connpass.com/
+
+# 日進
 - dojo_id: 145
   name: connpass
   group_id: 5408
   url: https://coderdojo-nisshin.connpass.com/
+
+# 稲城
 - dojo_id: 147
   name: doorkeeper
   group_id: 9690
   url: https://coderdojo-inagi.doorkeeper.jp/
+
 # 静岡
 - dojo_id: 148
   name: connpass
   group_id: 5590
   url: https://coderdojo-shizuoka.connpass.com/
+
 # 白河
 - dojo_id: 149
   name: doorkeeper
   group_id: 9703
   url: https://coderdojo-shirakawa.doorkeeper.jp/
+
+# 倉敷
 - dojo_id: 150
   name: connpass
   group_id: 5751
   url: https://cd-kurashiki.connpass.com/
+
+# 多摩センター
 - dojo_id: 153
   name: doorkeeper
   group_id: 9608
@@ -610,6 +711,8 @@
   name: connpass
   group_id: 640
   url: https://coderdojo-shinagawa-gotenyama.connpass.com/
+
+# 三鷹
 - dojo_id: 174
   name: connpass
   group_id: 6562
@@ -618,10 +721,14 @@
   name: connpass
   group_id: 6645
   url: https://coderdojo-kohokunt.connpass.com/
+
+# 猪名川
 - dojo_id: 181
   name: connpass
   group_id: 6141
   url: https://coderdojo-inagawa.connpass.com/
+
+# 瀬戸
 - dojo_id: 182
   name: connpass
   group_id: 6655
@@ -630,6 +737,8 @@
   name: facebook
   group_id: 1318246998318371
   url: https://www.facebook.com/pg/CoderDojoHakata/events/
+
+# あざみ野
 - dojo_id: 184
   name: connpass
   group_id: 6773
@@ -638,6 +747,8 @@
   name: doorkeeper
   group_id: 9906
   url: https://coderdojo-gotanda.doorkeeper.jp/
+
+# 名護
 - dojo_id: 186
   name: facebook # 第4回からは connpass で運用
   group_id: 318691575631474
@@ -650,6 +761,8 @@
   name: facebook # 第2回からは connpass で運用
   group_id: 569968173442983
   url: https://www.facebook.com/CoderDojoKagoshima/
+
+# 鹿児島
 - dojo_id: 187
   name: connpass
   group_id: 7373
@@ -670,16 +783,19 @@
   name: facebook
   group_id: 2400985366820315
   url: https://www.facebook.com/CoderDojoDazaifu/
+
 # 宇部
 - dojo_id: 192
   name: connpass
   group_id: 7006
   url: https://coderdojo-ube.connpass.com/
+
 # とよなか
 - dojo_id: 193
   name: connpass
   group_id: 7172
   url: https://coderdojo-toyonaka.connpass.com/
+
 # 韮崎 Facebookイベントページなし connnpassに移行
 # - dojo_id: 195
 #   name: facebook
@@ -689,6 +805,7 @@
   name: connpass
   group_id: 7466
   url: https://coderdojo-nirasaki.connpass.com/
+
 # 北杜 Facebookイベントページなし connpassに移行
 # - dojo_id: 196
 #   name: facebook

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -6,7 +6,7 @@
   prefecture_id: 1
   url: http://www.coderdojo-sapporo.jp/
   logo: "/img/dojos/sapporo.jpg"
-  description: 北海道札幌市で月２回開催
+  description: 北海道札幌市で月2回開催
   tags:
   - Scratch
   - micro:bit
@@ -20,7 +20,7 @@
   prefecture_id: 1
   url: https://coderdojo-sapporo-east.blogspot.jp/
   logo: "/img/dojos/japan.png"
-  description: 北海道札幌市で月２回開催
+  description: 北海道札幌市で月2回開催
   tags:
   - Scratch
   - micro:bit
@@ -203,7 +203,7 @@
   prefecture_id: 7
   logo: "/img/dojos/aizu.png"
   url: http://coderdojoaizu.strikingly.com/
-  description: 会津若松市内で毎月第３土曜に開催
+  description: 会津若松市内で毎月第3土曜に開催
   tags:
   - Scratch
   - micro:bit
@@ -374,8 +374,8 @@
   name: 館林
   prefecture_id: 10
   logo: "/img/dojos/tatebayashi.png"
-  url: http://coderdojo-tatebayashi.net/
-  description: 群馬県館林市で2ヶ月に1回
+  url: https://www.facebook.com/cd.tatebayashi/
+  description: 群馬県館林市で不定期開催
   tags:
   - Scratch
   - WEBサイト
@@ -399,7 +399,7 @@
   prefecture_id: 11
   url: https://www.facebook.com/CoderDojoTokorozawa/
   logo: "/img/dojos/tokorozawa.png"
-  description: 埼玉県所沢市で不定期に開催
+  description: 埼玉県所沢市で不定期開催
   tags:
   - Scratch
 - id: 77
@@ -520,7 +520,7 @@
   prefecture_id: 12
   logo: "/img/dojos/ichikawa-mama.jpg"
   url: http://beyondbb.jp/CDmama/index.html
-  description: 千葉県JR市川駅近辺で毎月2回開催
+  description: 千葉県JR市川駅近辺で月2回開催
   tags:
   - Scratch
   - micro:bit
@@ -554,8 +554,8 @@
   name: 松戸
   prefecture_id: 12
   logo: "/img/dojos/japan.png"
-  url: http://code4matsudo.org/coder-dojo-matsudo/2017/10/15/283/
-  description: 千葉県松戸市で不定期開催
+  url: http://code4matsudo.org/category/coder-dojo-matsudo/
+  description: 千葉県松戸市で隔月開催
   tags:
   - Scratch
 - id: 20
@@ -596,7 +596,7 @@
   prefecture_id: 12
   url: http://www.coderdojo-kashiwa.com/dojo/minamikashiwa/
   logo: "/img/dojos/minami-kashiwa.png"
-  description: 千葉県柏市光ヶ丘で毎月第３土曜日に開催
+  description: 千葉県柏市光ヶ丘で毎月第3土曜開催
   tags:
   - Scratch
 - id: 24
@@ -718,7 +718,7 @@
   prefecture_id: 13
   url: https://www.roundtable.co.jp/~tomio/blog/i01coach/?page_id=2532
   logo: "/img/dojos/shinagawa-gotenyama.png"
-  description: 東京都品川区で不定期に開催
+  description: 東京都品川区で不定期開催
   tags:
   - Scratch
   - Webサイト
@@ -732,7 +732,7 @@
   prefecture_id: 13
   url: https://www.facebook.com/groups/295361057723820/
   logo: "/img/dojos/japan.png"
-  description: 品川区五反田freeeオフィスで毎月第３土曜開催
+  description: 品川区五反田freeeオフィスで毎月第3土曜開催
   tags:
   - Scratch
   - micro:bit
@@ -946,7 +946,7 @@
   prefecture_id: 13
   logo: "/img/dojos/machida.png"
   url: https://coderdojo-machida.connpass.com/
-  description: 東京都町田市で不定期に開催
+  description: 東京都町田市で不定期開催
   tags:
   - Scratch
   - micro:bit
@@ -1166,7 +1166,7 @@
   prefecture_id: 14
   logo: "/img/dojos/japan.png"
   url: https://coderdojo-chigasaki.blogspot.com/
-  description: 神奈川県茅ヶ崎市で不定期に開催
+  description: 神奈川県茅ヶ崎市で不定期開催
   tags:
   - Scratch
   - micro:bit
@@ -1365,7 +1365,7 @@
   prefecture_id: 21
   logo: "/img/dojos/japan.png"
   url: https://coderdojo-kaizu.jimdo.com/
-  description: 岐阜県海津市で毎月2回開催
+  description: 岐阜県海津市で月2回開催
   tags:
   - Scratch
 - id: 200
@@ -1387,7 +1387,7 @@
   prefecture_id: 21
   logo: "/img/dojos/japan.png"
   url: https://coderdojotono.hatenablog.com/
-  description: 岐阜県多治見市まなびパークで毎月第１・第３土曜日に開催
+  description: 岐阜県多治見市まなびパークで毎月第1・第3土曜開催
   tags:
   - Scratch
 - id: 148
@@ -1436,7 +1436,7 @@
   prefecture_id: 23
   logo: "/img/dojos/japan.png"
   url: http://coderdojo-nagoya.hateblo.jp/
-  description: 名古屋市中区で毎月開催
+  description: 名古屋市中区で月2回開催
   tags:
   - Scratch
 - id: 2
@@ -1446,7 +1446,7 @@
   prefecture_id: 23
   logo: "/img/dojos/japan.png"
   url: https://coderdojo-mizuho.connpass.com/
-  description: 名古屋市瑞穂区で毎月開催
+  description: 名古屋市瑞穂区で月2回開催
   tags:
   - Scratch
   - micro:bit
@@ -1484,7 +1484,7 @@
   prefecture_id: 23
   logo: "/img/dojos/ichinomiya.png"
   url: https://hauska-paikka.jp/event/coderdojo/
-  description: 愛知県一宮市新生で月２回開催
+  description: 愛知県一宮市新生で月2回開催
   tags:
   - Scratch
   - PHP
@@ -1496,7 +1496,7 @@
   prefecture_id: 23
   logo: "/img/dojos/japan.png"
   url: https://coderdojo-seto.github.io/
-  description: 愛知県瀬戸市で毎月２回開催
+  description: 愛知県瀬戸市で月2回開催
   tags:
   - Scratch
   - Webサイト
@@ -1509,7 +1509,7 @@
   prefecture_id: 23
   logo: "/img/dojos/anjo.png"
   url: https://sites.google.com/coderdojo.com/anjo/
-  description: 愛知県安城市keyportで毎月第3土曜日午前に開催
+  description: 愛知県安城市keyportで毎月第3土曜午前に開催
   tags:
   - Scratch
   - micro:bit
@@ -1531,7 +1531,7 @@
   name: 新城
   prefecture_id: 23
   logo: "/img/dojos/japan.png"
-  url: https://www.facebook.com/CoderDojo-Shinshiro-842752475889001/
+  url: https://www.facebook.com/coderdojo.shinshiro/
   description: 愛知県新城市で毎月開催
   tags:
   - Scratch
@@ -1557,7 +1557,7 @@
   prefecture_id: 23
   logo: "/img/dojos/nisshin.png"
   url: https://coderdojo-nisshin.connpass.com/
-  description: 愛知県日進市で毎月２回開催
+  description: 愛知県日進市で月2回開催
   tags:
   - Scratch
   - micro:bit
@@ -1569,7 +1569,7 @@
   prefecture_id: 23
   logo: "/img/dojos/shikatsu.jpg"
   url: https://note.mu/cd_shikatsu
-  description: 愛知県北名古屋市で毎月第2木曜日
+  description: 愛知県北名古屋市で毎月第2木曜開催
   tags:
   - Scratch
   - micro:bit
@@ -1594,7 +1594,7 @@
   prefecture_id: 24
   logo: "/img/dojos/ise.png"
   url: https://coderdojo-ise.jimdo.com/
-  description: 三重県伊勢市で不定期に開催
+  description: 三重県伊勢市で不定期開催
   tags:
   - Scratch
   - micro:bit
@@ -1730,7 +1730,7 @@
   prefecture_id: 27
   logo: "/img/dojos/japan.png"
   url: https://coderdojo-suita.doorkeeper.jp/
-  description: 大阪府吹田市で不定期に開催
+  description: 大阪府吹田市で不定期開催
   tags:
   - Scratch
   - ラズベリーパイ
@@ -1743,7 +1743,7 @@
   prefecture_id: 27
   logo: "/img/dojos/takatsuki.png"
   url: https://www.facebook.com/coderdojotakatsuki/
-  description: 大阪府高槻市で不定期に開催
+  description: 大阪府高槻市で不定期開催
   tags:
   - Scratch
 - id: 40
@@ -1779,7 +1779,7 @@
   prefecture_id: 27
   logo: "/img/dojos/daito.png"
   url: http://coderdojodaito.strikingly.com/
-  description: 大阪府大東市で毎月第一土曜日に開催
+  description: 大阪府大東市で毎月第1土曜日に開催
   tags:
   - Scratch
   - micro:bit
@@ -1889,7 +1889,7 @@
   prefecture_id: 28
   logo: "/img/dojos/kobe.png"
   url: http://coderdojokobe.wixsite.com/home/
-  description: 神戸市中央区で月１回
+  description: 神戸市中央区で毎月開催
   tags:
   - Scratch
   - JavaScript
@@ -1899,7 +1899,7 @@
   name: 姫路
   prefecture_id: 28
   logo: "/img/dojos/himeji.png"
-  url: https://himejicoderdojo.doorkeeper.jp/
+  url: https://sites.google.com/site/himejicoderdojo/
   description: 兵庫県姫路市で第3土曜日に毎月開催
   tags:
   - Scratch
@@ -2011,7 +2011,7 @@
   prefecture_id: 29
   logo: "/img/dojos/japan.png"
   url: https://coderdojo-asuka.github.io/
-  description: 奈良県明日香村で毎月１回開催
+  description: 奈良県明日香村で毎月1回開催
   tags:
   - Scratch
   - micro:bit
@@ -2099,7 +2099,7 @@
   prefecture_id: 32
   logo: "/img/dojos/japan.png"
   url: https://github.com/smalruby/smalruby.jp/wiki/道場のフォーム
-  description: 島根県各地で各地で毎週１回〜２回開催
+  description: 島根県各地で各地で週1〜2回開催
   tags:
   - Scratch
   - Webサイト
@@ -2113,7 +2113,7 @@
   prefecture_id: 32
   logo: "/img/dojos/japan.png"
   url: https://zen.coderdojo.com/dojos/jp/ren2-mo2-ting3/iwami-takuno
-  description: 島根県大田市仁摩町で月に２回開催
+  description: 島根県大田市仁摩町で月2回開催
   tags:
   - Scratch
   - Webサイト
@@ -2126,7 +2126,7 @@
   prefecture_id: 32
   logo: "/img/dojos/japan.png"
   url: https://www.facebook.com/CoderDojoHamada
-  description: 島根県浜田市で月一で開催
+  description: 島根県浜田市で毎月開催
   tags:
   - Scratch
   - Webサイト
@@ -2289,7 +2289,7 @@
   prefecture_id: 36
   logo: "/img/dojos/miyoshi.png"
   url: https://www.facebook.com/groups/105010163561072/
-  description: 徳島県三好市で毎月第二週に開催
+  description: 徳島県三好市で毎月第2週に開催
   tags:
   - Minecraft
 - id: 188
@@ -2336,7 +2336,7 @@
   prefecture_id: 40
   logo: "/img/dojos/japan.png"
   url: https://www.facebook.com/coderdojokitakyushu/
-  description: 福岡県北九州市で１〜２ヶ月に１回開催
+  description: 福岡県北九州市で1〜2ヶ月に1回開催
   tags:
   - Scratch
   - Webサイト
@@ -2383,7 +2383,7 @@
   prefecture_id: 40
   logo: "/img/dojos/kashii.png"
   url: https://coderdojo-kashii.connpass.com/
-  description: 福岡市東区で毎月１回不定期に開催
+  description: 福岡市東区で毎月1回不定期開催
   tags:
   - Viscuit
   - Minecraft
@@ -2411,7 +2411,7 @@
   prefecture_id: 40
   logo: "/img/dojos/japan.png"
   url: https://www.facebook.com/coderdojo.fukuoka.kurume.suwano/
-  description: 福岡県久留米市で毎月2回開催
+  description: 福岡県久留米市で月2回開催
   tags:
   - Scratch
   - Medibang
@@ -2439,7 +2439,7 @@
   prefecture_id: 40
   logo: "/img/dojos/nakama.png"
   url: https://www.facebook.com/CoderDojoNAKAMA/
-  description: 福岡県中間市で２ヶ月に１回程度開催
+  description: 福岡県中間市で2ヶ月に1回程度開催
   tags:
   - Scratch
   - micro:bit
@@ -2595,7 +2595,7 @@
   prefecture_id: 47
   logo: "/img/dojos/japan.png"
   url: http://coderdojo-nago.com
-  description: 沖縄県名護市で月に２回開催
+  description: 沖縄県名護市で月2回開催
   tags:
   - Scratch
   - micro:bit
@@ -2609,7 +2609,7 @@
   prefecture_id: 47
   logo: "/img/dojos/uruma.png"
   url: https://coderdojo-uruma.hatenablog.com/
-  description: 沖縄県うるま市で毎月第２・第４土曜に開催
+  description: 沖縄県うるま市で毎月第2・第4土曜に開催
   tags:
   - Scratch
   - micro:bit


### PR DESCRIPTION
### やったこと
各 Dojo の統計を取っていたついでに、気付いたところの古い情報を更新しました。
- db/dojo_event_services.yaml の `name: none` の dojo 情報を確認し、イベントページがあれば追加しました。
- db/dojo_event_services.yaml にできるだけ Dojo 名を付けて分かりやすくしました。（全てはできていません😭）
- `rake statistics:aggregation` で問題なく集計ができることを確認。
- db/dojos.yaml の description の文言をできるだけ統一し、最新の情報に合わせて変更しました。

### これからやる事
- 新たに facebook イベントページが追加された Dojo があるので、2019年11月分の facebook イベント集計の時にやろうと思います。