### PR TITLE
塩尻のURLを修正

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1510,7 +1510,7 @@
   created_at: '2012-11-08'
   name: 塩尻
   prefecture_id: 20
-  url: http://coderdojo.shiojiri-osslabo.com/
+  url: https://coderdojo.shiojiri.fun/
   logo: "/img/dojos/shiojiri.png"
   description: 塩尻市で毎月開催
   tags:


### PR DESCRIPTION
とおりすがりにたまたま無効なURLとなっているのを見かけたので新しいもの(?)に修正しました。