### PR TITLE
連名で登録している道場もカウント可能にする

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -590,6 +590,13 @@ body>footer a:hover {
   display: block;
   margin: .5em 0;
   font-weight: bold;
+  .tooltip-arrow {
+    border-bottom-color: #777 !important;
+  }
+  .tooltip-inner {
+    background:  #777;
+    color:       #ffffff;
+  }
 }
 .dojo-counter {
   font-weight: bold;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -591,6 +591,14 @@ body>footer a:hover {
   margin: .5em 0;
   font-weight: bold;
 }
+.dojo-counter {
+  font-weight: bold;
+  background:  #B8B8B8;
+  color:       #ffffff;
+  padding:     5px 4px;
+  font-size:   70%;
+  border-radius: .9em;
+}
 
 .dojo-private {
   font-size: 80%;

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -40,6 +40,8 @@ class StatsController < ApplicationController
     end
 
     # 集計方法と集計対象
+    # TODO: 'DISTINCT dojo_id' cannot track joint-registrated dojos
+    #   cf. https://github.com/coderdojo-japan/coderdojo.jp/issues/610
     @aggregated_dojos   = DojoEventService.count('DISTINCT dojo_id')
     @annual_dojos_table = stats.annual_sum_total_of_aggregatable_dojo
 

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -32,7 +32,7 @@ class Dojo < ApplicationRecord
     end
 
     def active_dojos_count
-      active.count
+      active.sum(:counter)
     end
 
     def group_by_region

--- a/app/views/shared/_dojo.html.haml
+++ b/app/views/shared/_dojo.html.haml
@@ -2,7 +2,11 @@
   %header
     %a{:href => "#{dojo.url}"}
       %span.dojo-picture{style: "background-image: url(#{dojo.logo});"}
-      %span.dojo-name= "#{dojo.name} (#{dojo.prefecture.name})"
+    %a{:href => "#{dojo.url}"}
+      %span.dojo-name
+        = "#{dojo.name} (#{dojo.prefecture.name}) "
+        - if not dojo.counter == 1
+          %span.dojo-counter= "#{dojo.counter}"
   %ul.tags
     - dojo.tags.each do |tag|
       %li= tag

--- a/app/views/shared/_dojo.html.haml
+++ b/app/views/shared/_dojo.html.haml
@@ -6,7 +6,7 @@
       %span.dojo-name
         = "#{dojo.name} (#{dojo.prefecture.name}) "
         - if not dojo.counter == 1
-          %span.dojo-counter= "#{dojo.counter}"
+          %span.dojo-counter{'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'data-original-title' => '道場数'}= "#{dojo.counter}"
   %ul.tags
     - dojo.tags.each do |tag|
       %li= tag

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1764,6 +1764,7 @@
   order: '271004'
   created_at: '2014-02-11'
   name: 西宮・梅田
+  counter: 2
   prefecture_id: 27
   url: http://coderdojo-nishinomiya.info/
   logo: "/img/dojos/nishinomiya.png"
@@ -1791,6 +1792,7 @@
   order: '271004'
   created_at: '2016-08-15'
   name: 大阪狭山・本町
+  counter: 2
   prefecture_id: 27
   logo: "/img/dojos/hommachi.png"
   url: https://coderdojo-hommachi.doorkeeper.jp/
@@ -2245,6 +2247,7 @@
   order: '320005'
   created_at: '2019-09-06'
   name: しまね
+  counter: 7
   prefecture_id: 32
   logo: "/img/dojos/japan.png"
   url: https://github.com/smalruby/smalruby.jp/wiki/道場のフォーム

--- a/db/migrate/20200621020249_add_counter_to_dojo.rb
+++ b/db/migrate/20200621020249_add_counter_to_dojo.rb
@@ -1,0 +1,5 @@
+class AddCounterToDojo < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dojos, :counter, :integer, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190812033029) do
+ActiveRecord::Schema.define(version: 2020_06_21_020249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 20190812033029) do
     t.integer "prefecture_id"
     t.boolean "is_active", default: true, null: false
     t.boolean "is_private", default: false, null: false
+    t.integer "counter", default: 1, null: false
   end
 
   create_table "event_histories", id: :serial, force: :cascade do |t|

--- a/docs/how-to-add-dojo.md
+++ b/docs/how-to-add-dojo.md
@@ -30,6 +30,7 @@ Zen: https://zen.coderdojo.com/dojos/jp/okinawa-ken/okinawa-okinawa-prefecture/n
 ```yaml
 - created_at: '2019-06-15'
   name: 那覇
+  counter: 1                     # 省略化。連名道場のときに使います (後述)
   prefecture_id: 47
   logo: "/img/dojos/japan.png"   #  ロゴがあれば naha.png として追加
   url: https://coderdojo-naha.doorkeeper.jp/
@@ -48,6 +49,7 @@ Zen: https://zen.coderdojo.com/dojos/jp/okinawa-ken/okinawa-okinawa-prefecture/n
 | `created_at` | 掲載申請日の年月日 |
 | `order` | [全国地方公共団体コード](http://www.soumu.go.jp/denshijiti/code.html) (詳細は後述) |
 | `name` | Dojo名 |
+| `counter` | 省略化。[連名道場](https://github.com/coderdojo-japan/coderdojo.jp/issues/610)を登録する際に使います |
 | `prefecture_id` | `db/seeds.rb` の県番号 |
 | `logo` | 省略可。`public/img/dojos` にあるDojoロゴ画像パス |
 | `url` | 公式Webサイト (イベント管理ページも可) |

--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -30,6 +30,7 @@ namespace :dojos do
     dojos.each do |dojo|
       d = Dojo.find_or_initialize_by(id: dojo['id'])
       d.name          = dojo['name']
+      d.counter       = dojo['counter'] || 1
       d.email         = ''
       d.order         = dojo['order'] || search_order_number(dojo['name'])
       d.description   = dojo['description']


### PR DESCRIPTION
Fix #610 

連名で登録している道場もカウントできるようにしました! d(￣ ￣)✨ 
@chicaco デザインの部分以外はできたので (デザイン部分も[デザイン案は既に上がっていて](https://github.com/coderdojo-japan/coderdojo.jp/issues/610#issuecomment-646417313)あとは実装するだけなので)、一旦レビューお願いできると嬉しいです...!! (＞人＜ )✨

![image](https://user-images.githubusercontent.com/155807/85215515-c7746280-b3b4-11ea-94c9-8c225c385ab7.png)

![image](https://user-images.githubusercontent.com/155807/85215523-e7a42180-b3b4-11ea-9113-357ef782e926.png)

## やること

- [x] `counter` カラムの追加 (Default: 1, null: false) 91e4da3 
- [x] `counter` カラムを使って集計するように改善 6015c5d
- [x] `counter` カラムに関するドキュメントを追加 0e59e22
- [x] `counter` カラムの数をトップページに反映する (デザイン改善) 
   - デザイン案: https://github.com/coderdojo-japan/coderdojo.jp/issues/610#issuecomment-646417313 [![image](https://user-images.githubusercontent.com/155807/85215484-5cc32700-b3b4-11ea-94db-e70344b4f9ee.png)](https://github.com/coderdojo-japan/coderdojo.jp/issues/610#issuecomment-646417313)


## やらないこと

パッと見てどう対応するとベターなのか思いつかったので、一旦後回しにしました >< 💦

- 『集計対象の道場数』に連名道場をうまい感じに反映する (集計対象の場合のみ)
   - 集計できている連名道場 ([西宮・梅田](https://coderdojo-nishinomiya.info/)、[大阪狭山・本町](https://coderdojo-hommachi.doorkeeper.jp/)) と、そうでない連名道場 ([しまね](https://github.com/smalruby/smalruby.jp/wiki/%E9%81%93%E5%A0%B4%E3%81%AE%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0)) があるため、その点を考慮して下記『集計対象の道場数』をカウントする必要がありそうです :eyes: 💭  ![image](https://user-images.githubusercontent.com/155807/85215496-8da35c00-b3b4-11ea-945d-3943c0554eee.png)

当該コード部には TODO コメントを追記 📝 

```ruby
    # 集計方法と集計対象
    # TODO: 'DISTINCT dojo_id' cannot track joint-registrated dojos
    #   cf. https://github.com/coderdojo-japan/coderdojo.jp/issues/610
    @aggregated_dojos   = DojoEventService.count('DISTINCT dojo_id')
```