### PR TITLE
柏原Dojo イベントサービスの group_idを追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1,8 +1,8 @@
 # 柏原
-# - dojo_id: 271
-#   name: Doorkeeper #イベントページなし
-#   group_id: ???
-#   url: https://coderdojo-kashiwara.doorkeeper.jp/
+- dojo_id: 271
+  name: doorkeeper
+  group_id: 11894
+  url: https://coderdojo-kashiwara.doorkeeper.jp/
 
 # 長門: 未定
 # - dojo_id: 270


### PR DESCRIPTION
柏原Dojo [第１回イベント](https://coderdojo-kashiwara.doorkeeper.jp/events/123624)が Doorkeeper に追加されたので、`group_id`を追加し、「近日開催の道場」に表示されるようにしました🙆‍♀️

<img width="252" alt="スクリーンショット 2021-07-16 10 44 57" src="https://user-images.githubusercontent.com/48109243/125879341-099233ba-c515-4810-aeda-d3b30bdaf3f4.png">
