### PR TITLE
:new: Add CoderDojo 室蘭 in 北海道

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1,3 +1,9 @@
+# 室蘭: 未定
+# - dojo_id: 253
+#   name:     ???
+#   group_id: ???
+#   url:      ???
+
 # 岸和田
 - dojo_id: 252
   name: connpass

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -27,6 +27,17 @@
   - ラズベリーパイ
   - Python
   - Unity
+- id: 253
+  order: '012050'
+  created_at: '2020-09-10'
+  name: 室蘭
+  prefecture_id: 1
+  url: https://www.npokuru2.net/coderdojo%E5%AE%A4%E8%98%AD
+  logo: "/img/dojos/japan.png"
+  description: 室蘭市で月1回開催
+  tags:
+  - Scratch
+  - 電子工作
 - id: 100
   order: '012319'
   created_at: '2017-09-20'


### PR DESCRIPTION
### やった事
- 室蘭 Dojo の追加 🎉

```ruby
pry(main)> Dojo.last
  Dojo Load (0.3ms)  SELECT  "dojos".* FROM "dojos" ORDER BY "dojos"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> #<Dojo:0x00007fb434b2e748
 id: 253,
 name: "室蘭",
 email: "",
 order: "012050",
 description: "室蘭市で月1回開催",
 logo: "/img/dojos/japan.png",
 url: "https://www.npokuru2.net/coderdojo%E5%AE%A4%E8%98%AD",
 tags: ["Scratch", "電子工作"],
 created_at: Thu, 10 Sep 2020 19:24:34 JST +09:00,
 updated_at: Thu, 10 Sep 2020 19:24:34 JST +09:00,
 prefecture_id: 1,
 is_active: true,
 is_private: false,
 counter: 1>
```

- `dojo_event` は未定でコメント記載
- 表示、リンク先URLを確認 👀

<img width="240" alt="スクリーンショット 2020-09-10 19 28 39" src="https://user-images.githubusercontent.com/48109243/92717939-086c8980-f39c-11ea-823e-9e7bdf18c039.png">
