### PR TITLE
:new: Add CoderDojo 青梅 in 東京

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1,3 +1,9 @@
+# 青梅: 未定
+# - dojo_id: 254
+#   name:     ???
+#   group_id: ???
+#   url:      ???
+
 # 室蘭: 未定
 # - dojo_id: 253
 #   name:     ???

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -977,6 +977,20 @@
   description: 三鷹周辺で月に1回程度開催
   tags:
   - Scratch
+- id: 254
+  order: '132055'
+  created_at: '2020-09-14'
+  name: 青梅
+  prefecture_id: 13
+  logo: "/img/dojos/japan.png"
+  url: https://coderdojoome.github.io/
+  description: 青梅市で毎月開催
+  tags:
+  - Scratch
+  - Webサイト
+  - Python
+  - ラズベリーパイ
+  - 電子工作
 - id: 228
   order: '132071'
   created_at: '2019-10-11'


### PR DESCRIPTION
青梅 Dojo を追加しました 🎉

```ruby
pry(main)> Dojo.last
  Dojo Load (0.3ms)  SELECT  "dojos".* FROM "dojos" ORDER BY "dojos"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> #<Dojo:0x00007fdd4f1f91c0
 id: 254,
 name: "青梅",
 email: "",
 order: "132055",
 description: "青梅市で毎月開催",
 logo: "/img/dojos/japan.png",
 url: "https://coderdojoome.github.io/",
 tags: ["Scratch", "Webサイト", "Python", "ラズベリーパイ", "電子工作"],
 created_at: Mon, 14 Sep 2020 10:36:31 JST +09:00,
 updated_at: Mon, 14 Sep 2020 10:36:31 JST +09:00,
 prefecture_id: 13,
 is_active: true,
 is_private: false,
 counter: 1>
```

- `dojo_event` は未定でコメント記載
- 表示されること・リンク先へいけることを確認 👀

<img width="233" alt="スクリーンショット 2020-09-14 10 42 08" src="https://user-images.githubusercontent.com/48109243/93035206-5a046500-f677-11ea-91a2-6e10510657b1.png">

