### PR TITLE
ヘッダーがある幅で2行になってしまう問題を修正

### DIFF
--- a/app/assets/stylesheets/extension/header.scss
+++ b/app/assets/stylesheets/extension/header.scss
@@ -116,7 +116,7 @@ body {
     margin-right: 15px;
   }
 }
-@media only screen and (max-width:950px) {
+@media only screen and (max-width:990px) {
   .collapse > .navbar-nav > li > a {
     padding: 15px 8px;
   }


### PR DESCRIPTION
Fix #974

ヘッダーが複数行になってしまう問題(画像参照)を修正しました。
![image](https://user-images.githubusercontent.com/31533303/94756448-87b91000-03d2-11eb-8c82-09701b87249c.png)
