### PR TITLE
ヘッダーにセクションが埋まらない仕様のリファクタリング

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -940,3 +940,8 @@ body>footer a:hover {
     color: #2275CA;
   }
 }
+
+section {
+  scroll-margin-top: 70px;
+  scroll-snap-align: center;
+}

--- a/app/views/home/show.html.haml
+++ b/app/views/home/show.html.haml
@@ -61,8 +61,6 @@
     %script{src: "https://apis.google.com/js/platform.js"}
   %br
   = render partial: 'shared/social_buttons'
-  %br
-  %div#dojos
 
 /
   %section#events.detail-introduction.text-center
@@ -77,7 +75,7 @@
     オンライン開催! 早めにお申し込みください 😆🎫✨
 
 
-%section.dojos.text-center.grayscale-bg
+%section.dojos.text-center.grayscale-bg#dojos
   %br
   %h2{style: "color: dimgray;"} 🗾 日本各地の道場
   %br
@@ -115,7 +113,7 @@
       %a{href: "https://www.youtube.com/CoderDojoJapan",
          target: "_blank", rel: "external noopener"} 📺 YouTube
       など、様々な方法で CoderDojo の最新情報を発信しています。お好みの方法で最新情報をキャッチしてみよう！
-  
+
     %ul{style: "list-style: none;"}
       %li
         %a{href: "/kata"} 📑 Kata (型)
@@ -166,8 +164,6 @@
                           'data-src' => '/kata_cover.jpg', loading: 'lazy',
                             style: 'margin-bottom: 15px;'), '/kata'
       %a.button-to-details{href: '/kata'} Kata を読む
-    %br
-    %div#partners
 
 = render partial: 'shared/partners'
 %section.detail-introduction.partners_logo.text-center
@@ -175,11 +171,11 @@
   %div.kata{style: 'margin-bottom: 100px;'}
     %a.button-to-details{href: '/partnership'} パートナーシップの詳細を読む
 
-%div#news{style: "padding-bottom: 30px;"}
+%div{style: "padding-bottom: 30px;"}
 
 / Start with 'div' not 'section' due to grayscale-bg area
 .text-center.grayscale-bg
-  %section.detail-introduction
+  %section.detail-introduction#news
     %br
     %h2{style: "color: dimgray;"} 📰 ニュースレター購読
     %br
@@ -192,9 +188,8 @@
           過去の配信を読んでみる
         )
     = render partial: 'shared/newsletter'
-  %div#contact{style: "padding-bottom: 40px;"}
-  
-%section#faq.detail-introduction
+
+%section#faq.detail-introduction#contact
   %br
   %h2.text-center{style: "color: dimgray;"} ✅ よくある質問と回答
   %br
@@ -236,7 +231,6 @@
         A．
         %a{href: '/kata'}<> 📚 道場情報まとめ
         にあります！運営に関わってみたい方はぜひ 😉
-  %div#contact
 
 %section.detail-introduction.text-center
   %br
@@ -247,7 +241,6 @@
     %br
     %br
   / Contact Form via Wufoo
-  #contact
   #wufoo-qkjthoy0qpuvg9{style: "margin-top: -10px"}
     %a{href: "https://yasslab.wufoo.com/forms/qkjthoy0qpuvg9",
        target: "_blank", rel: "external noopener"}> 問い合わせフォーム

--- a/app/views/shared/_partners.haml
+++ b/app/views/shared/_partners.haml
@@ -1,4 +1,4 @@
-%section.detail-introduction.partners_logo.text-center
+%section.detail-introduction.partners_logo.text-center#partners
   %br
   %h2{style: "color: dimgray;"} 🤝 パートナー法人
   :javascript
@@ -42,8 +42,7 @@
     %li= link_to image_tag('/spinner.svg', 'data-src' => '/partners/github.png', alt: 'GitHub', class: 'lazyload', loading: 'lazy', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'GitHub for Nonprofit の提供'), 'https://news.coderdojo.jp/2019/08/29/github-for-nonprofit/', target: "_blank", rel: "noopener"
     %li= link_to image_tag('/spinner.svg', 'data-src' => '/partners/wro.png', alt: 'WRO Japan', class: 'lazyload', loading: 'lazy', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'ロボットキットの提供'), 'https://news.coderdojo.jp/2019/12/21/wro-japan-and-coderdojo-japan/', target: "_blank", rel: "noopener"
 
-    %li= link_to image_tag('/spinner.svg', 'data-src' => '/partners/hackforplay.png', alt: 'HackforPlay', class: 'lazyload', loading: 'lazy', data: { toggle: 'tooltip', placement: 'bottom' }, title: '法人向け HackforPlay の提供'), 'https://news.coderdojo.jp/2020/04/06/hackforplay-for-team/', target: "_blank", rel: "noopener"  
+    %li= link_to image_tag('/spinner.svg', 'data-src' => '/partners/hackforplay.png', alt: 'HackforPlay', class: 'lazyload', loading: 'lazy', data: { toggle: 'tooltip', placement: 'bottom' }, title: '法人向け HackforPlay の提供'), 'https://news.coderdojo.jp/2020/04/06/hackforplay-for-team/', target: "_blank", rel: "noopener"
     %li= link_to image_tag('/spinner.svg', 'data-src' => '/partners/google.png', alt: 'Google', class: 'lazyload', loading: 'lazy', data: { toggle: 'tooltip', placement: 'bottom' }, title: '活動資金に対する支援'), 'https://news.coderdojo.jp/2019/11/13/google-and-coderdojo-join-forces-in-japan/', target: "_blank", rel: "noopener"
 
     %li= link_to image_tag('/spinner.svg', 'data-src' => '/partners/tfabworks.png', alt: 'TFabWorks', class: 'lazyload', loading: 'lazy', data: { toggle: 'tooltip', placement: 'bottom' }, title: '無償レンタルプログラムの提供'), 'https://news.coderdojo.jp/2020/11/26/tfabworks-microbit-rental-program/', target: "_blank", rel: "noopener"
-    


### PR DESCRIPTION
close https://github.com/yasslab/anything/issues/102

id付きのリンク(例: https://coderdojo.jp/#dojos )に飛ぶと、ヘッダーに埋まってしまう問題がありました。
idの記述箇所を変えることで対応されていましたが、今回のPRではCSSでの修正に置き換えました。

![image](https://user-images.githubusercontent.com/31533303/107000881-fc121e80-67cb-11eb-9b00-32dc1449899d.png)
