### PR TITLE
change subdomain of CoderDojo東住吉 with `cd-hisumi`

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -26,7 +26,7 @@
 - dojo_id: 266
   name: doorkeeper
   group_id: 11772
-  url: https://coderdojohigashisumiyoshi.doorkeeper.jp/
+  url: https://cd-hisumi.doorkeeper.jp/
 
 # 八戸
 - dojo_id: 265

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -2013,7 +2013,7 @@
   name: 東住吉
   prefecture_id: 27
   logo: "/img/dojos/higashi-sumiyoshi.svg"
-  url: https://coderdojo-higashi-sumiyoshi.github.io/
+  url: https://cd-hisumi.github.io/
   description: 大阪市東住吉区で不定期開催
   tags:
   - Scratch


### PR DESCRIPTION
CoderDojo東住吉 の`やまおか`です。いつも お世話になっております 🙇 

subdomainの `coderdojo-higashisumiyoshi` が長く打ち間違いが多いようで、subdomain名を変更させて下さい。