### PR TITLE
2020年12月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4433,3 +4433,36 @@
   participants: 3
   evented_at: 2020/11/29 10:00
 
+# 2020/12/01 - 2020/12/31
+- dojo_id: 12
+  event_id:
+  participants: 3
+  evented_at: 2020/12/12 14:00
+- dojo_id: 23
+  event_id:
+  participants: 7
+  evented_at: 2020/12/13 14:00 #オンライン開催
+- dojo_id: 25
+  event_id:
+  participants: 2
+  evented_at: 2020/12/13 10:00
+- dojo_id: 86
+  event_id:
+  participants: 2
+  evented_at: 2020/12/20 10:30
+- dojo_id: 113
+  event_id:
+  participants: 0
+  evented_at: 2020/12/19 15:15
+- dojo_id: 131
+  event_id:
+  participants: 2
+  evented_at: 2020/12/13 10:00
+- dojo_id: 203
+  event_id:
+  participants: 1
+  evented_at: 2020/12/20 9:30
+- dojo_id: 222
+  event_id:
+  participants: 1
+  evented_at: 2020/12/13 14:00


### PR DESCRIPTION
### やったこと

- 2020年12月分のFacebookイベントを集計しました
- bundle exec rails statistics:aggregation[202012,202012,facebook,] 
<img width="508" alt="スクリーンショット 2021-01-04 15 24 17" src="https://user-images.githubusercontent.com/41533420/103506827-04133180-4ea1-11eb-9dec-93bb05f3cc33.png">
- 追加されたデータをコンソールで確認 
<img width="912" alt="スクリーンショット 2021-01-04 14 59 05" src="https://user-images.githubusercontent.com/41533420/103506835-08d7e580-4ea1-11eb-9d88-894fb69be9e6.png">

