### PR TITLE
`config/database.yml` で直接設定の指定を行わ無いようにしたい

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATABASE_HOST: localhost
+      DATABASE_USER: postgres
+      DATABASE_PASSWORD: password
+      DATABASE_PORT: 5432
       TZ: Asia/Tokyo
       SCRIVITO_EMAIL: test@example.com
       SCRIVITO_PASSWORD: testpassword

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,10 +20,10 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV.fetch('DATABASE_USER') { 'postgres' } %>
-  password: <%= ENV.fetch('DATABASE_PASSWORD') { 'password' } %>
-  host: <%= ENV.fetch('DATABASE_HOST') { 'db' } %>
-  port: <%= ENV.fetch('DATABASE_PORT') { '5432' } %>
+  username: <%= ENV.fetch('DATABASE_USER') { '' } %>
+  password: <%= ENV.fetch('DATABASE_PASSWORD') { '' } %>
+  host: <%= ENV.fetch('DATABASE_HOST') { '' } %>
+  port: <%= ENV.fetch('DATABASE_PORT') { '' } %>
 
 development:
   <<: *default


### PR DESCRIPTION
##  やりたいこと

`config/database.yml` で hostname などの指定があるためエラーになりました。ファイルでは直接 hostname などの指定を行わ無い様にしたい。理由としては、複数のプロジェクトで db 周りを使っており、何も指定し無いことで共通化しているので、今後もこのような運用でやっていきたい。

```
PG::ConnectionBad: could not translate host name "db" to address: nodename nor servname provided, or not known
```