### PR TITLE
2020年10月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4396,3 +4396,17 @@
   event_id:
   participants: 2
   evented_at: 2020/09/20 10:00
+
+# 2020/10/01 - 2020/10/31
+- dojo_id: 25
+  event_id:
+  participants: 2
+  evented_at: 2020/10/11 10:00
+- dojo_id: 86
+  event_id:
+  participants: 2
+  evented_at: 2020/10/18 10:30
+- dojo_id: 131
+  event_id:
+  participants: 3
+  evented_at: 2020/10/18 10:00


### PR DESCRIPTION
### やったこと
- 2020年10月分のFacebookイベントを集計しました📊
- `rails statistics:aggregation[202010,202010,facebook,]`異常なし ✅
- 追加されたのをコンソールで確認 ✅

```ruby
# 開催数
EventHistory.where(evented_at: (DateTime.now.prev_month.beginning_of_month..DateTime.now.prev_month.end_of_month)).for(:facebook).count
   (30.1ms)  SELECT COUNT(*) FROM "event_histories" WHERE "event_histories"."evented_at" BETWEEN $1 AND $2 AND "event_histories"."service_name" = $3  [["evented_at", "2020-09-30 15:00:00"], ["evented_at", "2020-10-31 14:59:59.999999"], ["service_name", "facebook"]]
=> 3

# 参加者数
EventHistory.where(evented_at: (DateTime.now.prev_month.beginning_of_month..DateTime.now.prev_month.end_of_month)).for(:facebook).sum(:participants) 
   (0.6ms)  SELECT SUM("event_histories"."participants") FROM "event_histories" WHERE "event_histories"."evented_at" BETWEEN $1 AND $2 AND "event_histories"."service_name" = $3  [["evented_at", "2020-09-30 15:00:00"], ["evented_at", "2020-10-31 14:59:59.999999"], ["service_name", "facebook"]]
=> 7
```