### PR TITLE
Fix layout Dojos because those descriptions are cut off

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -521,16 +521,22 @@ body>footer a:hover {
   padding-top: 1em;
   margin: .4em
 }
+.dojo-flex{
+  display: flex !important;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: auto;
+}
 
 .dojo {
-  display: inline-block;
-  height: 300px;
   width: 45%;
   margin: 5px;
   padding: 15px 0;
   background: #fff;
   position: relative;
-  text-align: center
+  text-align: center;
+  display: block;
+  height: auto
 }
 
 .dojo>p {
@@ -622,8 +628,7 @@ body>footer a:hover {
 
 @media only screen and (min-width:560px) {
   .dojo {
-    width: 220px;
-    height: 275px;
+    width: calc(220px - 10px);
     margin: 10px;
   }
   .event {

--- a/app/views/shared/_dojos.html+smartphone.haml
+++ b/app/views/shared/_dojos.html+smartphone.haml
@@ -8,5 +8,5 @@
             = region
             \- #{dojos.count} Dojos
       .panel-collapse.collapse{:id => "collapse#{index}", :role => "tabpanel"}
-        .panel-body.grayscale-bg
+        .panel-body.grayscale-bg.dojo-flex
           = render partial: 'shared/dojo', collection: dojos

--- a/app/views/shared/_dojos.html.haml
+++ b/app/views/shared/_dojos.html.haml
@@ -1,2 +1,2 @@
-%ul.loaded
+%ul.loaded.dojo-flex
   = render partial: 'shared/dojo', collection: regions_and_dojos.values.flatten


### PR DESCRIPTION
Fix #721 

[Dojo一覧でタグ/文章が長いとテキストが見切れてしまう問題 #721 ](https://github.com/coderdojo-japan/coderdojo.jp/issues/721) を、高さを可変にしてそれぞれの行ごとに揃えることで修正しました！
(場所が一つずつずれているのはDojo情報の更新がまだローカル環境でやれていないからです><)

![image](https://user-images.githubusercontent.com/31533303/73713062-5c9cf480-474f-11ea-9459-09ca09b49029.png)

