### PR TITLE
Update scrivito gem: 1.16.0 -> 1.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'pg'
 gem 'dumper'
 gem 'bootsnap'
 
-gem 'scrivito', '~> 1.16.0'
+gem 'scrivito', '~> 1.17'
 gem 'scrivito_section_widgets'
 gem 'scrivito_teaser_widget'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,38 +323,36 @@ GEM
       tilt (>= 1.1, < 3)
     sassc (2.4.0)
       ffi (~> 1.9)
-    scrivito (1.16.0)
-      scrivito_content_browser (= 1.16.0)
-      scrivito_editors (= 1.16.0)
-      scrivito_sdk (= 1.16.0)
-      scrivito_ui (= 1.16.0)
-    scrivito_content_browser (1.16.0)
+    scrivito (1.17.0)
+      scrivito_content_browser (= 1.17.0)
+      scrivito_editors (= 1.17.0)
+      scrivito_sdk (= 1.17.0)
+      scrivito_ui (= 1.17.0)
+    scrivito_content_browser (1.17.0)
       railties
-      scrivito_sdk (= 1.16.0)
-    scrivito_editors (1.16.0)
+      scrivito_sdk (= 1.17.0)
+    scrivito_editors (1.17.0)
       jquery-ui-rails (>= 5.0.0, < 7.0.0)
       railties
-      scrivito_content_browser (= 1.16.0)
-      scrivito_sdk (= 1.16.0)
-    scrivito_sdk (1.16.0)
+      scrivito_content_browser (= 1.17.0)
+      scrivito_sdk (= 1.17.0)
+    scrivito_sdk (1.17.0)
       addressable (~> 2.3)
       connection_pool (~> 2.2)
       diff-lcs (~> 1.3)
       hyp_diff (~> 0.0.4)
-      jbuilder (~> 2.6)
+      jbuilder (~> 2.10)
       jquery-rails (~> 4.1)
-      json (>= 1.8.6)
+      json (>= 2.0.0)
       memoist (>= 0.12.0)
-      multi_json (~> 1.9)
       multipart-post (~> 2.0)
       nokogiri (~> 1.7)
       rails (~> 5.2.0)
-      rake (>= 0.9.2.2)
     scrivito_section_widgets (1.1.2)
       scrivito
     scrivito_teaser_widget (0.1.2)
       scrivito
-    scrivito_ui (1.16.0)
+    scrivito_ui (1.17.0)
       railties
     secure_headers (6.3.1)
     selenium-webdriver (3.142.7)
@@ -457,7 +455,7 @@ DEPENDENCIES
   rspec-retry
   ruby-mp3info
   sass-rails (>= 5)
-  scrivito (~> 1.16.0)
+  scrivito (~> 1.17)
   scrivito_section_widgets
   scrivito_teaser_widget
   secure_headers


### PR DESCRIPTION
Scrivito gem 1.17.0 or higher started supporting Ruby 2.7+.

cf. https://www.scrivito.com/scrivito-rails-1-17-0-released-79afa2ec5eff3347

> ### Added support for Ruby 2.5, 2.6 and 2.7
> Scrivito now supports Ruby 2.5, 2.6 and 2.7. For details, see the Ruby 2.5.0 release notes and those of subsequent patch versions.
> 
> Scrivito no longer uses the `multi_json` gem. Instead it relies on the `json` gem.