### PR TITLE
2020年1月分のFacebookイベントを追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1104,11 +1104,11 @@
 #  group_id: 
 #  url: 
 
-# 上田: 2020年1月開始。イベント管理サービスは未定
-#- dojo_id: 232
-#  name: 
-#  group_id: 
-#  url: 
+# 上田
+- dojo_id: 232
+  name: doorkeeper
+  group_id: 10783
+  url: https://coderdojoueda.doorkeeper.jp/
 
 # 足立
 - dojo_id: 233

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4098,3 +4098,61 @@
   event_id:
   participants: 0
   evented_at: 2019/12/28 11:30
+
+# 2020/01/01 - 2020/01/31
+- dojo_id: 6
+  event_id:
+  participants: 0
+  evented_at: 2020/01/10 17:00
+- dojo_id: 203
+  event_id:
+  participants: 0
+  evented_at: 2020/01/12 09:30
+- dojo_id: 25
+  event_id:
+  participants: 0
+  evented_at: 2020/01/12 10:00
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2020/01/12 10:00
+- dojo_id: 12
+  event_id:
+  participants: 0
+  evented_at: 2020/01/12 10:30
+- dojo_id: 10
+  event_id:
+  participants: 0
+  evented_at: 2020/01/12 13:30
+- dojo_id: 6
+  event_id:
+  participants: 0
+  evented_at: 2020/01/17 17:00
+- dojo_id: 191
+  event_id:
+  participants: 0
+  evented_at: 2020/01/18 14:00
+- dojo_id: 94
+  event_id:
+  participants: 0
+  evented_at: 2020/01/19 10:00
+- dojo_id: 86
+  event_id:
+  participants: 0
+  evented_at: 2020/01/19 10:30
+- dojo_id: 103
+  event_id:
+  participants: 0
+  evented_at: 2020/01/20 18:00
+- dojo_id: 6
+  event_id:
+  participants: 0
+  evented_at: 2020/01/24 17:00
+- dojo_id: 229
+  event_id:
+  participants: 0
+  evented_at: 2020/01/25 13:00
+- dojo_id: 10
+  event_id:
+  participants: 0
+  evented_at: 2020/01/26 13:30


### PR DESCRIPTION
### やった事
2020年1月分 Facebook イベントを追加 🎉✨

### 気になった事
参加者数が全て 0 で Facebook の方のバグ？かと思いましたが、正しく取れているイベントもあったのでバグではなさそうでした！
例: [コーダー道場名護( 集計は connpass で運用)](https://www.facebook.com/events/2420115834902622/)

@chicaco お手隙の際にご確認よろしくお願いします📄✨