### PR TITLE
:new: Add CoderDojo 稲沢正明寺 in 愛知県

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1111,3 +1111,9 @@
   name: connpass
   group_id: 8841
   url: https://coderdojo-motoyama.connpass.com/
+
+# 稲沢正明寺
+- dojo_id: 235
+  name: peatix
+  group_id:
+  url: https://coderdojo-shomeiji.peatix.com/

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1526,6 +1526,17 @@
   tags:
   - Scratch
   - micro:bit
+- id: 235
+  order: '232203'
+  created_at: '2019-01-03'
+  name: 稲沢正明寺
+  prefecture_id: 23
+  logo: "/img/dojos/japan.png"
+  url: https://coderdojo-inazawash.com/
+  description: 愛知県稲沢市で毎月開催
+  tags:
+  - Scratch
+  - Viscuit
 - id: 84
   order: '232211'
   is_active: false


### PR DESCRIPTION
### やった事
稲沢正明寺 dojo の追加🎉
イベント管理を [Peatix](https://coderdojo-shomeiji20200118.peatix.com/view) で行っているようです。