### PR TITLE
コラボレーター未満の権限だとsecretにアクセスできないのでrspecを場合分けする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,9 @@ jobs:
         run: |
           bundle exec rails db:create
           bundle exec rails db:setup
-      - name: rspec
+      - name: rspec with scrivito
+        if: ${{ github.repository_owner == 'coderdojo-japan' }}
         run: bundle exec rails spec
+      - name: rspec without scrivito 
+        if: ${{ github.repository_owner != 'coderdojo-japan' }}
+        run: bundle exec rspec spec --tag ~@scrivito


### PR DESCRIPTION
https://github.com/coderdojo-japan/coderdojo.jp/issues/1328
