### PR TITLE
:new: Add CoderDojo 京都四条 in 京都府

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1143,3 +1143,9 @@
   name: doorkeeper
   group_id: 10432
   url: https://coderdojo-niizashiki.doorkeeper.jp/
+
+# 京都四条
+- dojo_id: 240
+  name: doorkeeper
+  group_id: 10943
+  url: https://coderdojo-kyoto-shijo.doorkeeper.jp/

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1665,6 +1665,18 @@
   - Java
   - JavaScript
   is_private: true
+- id: 240
+  order: '261009'
+  created_at: '2020-02-09'
+  name: 京都四条
+  prefecture_id: 26
+  logo: "/img/dojos/japan.png"
+  url: https://coderdojo-kyoto-shijo.doorkeeper.jp/
+  description: 京都府京都市で毎月開催
+  tags:
+  - Scratch
+  - Unity
+  - Webサイト
 - id: 34
   order: '261009'
   created_at: '2014-10-14'


### PR DESCRIPTION
### やったこと
- 京都四条 Dojo の追加 🎉
- イベントサービスに [doorkeeper](https://coderdojo-kyoto-shijo.doorkeeper.jp/) で追加 🎉
- 表示されることを確認👀
<img width="695" alt="スクリーンショット 2020-02-10 17 52 18" src="https://user-images.githubusercontent.com/48109243/74134800-82823780-4c2e-11ea-92d3-14fee0d475e0.png">

- `rails dojo_event_services:upsert` `rails statistics:aggregation` 共に異常なし✅

@chicaco お手隙の際にご確認よろしくお願いします📄✨
