### PR TITLE
2020年8月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4344,3 +4344,33 @@
   event_id:
   participants: 1
   evented_at: 2020/07/26 10:30
+
+# 2020/08/01 - 2020/08/31
+- dojo_id: 23
+  event_id:
+  participants: 2
+  evented_at: 2020/08/09 10:00 #オンライン開催
+- dojo_id: 25
+  event_id:
+  participants: 3
+  evented_at: 2020/08/09 10:00
+- dojo_id: 202
+  event_id:
+  participants: 1
+  evented_at: 2020/08/15 13:00
+- dojo_id: 10
+  event_id:
+  participants: 1
+  evented_at: 2020/08/16 14:00
+- dojo_id: 86
+  event_id:
+  participants: 4
+  evented_at: 2020/08/16 10:30
+- dojo_id: 23
+  event_id:
+  participants: 1
+  evented_at: 2020/08/23 10:00 #オンライン開催
+- dojo_id: 10
+  event_id:
+  participants: 1
+  evented_at: 2020/08/30 14:00


### PR DESCRIPTION
### やったこと
- 2020年8月分のFacebookイベントを集計しました📊
- `rails statistics:aggregation[202008,202008,facebook,]`異常なし ✅
- 追加されたのをコンソールで確認 ✅

```ruby
# 開催数
EventHistory.where(evented_at: (DateTime.now.prev_month.beginning_of_month..DateTime.now.prev_month.end_of_month)).for(:facebook).count
   (8.9ms)  SELECT COUNT(*) FROM "event_histories" WHERE "event_histories"."evented_at" BETWEEN $1 AND $2 AND "event_histories"."service_name" = $3  [["evented_at", "2020-07-31 15:00:00"], ["evented_at", "2020-08-31 14:59:59.999999"], ["service_name", "facebook"]]
=> 7

# 参加者数
EventHistory.where(evented_at: (DateTime.now.prev_month.beginning_of_month..DateTime.now.prev_month.end_of_month)).for(:facebook).sum(:participants) 
  (0.2ms)  SELECT SUM("event_histories"."participants") FROM "event_histories" WHERE "event_histories"."evented_at" BETWEEN $1 AND $2 AND "event_histories"."service_name" = $3  [["evented_at", "2020-07-31 15:00:00"], ["evented_at", "2020-08-31 14:59:59.999999"], ["service_name", "facebook"]]
=> 13
```