### PR TITLE
トップ画像の見せ方を改善

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -503,10 +503,27 @@ body>footer a:hover {
 .cover {
   overflow: hidden;
   min-height: 125px;
-  background: #999;
+  position: relative;
+  background-color: #000;
+  z-index: 0;
+  overflow: hidden;
+  &::before {
+    content: '';
+    -ms-filter: blur(6px);
+    filter: blur(10px);
+    position: absolute;
+    top: -5px;
+    left: -5px;
+    right: -5px;
+    bottom: -5px;
+    z-index: -1;
+    background: url('/assets/coderdojo-japan_cover.jpg') no-repeat center;
+    background-size: cover;
+    opacity: 0.6;
+  }
 }
 
-.cover>img {
+.cover img {
   height: 100%;
   width: 100%;
   max-width: 1000px;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -507,6 +507,7 @@ body>footer a:hover {
   background-color: #000;
   z-index: 0;
   overflow: hidden;
+  max-height: 50vh;
   &::before {
     content: '';
     -ms-filter: blur(6px);
@@ -526,12 +527,13 @@ body>footer a:hover {
 .cover img {
   height: 100%;
   width: 100%;
+  max-height: 50vh;
   max-width: 1000px;
   margin-left: auto;
   margin-right: auto;
   display: block;
-  margin-top: -3%;
   border-radius: 0px;
+  object-fit: contain;
 }
 
 // Each Dojo: /#dojos

--- a/app/views/home/show.html.haml
+++ b/app/views/home/show.html.haml
@@ -5,7 +5,7 @@
   %br
 
 %section.cover
-  = image_tag "coderdojo-japan_cover.jpg"
+  = image_tag "coderdojo-japan_cover.jpg", alt: 'CoderDojoJapan カバー画像', loading: 'lazy'
 
 %section.introduction.text-center.list
   %br
@@ -123,7 +123,7 @@
     %p
       %a{:href => "/kata"} Kata
       では運営に役立つ情報を、
-      %a{href: "https://twitter.com/CoderDojoJapan"}<> Twitter 
+      %a{href: "https://twitter.com/CoderDojoJapan"}<> Twitter
       \ や
       %a{href: "https://www.facebook.com/groups/coderdojo.jp"}< Facebook
       では最近の活動を、
@@ -140,7 +140,7 @@
       %a.button{:href => '/kata'} Kata を読む
     %br
 
-= render partial: 'shared/partners'  
+= render partial: 'shared/partners'
 
 
 .text-center.grayscale-bg


### PR DESCRIPTION
close https://github.com/coderdojo-japan/coderdojo.jp/issues/845
## やったこと
- [x] トップ画像がトリミングされず表示されるようにした
- [x] 背景の灰色の部分をぼかし画像に変更
- [x] altを設定

## 改善前
![image](https://user-images.githubusercontent.com/31533303/84004916-43c77880-a9a7-11ea-9fab-d0ba6d8a1862.png)

## 改善後
![image](https://user-images.githubusercontent.com/31533303/84004888-3ad6a700-a9a7-11ea-8285-f7f88d8d4edf.png)
