### PR TITLE
Scrivito のルーティングを削除

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
 
   # Default Scrivito routes. Adapt them to change the routing of CMS objects.
   # See the documentation of 'scrivito_route' for a detailed description.
-  scrivito_route '/',              using: 'homepage'
-  scrivito_route '(/)(*slug-):id', using: 'slug_id'
-  scrivito_route '/*permalink',    using: 'permalink', format: false
+  #scrivito_route '/',              using: 'homepage'
+  #scrivito_route '(/)(*slug-):id', using: 'slug_id'
+  #scrivito_route '/*permalink',    using: 'permalink', format: false
 end


### PR DESCRIPTION
Scrivito の制限にかかってしまってエラーになって、本番環境にアクセスできなくなっているので、
それを回避するために scrivito を使ってるパスをコメントアウトしました。

```
2021-06-08T07:35:23.449227+00:00 app[web.1]: [4] ! Unable to load application: Scrivito::ClientError: Your tenant reached its maximum Obj count (37868/10000)
2021-06-08T07:35:23.449255+00:00 app[web.1]: bundler: failed to load command: puma (/app/vendor/bundle/ruby/2.7.0/bin/puma)
```