### PR TITLE
2020年12月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4433,3 +4433,36 @@
   participants: 3
   evented_at: 2020/11/29 10:00
 
+# 2020/12/01 - 2020/12/31
+- dojo_id: 12
+  event_id:
+  participants: 3
+  evented_at: 2020/12/12 14:00
+- dojo_id: 23
+  event_id:
+  participants: 7
+  evented_at: 2020/12/13 14:00 #オンライン開催
+- dojo_id: 25
+  event_id:
+  participants: 2
+  evented_at: 2020/12/13 10:00
+- dojo_id: 86
+  event_id:
+  participants: 2
+  evented_at: 2020/12/20 10:30
+- dojo_id: 113
+  event_id:
+  participants: 0
+  evented_at: 2020/12/19 15:15
+- dojo_id: 131
+  event_id:
+  participants: 2
+  evented_at: 2020/12/13 10:00
+- dojo_id: 203
+  event_id:
+  participants: 1
+  evented_at: 2020/12/20 9:30
+- dojo_id: 222
+  event_id:
+  participants: 1
+  evented_at: 2020/12/13 14:00


### PR DESCRIPTION
### やったこと

- 2020年12月分のFacebookイベントを集計しました
- bundle exec rails statistics:aggregation[202012,202012,facebook,]
<img width="725" alt="スクリーンショット 2021-01-04 16 22 31" src="https://user-images.githubusercontent.com/41533420/103511750-f662a980-4eaa-11eb-8fc9-56f2afa79e44.png">

- 追加されたデータをコンソールで確認
<img width="775" alt="スクリーンショット 2021-01-04 16 23 23" src="https://user-images.githubusercontent.com/41533420/103511770-fcf12100-4eaa-11eb-8755-3680148db33f.png">

