### PR TITLE
2020年7月分 Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4322,3 +4322,25 @@
   event_id:
   participants: 1
   evented_at: 2020/06/29 19:00 #オンライン開催
+
+# 2020/07/01 - 2020/07/31
+- dojo_id: 25
+  event_id:
+  participants: 2
+  evented_at: 2020/07/12 10:00
+- dojo_id: 10
+  event_id:
+  participants: 1
+  evented_at: 2020/07/12 10:30
+- dojo_id: 86
+  event_id:
+  participants: 4
+  evented_at: 2020/07/19 10:30 #オンライン開催
+- dojo_id: 103
+  event_id:
+  participants: 0
+  evented_at: 2020/07/20 18:00 #オンライン開催
+- dojo_id: 10
+  event_id:
+  participants: 1
+  evented_at: 2020/07/26 10:30


### PR DESCRIPTION
### やったこと
- 2020年7月分の Facebook イベント集計
- `rails statistics:aggregation[202007,202007,facebook,]`コマンド問題なし ✅