### PR TITLE
Facebookイベント11月集計Facebookイベント11月集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4406,7 +4406,6 @@
   event_id:
   participants: 2
   evented_at: 2020/10/18 10:30
-
 - dojo_id: 131
   event_id:
   participants: 3

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4406,7 +4406,31 @@
   event_id:
   participants: 2
   evented_at: 2020/10/18 10:30
+
 - dojo_id: 131
   event_id:
   participants: 3
   evented_at: 2020/10/18 10:00
+
+# 2020/11/01 - 2020/11/30
+- dojo_id: 10
+  event_id:
+  participants: 1
+  evented_at: 2020/11/29 16:30 #オンライン開催
+- dojo_id: 12
+  event_id:
+  participants: 5
+  evented_at: 2020/11/07 14:00
+- dojo_id: 25
+  event_id:
+  participants: 3
+  evented_at: 2020/11/08 10:00
+- dojo_id: 86
+  event_id:
+  participants: 5
+  evented_at: 2020/11/15 10:30
+- dojo_id: 131
+  event_id:
+  participants: 3
+  evented_at: 2020/11/29 10:00
+


### PR DESCRIPTION
Facebookイベント11月集計を行いました。
### やったこと
- 2020年11月分のFacebookイベントを集計しました📊
- 追加されたのをコンソールで確認 ✅
