### PR TITLE
富田林ロゴ変更につきlogoファイル名変更

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1912,7 +1912,7 @@
   created_at: '2017-02-19'
   name: 富田林
   prefecture_id: 27
-  logo: "/img/dojos/japan.png"
+  logo: "/img/dojos/tondabayasi.png"
   url: https://coderdojotondabayashi.github.io/main/
   description: 富田林市で隔月開催
   tags:


### PR DESCRIPTION
id: 72富田林堀野です。1915行目japanからtondabayasiに変更いたしました。合わせてpublic/img/dojosへの該当ファイルupload許可もお願いいたします。