### PR TITLE
Setup default localhost db config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      DATABASE_HOST: localhost
-      DATABASE_USER: postgres
-      DATABASE_PASSWORD: password
-      DATABASE_PORT: 5432
       TZ: Asia/Tokyo
       SCRIVITO_EMAIL: test@example.com
       SCRIVITO_PASSWORD: testpassword

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,10 +20,10 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV.fetch('DATABASE_USER') { '' } %>
-  password: <%= ENV.fetch('DATABASE_PASSWORD') { '' } %>
-  host: <%= ENV.fetch('DATABASE_HOST') { '' } %>
-  port: <%= ENV.fetch('DATABASE_PORT') { '' } %>
+  username: <%= ENV.fetch('DATABASE_USER') { 'postgres' } %>
+  password: <%= ENV.fetch('DATABASE_PASSWORD') { 'password' } %>
+  host: <%= ENV.fetch('DATABASE_HOST') { 'localhost' } %>
+  port: <%= ENV.fetch('DATABASE_PORT') { '5432' } %>
 
 development:
   <<: *default


### PR DESCRIPTION
## 背景

> `ENV.fetch` に書かれていた値は対象の環境変数がないときのデフォルト値です。その何も指定しないことにしたのも昔の僕のようですが、デフォルト値を設定しないことにメリットはないので、環境の違いは環境変数で切り替えるようにすればいいかと思いました。エスパーすると、`ローカルサーバー` とおっしゃっているので、何も環境変数を設定していない結果、ただデフォルトの `localhost` につなぎにいって失敗されているのでしょう。`docker` を基準に環境は数年前に作ったのでデフォルト値もそれを基準としています。

cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1317#issuecomment-878236548

## やったこと

default の設定はあったほうが良さそうなので、設定しました。docker の場合は `env.sample`  で指定があるので、ローカルで利用しやす様に、何も設定して無いローカルのdbを基準に設定しました。


## 確認方法

`bin/setup` を実行できる
