### PR TITLE
ポケモン素材ダウンロードページにクレジット表記追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -998,3 +998,8 @@ section {
   background: #ffefdd;
   margin: 10px 20px;
 }
+
+.pokemon-notes {
+  font-size: 12px;
+  color: #909090;
+}

--- a/app/views/pokemons/new.html.haml
+++ b/app/views/pokemons/new.html.haml
@@ -52,4 +52,10 @@
         = f.label     :term_of_use, "上記の利用規約（全文）に同意する", style: "display:inline"
 
       = f.submit "申し込む", class: "form__submit"
+      %p.pokemon-notes
+        Scratch（スクラッチ）は、Scratch財団がMITメディアラボのライフロング・キンダーガーテン・グループの協力により開発しているプロジェクトです。https://scratch.mit.edu から自由に入手できます。
+        %br
+        ©2021 Pokémon. ©1995-2021 Nintendo/Creatures Inc./GAME FREAK inc.
+        %br
+        ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの登録商標です。
     /%p{style: "color: gray; text-align: center; padding-bottom: 30px"} 回答のコピーがメールで送信されます。


### PR DESCRIPTION
表記を追加しました。
![image](https://user-images.githubusercontent.com/31533303/115673459-9d4e5100-a387-11eb-88b6-0ed3325e23de.png)
