### PR TITLE
統計情報に2019年データを追加

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -10,16 +10,16 @@ class StatsController < ApplicationController
     @sum_of_dojos        = DojoEventService.count('DISTINCT dojo_id')
     @sum_of_participants = EventHistory.sum(:participants)
 
-    # 2012年1月1日〜2018年12月31日までの集計結果
-    period = Time.zone.local(2012).beginning_of_year..Time.zone.local(2018).end_of_year
-    stat   = Stat.new(period)
-    @dojos        = stat.annual_sum_total_of_aggregatable_dojo
-    @events       = stat.annual_count_of_event_histories
-    @participants = stat.annual_sum_of_participants
+    # 2012年1月1日〜2019年12月31日までの集計結果
+    period        = Time.zone.local(2012).beginning_of_year..Time.zone.local(2019).end_of_year
+    statistics    = Stat.new(period)
+    @dojos        = statistics.annual_sum_total_of_aggregatable_dojo
+    @events       = statistics.annual_count_of_event_histories
+    @participants = statistics.annual_sum_of_participants
 
-    @high_charts_globals = HighChartsBuilder.global_options
-    @annual_dojos_chart           = stat.annual_dojos_chart
-    @annual_event_histories_chart = stat.annual_event_histories_chart
-    @annual_participants_chart    = stat.annual_participants_chart
+    @high_charts_globals          = HighChartsBuilder.global_options
+    @annual_dojos_chart           = statistics.annual_dojos_chart
+    @annual_event_histories_chart = statistics.annual_event_histories_chart
+    @annual_participants_chart    = statistics.annual_participants_chart
   end
 end

--- a/app/models/high_charts_builder.rb
+++ b/app/models/high_charts_builder.rb
@@ -15,10 +15,10 @@ class HighChartsBuilder
         f.series(type: 'column', name: '増加数', yAxis: 0, data: data[:increase_nums])
         f.series(type: 'line', name: '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
-          { title: { text: '増加数' }},
-          { title: { text: '累積合計' }, opposite: true }
+          { title: { text: '増加数' },   tickInterval: 15, max: 75 },
+          { title: { text: '累積合計' }, tickInterval: 50, max: 250, opposite: true }
         ]
-        f.chart(width: 600)
+        f.chart(width: 600, alignTicks: false)
         f.colors(["#A0D3B5", "#505D6B"])
       end
     end
@@ -32,10 +32,10 @@ class HighChartsBuilder
         f.series(type: 'column', name: '開催回数', yAxis: 0, data: data[:increase_nums])
         f.series(type: 'line',   name: '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
-          { title: { text: '開催回数' }, tickInterval: 300 },
-          { title: { text: '累積合計' }, opposite: true }
+          { title: { text: '開催回数' }, tickInterval:  400, max: 2000 },
+          { title: { text: '累積合計' }, tickInterval: 1000, max: 5000, opposite: true }
         ]
-        f.chart(width: 600)
+        f.chart(width: 600, alignTicks: false)
         f.colors(["#F4C34F", "#BD2561"])
       end
     end
@@ -49,10 +49,10 @@ class HighChartsBuilder
         f.series(type: 'column', name: '参加者数', yAxis: 0, data: data[:increase_nums])
         f.series(type: 'line',   name: '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
-          { title: { text: '参加者数' } },
-          { title: { text: '累積合計' }, opposite: true }
+          { title: { text: '参加者数' }, tickInterval: 2500, max: 12500 },
+          { title: { text: '累積合計' }, tickInterval: 6000, max: 30000, opposite: true }
         ]
-        f.chart(width: 600)
+        f.chart(width: 600, alignTicks: false)
         f.colors(["#EF685E", "#35637D"])
       end
     end

--- a/app/views/stats/show.html.haml
+++ b/app/views/stats/show.html.haml
@@ -29,13 +29,14 @@
         %tr
           %th
           - @dojos.keys.each do |year|
-            %td{style: 'padding: 0 5px; font-weight: bold;'} #{year}年
-          %td{style: 'padding: 0 5px; font-weight: bold;'} 合計
+            %th{style: 'padding: 0 5px;'} #{year}年
+          %th{style: 'padding: 0 5px; text-align: center;'} 合計
       %tbody{style: 'text-align: center;'}
         %tr
           %td 道場数
           - @dojos.each_value do |num|
             %td= num
+          %td= @dojos.values.last
         %tr
           %td 開催数
           - @events.each_value do |num|

--- a/app/views/stats/show.html.haml
+++ b/app/views/stats/show.html.haml
@@ -56,7 +56,7 @@
   %b / #{@dojo_count} Dojos
 
   %h3{style: "margin-top: 60px;"} 🆕 最新データ
-  2019年のデータも含めた最新の統計情報は次のとおりです。
+  2020年のデータも含めた最新の統計情報は次のとおりです。
   %div{style: "margin-top: 20px;", align: 'center' }
     %table{style: 'margin-top: 4px;'}
       %thead


### PR DESCRIPTION
## 背景

統計情報ページに2019年データを追加表示する

## やりたいこと

- 推移グラフ、推移テーブルで2019年データを表示する
- 最新データは「2020年のデータを含めた」に修正する

## このPRでやること

- [x] 推移グラフに2019年データまで表示し、左右のスケールを修正
- [x] 推移テーブルに2019年データまで表示
- [x] 最新データの説明文言修正
- [x] RSpec の予約語回避のため、stats_controller.rb 内の変数 stat を statistics に変更

## やらなかったこと

特になし

## 困っていること

特になし