### PR TITLE
藤井寺Dojo イベントサービス追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -4,11 +4,11 @@
   group_id: 11610
   url: https://coderdojo-hachinohe.doorkeeper.jp/
 
-# 藤井寺: イベントサービス未定
-# - dojo_id: 264
-#   name:     ???
-#   group_id: ???
-#   url:      ???
+# 藤井寺
+- dojo_id: 264
+  name: doorkeeper
+  group_id: 11663
+  url: https://coderdojo-fujiidera.doorkeeper.jp/
 
 # 浦和@Urawa Minecraft Club
 - dojo_id: 263


### PR DESCRIPTION
### やったこと
[「統計システムへの追加」](https://github.com/coderdojo-japan/coderdojo.jp/blob/master/docs/how-to-add-dojo.md#%E7%B5%B1%E8%A8%88%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0%E3%81%B8%E3%81%AE%E8%BF%BD%E5%8A%A0)の手順で、藤井寺Dojoのイベントサービスを追加し、近日開催イベントに情報が載るようにしました🙆‍♀️

<img width="565" alt="スクリーンショット 2021-03-13 22 09 59" src="https://user-images.githubusercontent.com/48109243/111031025-dcb08600-8448-11eb-8875-ca6fe1107c1e.png">
