### PR TITLE
2020年の統計データを追加

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -2,8 +2,8 @@ class StatsController < ApplicationController
   def show
     @url                 = request.url
 
-    # 2012年1月1日〜2019年12月31日までの集計結果
-    period        = Time.zone.local(2012).beginning_of_year..Time.zone.local(2019).end_of_year
+    # 2012年1月1日〜2020年12月31日までの集計結果
+    period        = Time.zone.local(2012).beginning_of_year..Time.zone.local(2020).end_of_year
     stats         = Stat.new(period)
 
     # 推移グラフ

--- a/app/models/high_charts_builder.rb
+++ b/app/models/high_charts_builder.rb
@@ -33,7 +33,7 @@ class HighChartsBuilder
         f.series(type: 'line',   name: '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
           { title: { text: '開催回数' }, tickInterval:  400, max: 2000 },
-          { title: { text: '累積合計' }, tickInterval: 1000, max: 5000, opposite: true }
+          { title: { text: '累積合計' }, tickInterval: 1200, max: 6000, opposite: true }
         ]
         f.chart(width: 600, alignTicks: false)
         f.colors(["#F4C34F", "#BD2561"])
@@ -50,7 +50,7 @@ class HighChartsBuilder
         f.series(type: 'line',   name: '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
           { title: { text: '参加者数' }, tickInterval: 2500, max: 12500 },
-          { title: { text: '累積合計' }, tickInterval: 6000, max: 30000, opposite: true }
+          { title: { text: '累積合計' }, tickInterval: 8000, max: 40000, opposite: true }
         ]
         f.chart(width: 600, alignTicks: false)
         f.colors(["#EF685E", "#35637D"])


### PR DESCRIPTION
### やったこと
統計情報に2020年のデータを追加しました📊✨
https://coderdojo.jp/stats

<img width="700" alt="スクリーンショット 2021-03-23 12 57 48" src="https://user-images.githubusercontent.com/48109243/112090695-67c31600-8bd7-11eb-9f0f-d53287db73f2.png">
<img width="718" alt="スクリーンショット 2021-03-23 12 57 59" src="https://user-images.githubusercontent.com/48109243/112090700-68f44300-8bd7-11eb-8a18-8dc2ccae9f2c.png">

### 気になること
モバイル時、2020年分が増えて横幅`width: 100%`に入らなくなったため、「道場数」が改行になってしまった👀
<img width="375" alt="スクリーンショット 2021-03-23 12 59 00" src="https://user-images.githubusercontent.com/48109243/112090779-8b865c00-8bd7-11eb-85e1-e1e782bc3ff5.png">

