### PR TITLE
:new: Add CoderDojo 法隆寺 in 奈良県

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -2006,6 +2006,16 @@
   - micro:bit
   - JavaScript
   - Webサイト
+- id: 236
+  order: '292095'
+  created_at: '2020-01-11'
+  name: 法隆寺
+  prefecture_id: 29
+  logo: "/img/dojos/japan.png"
+  url: https://zen.coderdojo.com/dojos/jp/nai4-liang2-xian4-sheng1-ju1-jun4-sheng1-ju1-jun4/horyujinararohasuraiburar
+  description: 奈良県生駒市班鳩町で毎月開催
+  tags:
+  - Scratch
 - id: 128
   order: '293431'
   is_active: false


### PR DESCRIPTION
### やったこと
法隆寺Dojo の追加🎉
<img width="240" alt="スクリーンショット 2020-01-11 13 26 14" src="https://user-images.githubusercontent.com/48109243/72198801-fbe30a80-3475-11ea-92b5-2458c1b66e64.png">

申請時の URL は個人のページだった為、[zen.coderdojo.com](https://zen.coderdojo.com/dojos/jp/nai4-liang2-xian4-sheng1-ju1-jun4-sheng1-ju1-jun4/horyujinararohasuraiburar) の法隆寺ページにしてあります👍
https://idobata.io/archives/messages/32650293#message_32650293