### PR TITLE
2020年2月分のFacebookイベントを集計

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -48,7 +48,7 @@
 
 # 名取
 - dojo_id: 85
-  name: facebook
+  name: facebook # connpass: https://coderdojonatori.connpass.com/
   group_id: 1379707208756830
   url: https://www.facebook.com/pg/coderdojonatori/events/
 
@@ -320,9 +320,13 @@
 
 # 甲府
 - dojo_id: 88
-  name: facebook
+  name: facebook # 第２回からは connpass
   group_id: 124249914820641
   url: https://www.facebook.com/pg/coderdojo.kofu/events/
+- dojo_id: 88
+  name: connpass
+  group_id: 4255
+  url: https://coderdojokofu.connpass.com/
 
 # 安曇野
 - dojo_id: 87

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -2558,10 +2558,6 @@
   event_id: 1372320219469831
   participants: 0
   evented_at: 2017/07/23 11:20
-- dojo_id: 88
-  event_id: 1924777571134708
-  participants: 0
-  evented_at: 2017/08/20 10:20
 - dojo_id: 94
   event_id: 1391919444222938
   participants: 3
@@ -4156,3 +4152,57 @@
   event_id:
   participants: 0
   evented_at: 2020/01/26 13:30
+
+# 2020/02/01 - 2020/02/29
+- dojo_id: 6
+  event_id:
+  participants: 0
+  evented_at: 2020/02/07 17:00
+- dojo_id: 203
+  event_id:
+  participants: 0
+  evented_at: 2020/02/09 09:30
+- dojo_id: 25
+  event_id:
+  participants: 0
+  evented_at: 2020/02/09 10:00
+- dojo_id: 12
+  event_id:
+  participants: 0
+  evented_at: 2020/02/09 10:30
+- dojo_id: 10
+  event_id:
+  participants: 0
+  evented_at: 2020/02/09 13:30
+- dojo_id: 6
+  event_id:
+  participants: 0
+  evented_at: 2020/02/14 17:00
+- dojo_id: 94
+  event_id:
+  participants: 0
+  evented_at: 2020/02/16 10:00
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2020/02/16 10:00
+- dojo_id: 25
+  event_id:
+  participants: 0
+  evented_at: 2020/02/16 10:30
+- dojo_id: 86
+  event_id:
+  participants: 0
+  evented_at: 2020/02/16 10:30
+- dojo_id: 103
+  event_id:
+  participants: 0
+  evented_at: 2020/02/17 18:00
+- dojo_id: 10
+  event_id:
+  participants: 0
+  evented_at: 2020/02/23 13:30
+- dojo_id: 222
+  event_id:
+  participants: 0
+  evented_at: 2020/02/24 13:30


### PR DESCRIPTION
### やったこと
- 2月分のFacebookイベントを集計
- 甲府Dojo を [connpass](https://coderdojokofu.connpass.com/) に移行（第2回から）
- 名取Dojo の connpass ページをコメント（直近の動きが見られたら移行する）
- `rails dojo_event_services:upsert`、`rails statistics:aggregation` 異常なし

@chicaco お手隙の際にご確認よろしくお願いします📄✨
