### PR TITLE
2020年4月分 Facebook イベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4232,3 +4232,42 @@
   event_id:
   participants: 0
   evented_at: 2020/03/27 17:00
+
+# 2020/04/01 - 2020/04/30 全てリモート開催
+- dojo_id: 6
+  event_id:
+  participants: 0
+  evented_at: 2020/04/10 17:00
+- dojo_id: 23
+  event_id:
+  participants: 0
+  evented_at: 2020/04/12 10:00
+- dojo_id: 25
+  event_id:
+  participants: 0
+  evented_at: 2020/04/12 10:00
+- dojo_id: 6
+  event_id:
+  participants: 0
+  evented_at: 2020/04/17 17:00
+- dojo_id: 111
+  event_id:
+  participants: 0
+  evented_at: 2020/04/18 14:00
+- dojo_id: 222
+  event_id:
+  participants: 0
+  evented_at: 2020/04/18 14:00
+- dojo_id: 86
+  event_id:
+  participants: 0
+  evented_at: 2020/04/19 13:00
+- dojo_id: 6
+  event_id:
+  participants: 0
+  evented_at: 2020/04/24 17:00
+- dojo_id: 23
+  event_id:
+  participants: 0
+  evented_at: 2020/04/26 10:00
+


### PR DESCRIPTION
### やったこと
- 2020年4月分 Facebook イベントを集計しました📊
全てオンライン開催で、人数はまたしても 0 となっています😥
開催数は 9 です。

```ruby
[1] pry(main)> EventHistory.where(evented_at: (DateTime.now.prev_month.beginning_of_month..DateTime.now.prev_month.end_of_month)).for(:facebook).count
   (35.0ms)  SELECT COUNT(*) FROM "event_histories" WHERE "event_histories"."evented_at" BETWEEN $1 AND $2 AND "event_histories"."service_name" = $3  [["evented_at", "2020-03-31 15:00:00"], ["evented_at", "2020-04-30 14:59:59.999999"], ["service_name", "facebook"]]
=> 9
```
- `rails dojo_event_services:upsert` , `rails statistics:aggregation` コマンド共に正常に動きました ✅
