### PR TITLE
:new: Add CoderDojo 西尾 in 愛知県

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1143,3 +1143,9 @@
   name: doorkeeper
   group_id: 10432
   url: https://coderdojo-niizashiki.doorkeeper.jp/
+
+# 西尾
+- dojo_id: 241
+  name: doorkeeper
+  group_id: 10003
+  url: https://coderdojo-nishio.doorkeeper.jp/

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1543,6 +1543,17 @@
   tags:
   - Scratch
   - micro:bit
+- id: 241
+  order: '232131'
+  created_at: '2020-02-10'
+  name: 西尾
+  prefecture_id: 23
+  logo: "/img/dojos/japan.png"
+  url: https://www.coderdojo-nishio.com/
+  description: 愛知県西尾市で毎月開催
+  tags:
+  - Scratch
+  - micro:bit
 - id: 218
   order: '232157'
   created_at: '2019-06-23'


### PR DESCRIPTION
### やったこと
- 西尾 Dojo の追加 🎉
- イベントサービスに [doorkeeper](https://coderdojo-nishio.doorkeeper.jp/) で追加 🎉
- 表示されることを確認 👀
<img width="684" alt="スクリーンショット 2020-02-10 22 49 53" src="https://user-images.githubusercontent.com/48109243/74155284-a8700200-4c57-11ea-9bdd-b04b7c0c3aaf.png">

- `rails dojo_event_services:upsert`、 `rails statistics:aggregation` 異常なし✅

@chicaco こちらも合わせてお手隙の際にご確認よろしくお願いします📄✨