### PR TITLE
rake タスク dojos:sort_yaml をコメントアウト(無効化)

### DIFF
--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -64,17 +64,17 @@ http://www.soumu.go.jp/denshijiti/code.html
     end
   end
 
-  desc '現在のyamlファイルのカラムをソートします'
-  task sort_yaml: :environment do
-    dojos = Dojo.load_attributes_from_yaml
-
-    # Dojo column should start with 'name' for human-readability
-    dojos.map! do |dojo|
-      dojo.sort_by { |a,b| a.last }.to_h
-    end
-
-    Dojo.dump_attributes_to_yaml(dojos)
-  end
+  # desc '現在のyamlファイルのカラムをソートします'
+  # task sort_yaml: :environment do
+  #   dojos = Dojo.load_attributes_from_yaml
+  #
+  #   # Dojo column should start with 'name' for human-readability
+  #   dojos.map! do |dojo|
+  #     dojo.sort_by { |a,b| a.last }.to_h
+  #   end
+  #
+  #   Dojo.dump_attributes_to_yaml(dojos)
+  # end
 
   desc 'DBからyamlファイルを生成します'
   task migrate_adding_id_to_yaml: :environment do

--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -64,6 +64,7 @@ http://www.soumu.go.jp/denshijiti/code.html
     end
   end
 
+  # NOTE: 2020年1月中はコメントアウトで残し、もし必要になる場面が無ければ翌月以降に削除する
   # desc '現在のyamlファイルのカラムをソートします'
   # task sort_yaml: :environment do
   #   dojos = Dojo.load_attributes_from_yaml


### PR DESCRIPTION
## 背景

使用されていない＆使用できないコードは削除したい。

## やりたいこと

out-of-date で現在使用されていない `rake dojos:sort_yaml` の処理を無効化する。
しばらく様子を見て、運用上問題がないようであれば不要コードは削除する。

## このPRでやること

- [x] `rake dojos:sort_yaml` のコードをコメントアウトする

## やらなかったこと

- `rake dojos:sort_yaml` のコードの削除

## 困っていること

特になし
