### PR TITLE
近日開催の道場のトップにポケモンWSを自動で表示する

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,7 @@ class EventsController < ApplicationController
   def index
     @url             = request.url
     @upcoming_events = UpcomingEvent.group_by_prefecture
+    @pokemon_events  = UpcomingEvent.group_by_keyword('ポケモン')
 
     respond_to do |format|
       format.html

--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -26,6 +26,12 @@ class UpcomingEvent < ApplicationRecord
       end
       result
     end
+
+    def group_by_keyword(keyword)
+      eager_load(dojo_event_service: :dojo).since(Time.zone.today).
+        merge(Dojo.default_order).
+        where('event_title like(?)', "%#{keyword}%")
+    end
   end
 
   def catalog

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -18,11 +18,14 @@
     /です)
 
   %p.event-notice{style: "margin-top: 30px; margin-bottom: 60px;"}
-    🆕 
-    %a{href: "https://bit.ly/pokemon-special-workshop-in-kashiwa", target: "_blank", rel: "external noopener"} プログラミングでポケモンをうごかしてみよう
+    🆕 ポケモン・ワークショップ開催中！
     %br
     %small
-      5月16日 (日曜) 午前10時からオンライン開催
+      %a{href: "https://bit.ly/pokemon-special-workshop-in-kashiwa", target: "_blank", rel: "external noopener"} 5月16日 10:00〜 @ Kashiwa
+    %br
+    - @pokemon_events.each do |event|
+      %a{href: "#{event.event_url}", target: "_blank", rel: "external noopener"}
+        %small #{event.event_at.strftime('%-m月%d日 %H:%M〜')} @ #{event.dojo_event_service.dojo.name}
 
   = render partial: 'upcoming_events', locals: { upcoming_events: @upcoming_events }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/155807/118073019-030d8600-b3e6-11eb-98d5-7587a70ce8ce.png)

Kashiwa 以外の CoderDojo もワークショップ開催準備を始めており、
１つずつ掲載・非掲載の対応をしていくと対応コストの増加が見込まれるため、
「ポケモン」に部分一致するイベント名をトップに表示する仕組みにしました。

cf. プログラミングでポケモンを動かすワークショップが、全国のCoderDojoで実施可能に。
https://news.coderdojo.jp/2021/04/23/programming-with-pokemon/

📝 NOTE: CoderDojo Kashiwa のみ UpcomingEvents テーブルに含まれていないデータのため、手動で掲載・非掲載の対応をしています。