### PR TITLE
Change notification format: HTML -> Markdown

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,5 +93,4 @@ jobs:
           hookUrl: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}
           format: 'markdown'
           message: |
-            CI build for [${{ env.COMMIT_LINK }}](${{ env.COMMIT_URL }}) : <span class='label label-${{ env.STATUS_LABEL }}'>${{ env.STATUS_TEXT }}</span> ([GitHub Actions](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}))<br>
-            <img src='https://github.com/${{ env.COMMIT_ACTOR }}.png' class='icon-rounded' width='16' height='16'> [${{ env.COMMIT_ACTOR }}](https://github.com/${{ env.COMMIT_ACTOR }}): ${{ env.COMMIT_MESSAGE }} ([${{ env.COMMIT_SHA }}](https://github.com/${{ github.repository }}/commit/${{ env.COMMIT_SHA }}))
+            CI build for [${{ env.COMMIT_LINK }}](${{ env.COMMIT_URL }}) : <span class='label label-${{ env.STATUS_LABEL }}'>${{ env.STATUS_TEXT }}</span> ([GitHub Actions](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}))<br><img src='https://github.com/${{ env.COMMIT_ACTOR }}.png' class='icon-rounded' width='16' height='16'> [${{ env.COMMIT_ACTOR }}](https://github.com/${{ env.COMMIT_ACTOR }}): ${{ env.COMMIT_MESSAGE }} ([${{ env.COMMIT_SHA }}](https://github.com/${{ github.repository }}/commit/${{ env.COMMIT_SHA }}))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,9 +91,7 @@ jobs:
         uses: mahaker/actions-idobata@v1.1.1
         with:
           hookUrl: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}
-          format: 'html'
+          format: 'markdown'
           message: |
-            <div>
-            CI build for <a href='${{ env.COMMIT_URL }}'>${{ env.COMMIT_LINK }}</a> : <span class='label label-${{ env.STATUS_LABEL }}'>${{ env.STATUS_TEXT }}</span> (<a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'>GitHub Actions</a>)<br>
-            <img src='https://github.com/${{ env.COMMIT_ACTOR }}.png' class='icon-rounded' width='16' height='16'> <a href='https://github.com/${{ env.COMMIT_ACTOR }}'>${{ env.COMMIT_ACTOR }}</a>: ${{ env.COMMIT_MESSAGE }} (<a href='https://github.com/${{ github.repository }}/commit/${{ env.COMMIT_SHA }}'>${{ env.COMMIT_SHA }}</a>)
-            </div>
+            CI build for [${{ env.COMMIT_LINK }}](${{ env.COMMIT_URL }}) : <span class='label label-${{ env.STATUS_LABEL }}'>${{ env.STATUS_TEXT }}</span> ([GitHub Actions](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}))<br>
+            <img src='https://github.com/${{ env.COMMIT_ACTOR }}.png' class='icon-rounded' width='16' height='16'> [${{ env.COMMIT_ACTOR }}](https://github.com/${{ env.COMMIT_ACTOR }}): ${{ env.COMMIT_MESSAGE }} ([${{ env.COMMIT_SHA }}](https://github.com/${{ github.repository }}/commit/${{ env.COMMIT_SHA }}))


### PR DESCRIPTION
This is sample markdown text to test notification format:

## Sample Markdown text

Bump google-apis-drive_v3 from 0.11.0 to 0.12.0 Bumps [google-apis-drive_v3](https://github.com/googleapis/google-api-ruby-client) from 0.11.0 to 0.12.0. - [Release notes](https://github.com/googleapis/google-api-ruby-client/releases) - [Changelog](https://github.com/googleapis/google-api-ruby-client/blob/master/generated/google-apis-drive_v3/CHANGELOG.md) - [Commits](https://github.com/googleapis/google-api-ruby-client/compare/0.11.0...0.12.0) Signed-off-by: dependabot-preview[bot] (94c6cf6d)