### PR TITLE
KorairaのPeatixページを追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -300,10 +300,14 @@
   name: connpass
   group_id: 3809
   url: https://coderdojokodaira-ninja.connpass.com/
-- dojo_id: 13
+- dojo_id: 13 #実態はGoogleフォームで管理
   name: connpass
   group_id: 11719
   url: https://coderdojo-jp-kodaira.connpass.com/
+- dojo_id: 13 #Googleフォームで管理しているものとは「別枠」（裾野拡大目的の企画モノ専用）
+  name: peatix
+  group_id: 
+  url: https://coderdojo-kodaira-study.peatix.com/
 
 - dojo_id: 14
   name: peatix


### PR DESCRIPTION
connpassの追加のついでに、単発のワークショップ等はPeatixのみで募集をかけている（過去の統計にも掲載していない）ので、念のためにこちらも追加します。