### PR TITLE
Fix pipeline of Heroku Review Apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,6 +10,11 @@
     "heroku-postgresql",
     "scheduler"
   ],
+  "environments": {
+    "review": {
+      "addons": ["heroku-postgresql:hobby-dev"]
+    }
+  }
   "buildpacks": [
     {
       "url": "heroku/ruby"

--- a/app.json
+++ b/app.json
@@ -21,65 +21,8 @@
     }
   ],
   "env": {
-    "BASIC_AUTH_NAME": {
-      "required": true
-    },
-    "BASIC_AUTH_PASSWORD": {
-      "required": true
-    },
-    "DOORKEEPER_API_TOKEN": {
-      "required": true
-    },
-    "DUMPER_APP_KEY": {
-      "required": true
-    },
-    "FACEBOOK_APP_ID": {
-      "required": true
-    },
-    "FACEBOOK_APP_SECRET": {
-      "required": true
-    },
-    "IDOBATA_HOOK_URL": {
-      "required": true
-    },
-    "LANG": {
-      "required": true
-    },
-    "LETSENCRYPT_REQUEST": {
-      "required": true
-    },
-    "LETSENCRYPT_RESPONSE": {
-      "required": true
-    },
-    "IS_LIVE_SCHEDULED": {
-      "required": true
-    },
-    "RACK_ENV": "staging",
+    "RACK_ENV":  "staging",
     "RAILS_ENV": "staging",
-    "RAILS_SERVE_STATIC_FILES": {
-      "required": true
-    },
-    "SCRIVITO_API_KEY": {
-      "required": true
-    },
-    "SCRIVITO_EMAIL": {
-      "required": true
-    },
-    "SCRIVITO_PASSWORD": {
-      "required": true
-    },
-    "SCRIVITO_TENANT": {
-      "required": true
-    },
-    "SCRIVITO_WORKSPACE": {
-      "required": true
-    },
-    "SECRET_KEY_BASE": {
-      "required": true
-    },
-    "TZ": {
-      "required": true
-    }
   },
   "formation": {
     "web": {

--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
     "review": {
       "addons": ["heroku-postgresql:hobby-dev"]
     }
-  }
+  },
   "buildpacks": [
     {
       "url": "heroku/ruby"
@@ -22,7 +22,7 @@
   ],
   "env": {
     "RACK_ENV":  "staging",
-    "RAILS_ENV": "staging",
+    "RAILS_ENV": "staging"
   },
   "formation": {
     "web": {


### PR DESCRIPTION
Heroku Review Apps are upgraded and need to follow the change.

> The new version of review apps does not support parent apps -
> inherited configuration is specified in app.json or
> in the Pipeline’s configuration variables.

cf. [Review Apps (New) - Heroku Dev Center](https://devcenter.heroku.com/articles/github-integration-review-apps#feature-changes)

cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/907#issuecomment-665622420