### PR TITLE
しまねのDojo数を修正

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -2416,7 +2416,7 @@
   order: '320005'
   created_at: '2019-09-06'
   name: しまね
-  counter: 6
+  counter: 7
   prefecture_id: 32
   logo: "/img/dojos/japan.png"
   url: https://github.com/smalruby/smalruby.jp/wiki/道場のフォーム


### PR DESCRIPTION
「CoderDojo しまね」ウェブサイトに記載の7つのDojoのうち、益田が 2021/02/04 付でverifiedされていたので老婆心ながらPRだします