### PR TITLE
2021年03月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4498,3 +4498,21 @@
   event_id:
   participants: 0
   evented_at: 2021/02/21 10:00
+
+# 2021/03/01 - 2021/03/31
+- dojo_id: 86
+  event_id:
+  participants: 2
+  evented_at: 2021/03/21 10:30
+- dojo_id: 113
+  event_id:
+  participants: 0
+  evented_at: 2021/03/20 15:15
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2021/03/21 10:00
+- dojo_id: 203
+  event_id:
+  participants: 1
+  evented_at: 2021/03/21 9:30


### PR DESCRIPTION
やったこと

- 2021年03月分のFacebookをイベント集計しました
- `bundle exec rails statistics:aggregation[202101,202101,facebook,]`を実行して異常なし
- 追加されたデータをコンソールで確認

（別途Idobataにスクショ有り）