### PR TITLE
近日開催予定の一覧に「ポケモン」タグを表示

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -781,6 +781,18 @@ body>footer a:hover {
   }
 }
 
+.event-tag-pokemon {
+  background-color: $lightblue;
+  font-weight: bold;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+.event-tag-pokemon-cover {
+  text-align: left;
+  padding: 0 10px;
+}
+
 
 .event>p {
   margin: 10px;

--- a/app/views/events/_upcoming_events.html.haml
+++ b/app/views/events/_upcoming_events.html.haml
@@ -15,3 +15,6 @@
             %a.event-url{ href: "#{event[:event_url]}" }
               %span= event[:event_title]
             %span= "(#{event[:dojo_name]})"
+            - if event[:event_title].include? 'ポケモン'
+              %div.event-tag-pokemon-cover
+                %span.event-tag-pokemon ポケモン


### PR DESCRIPTION
ポケモン対応の有無がわかるよう、タグ表示を実装しました。

タイトルに「ポケモン」の文字列が含まれると表示されます。

表示イメージです🔽 
![image](https://user-images.githubusercontent.com/31533303/115171278-afb55a00-a0fd-11eb-8ef1-ab498acad586.png)
