### PR TITLE
Switching from SoundCloud to Anchor.fm podcasts

### DIFF
--- a/anchorfm_sample.rss
+++ b/anchorfm_sample.rss
@@ -1,0 +1,720 @@
+<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:anchor="https://anchor.fm/xmlns">
+	<channel>
+		<title><![CDATA[DojoCast]]></title>
+		<description><![CDATA[CoderDojo コミュニティに関わる人々をハイライトするポッドキャスト番組です 📻✨]]></description>
+		<link>https://coderdojo.jp/podcasts</link>
+		<image>
+			<url>https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg</url>
+			<title>DojoCast</title>
+			<link>https://coderdojo.jp/podcasts</link>
+		</image>
+		<generator>Anchor Podcasts</generator>
+		<lastBuildDate>Fri, 23 Jul 2021 05:34:53 GMT</lastBuildDate>
+		<atom:link href="https://anchor.fm/s/54d501e8/podcast/rss" rel="self" type="application/rss+xml"/>
+		<author><![CDATA[一般社団法人 CoderDojo Japan]]></author>
+		<copyright><![CDATA[一般社団法人 CoderDojo Japan]]></copyright>
+		<language><![CDATA[ja]]></language>
+		<atom:link rel="hub" href="https://pubsubhubbub.appspot.com/"/>
+		<itunes:author>一般社団法人 CoderDojo Japan</itunes:author>
+		<itunes:summary>CoderDojo コミュニティに関わる人々をハイライトするポッドキャスト番組です 📻✨</itunes:summary>
+		<itunes:type>episodic</itunes:type>
+		<itunes:owner>
+			<itunes:name>一般社団法人 CoderDojo Japan</itunes:name>
+			<itunes:email>podcasts60+54d501e8@anchor.fm</itunes:email>
+		</itunes:owner>
+		<itunes:explicit>No</itunes:explicit>
+		<itunes:category text="Education"/>
+		<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		<item>
+			<title><![CDATA[023 - みん経ネットワークと CoderDojo]]></title>
+			<description><![CDATA[<p>CoderDojo の活動を計３０回以上取材していただいた『みんなの経済新聞ネットワーク』編集長の西さんと、高田馬場経済新聞や CASE Shinjuku を運営されている森下さんをお迎えして、 ・みん経に載った活動の例 ・活動を周知/広報するコツ ・メディア掲載までの流れ などについてお伺いしました! 🎤 👥 みんなの経済新聞ネットワーク https://minkei.net/ また、JR 高田馬場駅 (東京感動線) のご協力のもと、本をテーマにしたカフェ『STAND by bookandbedtokyo』を会場として提供していただきました。 https://twitter.com/tokyo_moving_o/status/1373486799612305408</p>
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/023----CoderDojo-euhitu</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-23</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Sun, 21 Mar 2021 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033726/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717541-44100-2-6210ccff39d4b870.mp3" length="29729853" type="audio/mpeg"/>
+			<itunes:summary>&lt;p&gt;CoderDojo の活動を計３０回以上取材していただいた『みんなの経済新聞ネットワーク』編集長の西さんと、高田馬場経済新聞や CASE Shinjuku を運営されている森下さんをお迎えして、 ・みん経に載った活動の例 ・活動を周知/広報するコツ ・メディア掲載までの流れ などについてお伺いしました! 🎤 👥 みんなの経済新聞ネットワーク https://minkei.net/ また、JR 高田馬場駅 (東京感動線) のご協力のもと、本をテーマにしたカフェ『STAND by bookandbedtokyo』を会場として提供していただきました。 https://twitter.com/tokyo_moving_o/status/1373486799612305408&lt;/p&gt;
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>1858</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+			<itunes:episode>23</itunes:episode>
+			<itunes:episodeType>full</itunes:episodeType>
+		</item>
+		<item>
+			<title><![CDATA[022 - DojoCon Japan 2020 ふりかえり]]></title>
+			<description><![CDATA[DojoCon Japan 2020 共同実行委員長の曽我さん (@ymsg19)、宮島さん (@kiriem_) をゲストにお迎えして、DojoCon Japan 2020 の後日談についてお伺いました 🎤👥 ラジオ感覚で聴いていただけると嬉しいです 😌🎶
+
+DojoCon Japan 2020 - Beyond the Distance (距離を超えて) https://dojocon2020.coderdojo.jp/
+
+DojoCon Japan 2020 - YouTube
+https://www.youtube.com/playlist?list=PL_XgRvFvKBPZOwlkFq89AzWYsyp8tMD4s
+
+当日の投稿まとめ - Togetter
+https://togetter.com/li/1644235
+
+0:00 ゲスト自己紹介：曽我さん https://twitter.com/ymsg19
+0:36 ゲスト自己紹介：宮島さん https://twitter.com/kiriem_
+1:44 DojoCon Japan 2020 とは? https://dojocon2020.coderdojo.jp/
+3:36 DojoCon Japan 2020 のキッカケ『自分でアクションを起こす』
+4:52 DojoCon Japan 2018 の開催経験が、オンライン開催にも活きた
+6:56 ３ヶ月で、３００人規模のイベントが開催できた
+7:49 実行委員の経験が０でも、実行委員長になれた
+8:54 早く意思決定できる仕組みと、新しい試みを推奨する心持ち
+11:04 参加者の感想『失敗しても許される雰囲気・空気感が良かった』
+11:36 実行委員１人１人の裁量を大きく、ボトルネックを解決していった
+12:27 共同実行委員長の間では、頻繁にコミュニケーションをとっていた
+13:38 新企画『カウントダウン DojoCon Japan』の趣旨 https://www.youtube.com/playlist?list=PL_XgRvFvKBPa_Z5hiRAK4sJcRWqCD8eV_
+15:21 オンライン開催では、当日に使うツールを紹介する場があると良い
+16:39 盛り上がりを作り、実行委員もツールを試せる、一石二鳥の試み
+18:04 実行委員の目線でも、他のチームの動きが見渡せて、一石三鳥！？
+19:38 DojoCon Japan 2020 の実行委員は７５名以上。全体は３回のみ
+21:07 全体ミーティングの発言者は少数、聴く人が多数。カウントダウンで十分？
+22:56 DojoCon Japan 2020 開催前日から、開催当日までの動き
+26:00 『oVice』とは？oViceで参加者の対話を促せた https://ovice.in/ja/
+27:58 『oVice』の良さを知るには、実際に体験してみるのが一番良い
+28:59 DojoCon Japan 2020 セッション例『Scratch × 機械学習』
+30:18 DojoCon Japan 2020 セッション例『オンライン vs. オフライン対談』
+32:05 DojoCon Japan 2020 企画例『交流室』- 話しかけやすさを大切に
+34:45 オンラインでも、さまざまな地域の方が話し合える場を実現できた
+36:03 コメント『素晴らしいイベントでした！楽しく、勉強になりました』
+36:27 当日の様子まとめ (Togetter) https://togetter.com/li/1644235
+37:03 当日の動画まとめ (YouTube) https://www.youtube.com/playlist?list=PL_XgRvFvKBPZOwlkFq89AzWYsyp8tMD4s
+37:24 DojoCon Japan 2020 ワークショップ例『ポケモン × CoderDojo』
+40:17 コメント『ポケモンワークショップに参加しました！』
+41:42 DojoCon Japan 2020 ふりかえり『走り抜けて、見えた風景』
+45:14 DojoCon Japan 2020 ふりかえり『新しい価値を作っていく』
+46:30 トライ＆エラーを繰り返し、『分からない→分かる』が増えた
+48:34 宮島さんのメッセージ『コミュニティの自信。スポンサーへの感謝』
+52:11 曽我さんのメッセージ『実行委員/参加者への感謝。次へのステップ』
+55:25 まとめ。色々な変化に対応し、新しいことにチャレンジし続けよう
+
+#CoderDojo #DojoCast #DojoConJapan
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/022---DojoCon-Japan-2020-euhiui</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-22</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Thu, 07 Jan 2021 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033746/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717555-44100-2-8bdba32c272262a4.mp3" length="55088273" type="audio/mpeg"/>
+			<itunes:summary>DojoCon Japan 2020 共同実行委員長の曽我さん (@ymsg19)、宮島さん (@kiriem_) をゲストにお迎えして、DojoCon Japan 2020 の後日談についてお伺いました 🎤👥 ラジオ感覚で聴いていただけると嬉しいです 😌🎶
+
+DojoCon Japan 2020 - Beyond the Distance (距離を超えて) https://dojocon2020.coderdojo.jp/
+
+DojoCon Japan 2020 - YouTube
+https://www.youtube.com/playlist?list=PL_XgRvFvKBPZOwlkFq89AzWYsyp8tMD4s
+
+当日の投稿まとめ - Togetter
+https://togetter.com/li/1644235
+
+0:00 ゲスト自己紹介：曽我さん https://twitter.com/ymsg19
+0:36 ゲスト自己紹介：宮島さん https://twitter.com/kiriem_
+1:44 DojoCon Japan 2020 とは? https://dojocon2020.coderdojo.jp/
+3:36 DojoCon Japan 2020 のキッカケ『自分でアクションを起こす』
+4:52 DojoCon Japan 2018 の開催経験が、オンライン開催にも活きた
+6:56 ３ヶ月で、３００人規模のイベントが開催できた
+7:49 実行委員の経験が０でも、実行委員長になれた
+8:54 早く意思決定できる仕組みと、新しい試みを推奨する心持ち
+11:04 参加者の感想『失敗しても許される雰囲気・空気感が良かった』
+11:36 実行委員１人１人の裁量を大きく、ボトルネックを解決していった
+12:27 共同実行委員長の間では、頻繁にコミュニケーションをとっていた
+13:38 新企画『カウントダウン DojoCon Japan』の趣旨 https://www.youtube.com/playlist?list=PL_XgRvFvKBPa_Z5hiRAK4sJcRWqCD8eV_
+15:21 オンライン開催では、当日に使うツールを紹介する場があると良い
+16:39 盛り上がりを作り、実行委員もツールを試せる、一石二鳥の試み
+18:04 実行委員の目線でも、他のチームの動きが見渡せて、一石三鳥！？
+19:38 DojoCon Japan 2020 の実行委員は７５名以上。全体は３回のみ
+21:07 全体ミーティングの発言者は少数、聴く人が多数。カウントダウンで十分？
+22:56 DojoCon Japan 2020 開催前日から、開催当日までの動き
+26:00 『oVice』とは？oViceで参加者の対話を促せた https://ovice.in/ja/
+27:58 『oVice』の良さを知るには、実際に体験してみるのが一番良い
+28:59 DojoCon Japan 2020 セッション例『Scratch × 機械学習』
+30:18 DojoCon Japan 2020 セッション例『オンライン vs. オフライン対談』
+32:05 DojoCon Japan 2020 企画例『交流室』- 話しかけやすさを大切に
+34:45 オンラインでも、さまざまな地域の方が話し合える場を実現できた
+36:03 コメント『素晴らしいイベントでした！楽しく、勉強になりました』
+36:27 当日の様子まとめ (Togetter) https://togetter.com/li/1644235
+37:03 当日の動画まとめ (YouTube) https://www.youtube.com/playlist?list=PL_XgRvFvKBPZOwlkFq89AzWYsyp8tMD4s
+37:24 DojoCon Japan 2020 ワークショップ例『ポケモン × CoderDojo』
+40:17 コメント『ポケモンワークショップに参加しました！』
+41:42 DojoCon Japan 2020 ふりかえり『走り抜けて、見えた風景』
+45:14 DojoCon Japan 2020 ふりかえり『新しい価値を作っていく』
+46:30 トライ＆エラーを繰り返し、『分からない→分かる』が増えた
+48:34 宮島さんのメッセージ『コミュニティの自信。スポンサーへの感謝』
+52:11 曽我さんのメッセージ『実行委員/参加者への感謝。次へのステップ』
+55:25 まとめ。色々な変化に対応し、新しいことにチャレンジし続けよう
+
+#CoderDojo #DojoCast #DojoConJapan
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3442</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[021 - TFabWorks 無償レンタルプログラム]]></title>
+			<description><![CDATA[2020年11月26日から事前登録が始まり、2021年1月15日からレンタル開始される CoderDojo 向けの TFabWorks 無償レンタルプログラムについて、TFabWorks 代表の高松さんにお伺いします。
+
+CoderDojo 向け TFabWork 無償レンタルプログラム
+https://tfabworks.com/coderdojo-rental/
+
+DojoCast - Highlight people around CoderDojo community by Podcast
+https://coderdojo.jp/podcasts
+
+CoderDojo Japan - 子どものためのプログラミング道場
+https://coderdojo.jp/
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/021---TFabWorks-euhiv6</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-21</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Fri, 11 Dec 2020 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033766/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717560-44100-2-c61ae164f7b131da.mp3" length="108284937" type="audio/mpeg"/>
+			<itunes:summary>2020年11月26日から事前登録が始まり、2021年1月15日からレンタル開始される CoderDojo 向けの TFabWorks 無償レンタルプログラムについて、TFabWorks 代表の高松さんにお伺いします。
+
+CoderDojo 向け TFabWork 無償レンタルプログラム
+https://tfabworks.com/coderdojo-rental/
+
+DojoCast - Highlight people around CoderDojo community by Podcast
+https://coderdojo.jp/podcasts
+
+CoderDojo Japan - 子どものためのプログラミング道場
+https://coderdojo.jp/
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>2707</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[020 - Scratch と機械学習で作ってみた話]]></title>
+			<description><![CDATA[『Scratch × 機械学習』でモノづくりをし、各種コンテストでも高く評価されたお話などについて、沖縄の CoderDojo 嘉手納で活動されている小川さん達に伺っていきます！🎤👥✨
+
+CoderDojo 嘉手納 http://coderdojokadena.hatenablog.jp/
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/020---Scratch-euhitv</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-20</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Sat, 07 Nov 2020 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033727/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717540-48000-2-e8a26afbc2fa524e.mp3" length="31358208" type="audio/mpeg"/>
+			<itunes:summary>『Scratch × 機械学習』でモノづくりをし、各種コンテストでも高く評価されたお話などについて、沖縄の CoderDojo 嘉手納で活動されている小川さん達に伺っていきます！🎤👥✨
+
+CoderDojo 嘉手納 http://coderdojokadena.hatenablog.jp/
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>1959</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[019 - CoderDojo Japan 理事の日常]]></title>
+			<description><![CDATA[一般社団法人 CoderDojo Japan で行われている普段の業務内容（隔週の定例会、法人連携の進め方、海外との英語ミーティングなど）についてお話ししました！
+
+本エピソードでは、2016年の設立背景、理事募集で応募された宮島さんのストーリー、いただいたコメントへの質疑応答などが含まれています。
+
+参考: 理事募集のお知らせ - CoderDojo Japan
+https://coderdojo.jp/join-in-board
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/019---CoderDojo-Japan-euhiu7</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-19</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Mon, 03 Aug 2020 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033735/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717549-48000-2-6b9093e3dc59d8db.mp3" length="55572864" type="audio/mpeg"/>
+			<itunes:summary>一般社団法人 CoderDojo Japan で行われている普段の業務内容（隔週の定例会、法人連携の進め方、海外との英語ミーティングなど）についてお話ししました！
+
+本エピソードでは、2016年の設立背景、理事募集で応募された宮島さんのストーリー、いただいたコメントへの質疑応答などが含まれています。
+
+参考: 理事募集のお知らせ - CoderDojo Japan
+https://coderdojo.jp/join-in-board
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3473</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[018 - ゲームと機械学習と Scratch 本]]></title>
+			<description><![CDATA[2020年7月出版の２つの Scratch 書籍を、それぞれの著者および出版社のご協力のもと、CoderDojo 向けに寄贈していただけることになりました。
+
+
+  
+    できるキッズ スクラッチでゲームをつくろう! 楽しく学べるプログラミング (著: 三橋優希・できるシリーズ編集部、出版: インプレス)
+  
+  
+    Scratchではじめる機械学習 ―作りながら楽しく学べるAIプログラミング (著: 石原 淳也・倉本 大資、監修: 阿部 和広、出版: オライリー・ジャパン)
+  
+
+
+本ライブ配信では、各書籍の著者 (三橋さん、石原さん) をお招きして、同書籍の内容や寄贈に関する経緯、CoderDojo コミュニティとの関わりなどについてお伺いします。
+
+・三橋 優希さん https://twitter.com/yukimihashi
+・石原 淳也さん https://twitter.com/jishiha
+
+書籍の詳細および寄贈の背景などについては下記の記事をご参照ください。
+
+ゲームや機械学習の Scratch 書籍、全国の CoderDojo 向けに寄贈
+https://news.coderdojo.jp/2020/07/19/scratch-books-for-coderdojo/
+
+0:00 はじめに
+2:11 ゲスト自己紹介：三橋 優希さん https://twitter.com/yukimihashi
+2:54 ゲスト自己紹介：石原 淳也さん https://twitter.com/jishiha
+4:32 新しい試み『ライブ配信 × アーカイブ配信』
+5:20 書籍『Scratch × ゲーム』の内容 https://book.impress.co.jp/books/1120101018
+8:11 書籍『Scratch × ゲーム』の特徴。まずは絵を描いてみよう
+11:15 書籍『Scratch × 機械学習』の内容 https://www.oreilly.co.jp/books/9784873119182/
+13:13 書籍『Scratch × 機械学習』は子ども向け人工知能の本
+14:17 機械学習をScratchで学ぼう。対象は小学校高学年以上
+15:33 大人も楽しめる内容と構成（例：遺伝的アルゴリズム）
+16:38 姿勢推定や音声/画像認識に触った後、理論を学ぶ流れ
+20:24 自主制作で２冊を出し、商業出版で３冊目を書いた https://yuki384.github.io/kitsuneko-site/
+21:45 自主制作２冊の紹介 https://yuki384.github.io/kitsuneko-site/
+22:05 １冊目：ドット絵エディタ、物理エンジン、自作言語、3G制作
+23:02 ２冊目：アクションゲーム、100% Pen、リバーシ、Raspberry Pi
+25:37 Scratch×機械学習以前にも ml2scratch があった https://github.com/champierre/ml2scratch
+27:34 様々なツールを Scratch と繋げる活動は以前からあった
+29:00 JavaScript でも利用できる仕組みが画期的だった
+31:21 Scratch をカスタマイズして公開 https://stretch3.github.io/
+32:20 Scratch 公式に取り込まれると作品も共有もできる
+33:53 Google 公式コンテストに採用 https://campaigns.google.co.jp/kids_ai/
+37:15 執筆秘話：楽しんでもらうための工夫。各章にクイズを設置
+39:45 表紙カバーにいる３人のキャラクター。実は…！？
+40:55 執筆秘話：理論の説明（１００ページ）を全て書き直した！？
+44:05 ギリギリまで調整した結果、日本語版のツールに対応できた
+47:33 質問『執筆に掛かった期間は？自主制作と商業出版の違いは？』
+49:38 子ども向けプログラミング学習サービス『メクルン』 https://mekurun.com/
+52:22 Google等からAIツールがもっと出る。連携例もどんどん増えるはず
+55:39 まとめ。CoderDojo向け寄贈も順次発送予定 https://news.coderdojo.jp/2020/07/19/scratch-books-for-coderdojo/
+57:04 YouTubeチャンネル開設！高評価＆チャンネル登録もぜひ！ https://youtube.com/coderdojojapan
+
+#Scratch #ゲーム #機械学習
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/018----Scratch-euhiuf</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-18</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Mon, 20 Jul 2020 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033743/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717550-44100-2-01a86a1392d6cba5.mp3" length="55903711" type="audio/mpeg"/>
+			<itunes:summary>2020年7月出版の２つの Scratch 書籍を、それぞれの著者および出版社のご協力のもと、CoderDojo 向けに寄贈していただけることになりました。
+
+
+  
+    できるキッズ スクラッチでゲームをつくろう! 楽しく学べるプログラミング (著: 三橋優希・できるシリーズ編集部、出版: インプレス)
+  
+  
+    Scratchではじめる機械学習 ―作りながら楽しく学べるAIプログラミング (著: 石原 淳也・倉本 大資、監修: 阿部 和広、出版: オライリー・ジャパン)
+  
+
+
+本ライブ配信では、各書籍の著者 (三橋さん、石原さん) をお招きして、同書籍の内容や寄贈に関する経緯、CoderDojo コミュニティとの関わりなどについてお伺いします。
+
+・三橋 優希さん https://twitter.com/yukimihashi
+・石原 淳也さん https://twitter.com/jishiha
+
+書籍の詳細および寄贈の背景などについては下記の記事をご参照ください。
+
+ゲームや機械学習の Scratch 書籍、全国の CoderDojo 向けに寄贈
+https://news.coderdojo.jp/2020/07/19/scratch-books-for-coderdojo/
+
+0:00 はじめに
+2:11 ゲスト自己紹介：三橋 優希さん https://twitter.com/yukimihashi
+2:54 ゲスト自己紹介：石原 淳也さん https://twitter.com/jishiha
+4:32 新しい試み『ライブ配信 × アーカイブ配信』
+5:20 書籍『Scratch × ゲーム』の内容 https://book.impress.co.jp/books/1120101018
+8:11 書籍『Scratch × ゲーム』の特徴。まずは絵を描いてみよう
+11:15 書籍『Scratch × 機械学習』の内容 https://www.oreilly.co.jp/books/9784873119182/
+13:13 書籍『Scratch × 機械学習』は子ども向け人工知能の本
+14:17 機械学習をScratchで学ぼう。対象は小学校高学年以上
+15:33 大人も楽しめる内容と構成（例：遺伝的アルゴリズム）
+16:38 姿勢推定や音声/画像認識に触った後、理論を学ぶ流れ
+20:24 自主制作で２冊を出し、商業出版で３冊目を書いた https://yuki384.github.io/kitsuneko-site/
+21:45 自主制作２冊の紹介 https://yuki384.github.io/kitsuneko-site/
+22:05 １冊目：ドット絵エディタ、物理エンジン、自作言語、3G制作
+23:02 ２冊目：アクションゲーム、100% Pen、リバーシ、Raspberry Pi
+25:37 Scratch×機械学習以前にも ml2scratch があった https://github.com/champierre/ml2scratch
+27:34 様々なツールを Scratch と繋げる活動は以前からあった
+29:00 JavaScript でも利用できる仕組みが画期的だった
+31:21 Scratch をカスタマイズして公開 https://stretch3.github.io/
+32:20 Scratch 公式に取り込まれると作品も共有もできる
+33:53 Google 公式コンテストに採用 https://campaigns.google.co.jp/kids_ai/
+37:15 執筆秘話：楽しんでもらうための工夫。各章にクイズを設置
+39:45 表紙カバーにいる３人のキャラクター。実は…！？
+40:55 執筆秘話：理論の説明（１００ページ）を全て書き直した！？
+44:05 ギリギリまで調整した結果、日本語版のツールに対応できた
+47:33 質問『執筆に掛かった期間は？自主制作と商業出版の違いは？』
+49:38 子ども向けプログラミング学習サービス『メクルン』 https://mekurun.com/
+52:22 Google等からAIツールがもっと出る。連携例もどんどん増えるはず
+55:39 まとめ。CoderDojo向け寄贈も順次発送予定 https://news.coderdojo.jp/2020/07/19/scratch-books-for-coderdojo/
+57:04 YouTubeチャンネル開設！高評価＆チャンネル登録もぜひ！ https://youtube.com/coderdojojapan
+
+#Scratch #ゲーム #機械学習
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3493</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[017 - 映画と漫画とプログラミング]]></title>
+			<description><![CDATA[映画『電気海月のインシデント』プロデューサーの @kondo_orange さん、一般社団法人 CoderDojo Japan 理事の @kiriem_ さんのお二人と『DojoCast』を配信します 🎤👥✨
+
+映画『電気海月のインシデント』https://jellyfish-movie.jp/
+
+https://twitter.com/kondo_orange
+https://twitter.com/kiriem_
+
+DojoCast は CoderDojo 関係者と対談するポッドキャストです。アプリや Web でも聴けます！
+
+🎧 Podcast アプリで聴く
+https://podcasts.apple.com/jp/podcast/dojocast/id1458122473
+
+☯️ DojoCast - CoderDojo Japan
+https://coderdojo.jp/podcasts
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/017---euhiu8</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-17</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Fri, 31 Jan 2020 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033736/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717552-44100-2-46d85c1fa7f3b1ec.mp3" length="59904834" type="audio/mpeg"/>
+			<itunes:summary>映画『電気海月のインシデント』プロデューサーの @kondo_orange さん、一般社団法人 CoderDojo Japan 理事の @kiriem_ さんのお二人と『DojoCast』を配信します 🎤👥✨
+
+映画『電気海月のインシデント』https://jellyfish-movie.jp/
+
+https://twitter.com/kondo_orange
+https://twitter.com/kiriem_
+
+DojoCast は CoderDojo 関係者と対談するポッドキャストです。アプリや Web でも聴けます！
+
+🎧 Podcast アプリで聴く
+https://podcasts.apple.com/jp/podcast/dojocast/id1458122473
+
+☯️ DojoCast - CoderDojo Japan
+https://coderdojo.jp/podcasts
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3744</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[016 - DojoCon Japan 2019 ふりかえり]]></title>
+			<description><![CDATA[DojoCon Japan 2019 実行委員の方々に DojoCon Japan 2019 を開催してみた感想について聞いてみました。
+
+DojoCon Japan 2019 - つぎのステップ    
+https://dojocon2019.coderdojo.jp/
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/016---DojoCon-Japan-2019-euhiu9</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-16</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Sun, 26 Jan 2020 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033737/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717558-48000-2-034ede93618c0e0b.mp3" length="29311488" type="audio/mpeg"/>
+			<itunes:summary>DojoCon Japan 2019 実行委員の方々に DojoCon Japan 2019 を開催してみた感想について聞いてみました。
+
+DojoCon Japan 2019 - つぎのステップ    
+https://dojocon2019.coderdojo.jp/
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>1831</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[015 - DojoCon Japan 2019 ハイライト]]></title>
+			<description><![CDATA[DojoCon Japan 2019 実行委員長 Utsu さん、副実行委員長 Katz さんのお二人と DojoCon Japan 2019 の見どころについてお話ししました。
+
+DojoCon Japan 2019 - つぎのステップ
+https://dojocon2019.coderdojo.jp/
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/015---DojoCon-Japan-2019-euhiu5</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-15</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Fri, 29 Nov 2019 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033733/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717554-44100-2-26d8e275b6e185f0.mp3" length="53585783" type="audio/mpeg"/>
+			<itunes:summary>DojoCon Japan 2019 実行委員長 Utsu さん、副実行委員長 Katz さんのお二人と DojoCon Japan 2019 の見どころについてお話ししました。
+
+DojoCon Japan 2019 - つぎのステップ
+https://dojocon2019.coderdojo.jp/
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3349</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[014 - [PR] 深センに来てみたよ! @ Makeblock]]></title>
+			<description><![CDATA[Makeblock 社 @maming435 さんと CoderDojo メンター @YukiMihashi さんのお２人と、様々なIT企業・ベンチャー企業などが集まる『深圳 (シンセン)』の Makeblock 社で収録しました。深圳の大学城 (University Town) 、決済事情、Makeblock Halocode PM、未踏ジュニア深圳ツアーの話などについて触れています。
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/014---PR----Makeblock-euhitp</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-14</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Tue, 13 Aug 2019 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033721/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717538-48000-2-2903cbe27d4c7555.mp3" length="13930368" type="audio/mpeg"/>
+			<itunes:summary>Makeblock 社 @maming435 さんと CoderDojo メンター @YukiMihashi さんのお２人と、様々なIT企業・ベンチャー企業などが集まる『深圳 (シンセン)』の Makeblock 社で収録しました。深圳の大学城 (University Town) 、決済事情、Makeblock Halocode PM、未踏ジュニア深圳ツアーの話などについて触れています。
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>870</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[013 - CoderDojo × Scratch 本の執筆秘話]]></title>
+			<description><![CDATA[ゲスト: CoderDojo 枚方の共同チャンピオンで、CoderDojo Japan 公式 Scratch 本の筆頭著者である @ippey_s さんとお話ししました。
+
+詳細: https://coderdojo.jp/podcasts/13
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/013---CoderDojo--Scratch-euhiu2</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-13</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Thu, 30 May 2019 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033730/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717542-48000-2-8836fd8cc35d6db6.mp3" length="51470208" type="audio/mpeg"/>
+			<itunes:summary>ゲスト: CoderDojo 枚方の共同チャンピオンで、CoderDojo Japan 公式 Scratch 本の筆頭著者である @ippey_s さんとお話ししました。
+
+詳細: https://coderdojo.jp/podcasts/13
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3216</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[012 - [英語] The 1st CoderDojo and the Global Vision]]></title>
+			<description><![CDATA[Guest: Bill Liao, co-founder of CoderDojo, talking about the story of the 1st CoderDojo, including how he met James Whelton (the other co-founder), why he started, and what vision is behind the rule, “Be Cool!”.
+
+See the following page for details.
+https://coderdojo.jp/podcasts/12
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/012----The-1st-CoderDojo-and-the-Global-Vision-euhitq</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-12</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Sat, 18 May 2019 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033722/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717539-44100-2-b82fcaae2f4c973c.mp3" length="15137644" type="audio/mpeg"/>
+			<itunes:summary>Guest: Bill Liao, co-founder of CoderDojo, talking about the story of the 1st CoderDojo, including how he met James Whelton (the other co-founder), why he started, and what vision is behind the rule, “Be Cool!”.
+
+See the following page for details.
+https://coderdojo.jp/podcasts/12
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>946</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[011 - [PR] 様々なメンタリングの形]]></title>
+			<description><![CDATA[未踏ジュニア代表で CoderDojo ロンドンでもメンターをしていた @ukkaripon さん、CoderDojo 金沢代表で未踏ジュニアPMの @teramotodaiki さんをお迎えして、CoderDojo と未踏ジュニアの共通点、PMのメンタリング事例、好きなものを作り込んだクリエータの活躍例、チーム開発vs個人開発、なぜプロトタイプは高く評価されやすいのか、などを話しました。
+
+収録日: 2019/03/25
+https://coderdojo.jp/podcasts/11
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/011---PR-euhiu6</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-11</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Mon, 25 Mar 2019 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033734/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717545-44100-2-a728412fae80b5cc.mp3" length="59550896" type="audio/mpeg"/>
+			<itunes:summary>未踏ジュニア代表で CoderDojo ロンドンでもメンターをしていた @ukkaripon さん、CoderDojo 金沢代表で未踏ジュニアPMの @teramotodaiki さんをお迎えして、CoderDojo と未踏ジュニアの共通点、PMのメンタリング事例、好きなものを作り込んだクリエータの活躍例、チーム開発vs個人開発、なぜプロトタイプは高く評価されやすいのか、などを話しました。
+
+収録日: 2019/03/25
+https://coderdojo.jp/podcasts/11
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3721</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[010 - [英語] Programming is Beyond a Job For Me]]></title>
+			<description><![CDATA[Guests: James Whelton, Junya Ishihara, Reina Masumoto, and Yuki Mihashi. (And Yosuke Toyota from the middle of recording.) This episode includes where James go around during Japan trip, his experiences in startup in Dubai, and differences in style between Startup and CoderDojo.
+
+For English speakers, give it a listen from 1.35. ;) This podcast is conducted in English, but includes Japanese a little bit. But no worries! All Japanese talks are translated into English just after them by me (@yasulab).
+
+収録日: 2018/12/05
+https://coderdojo.jp/podcasts/10
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/010----Programming-is-Beyond-a-Job-For-Me-euhiuh</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-10</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Wed, 05 Dec 2018 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033745/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717553-48000-2-3c214c8b5d2d8504.mp3" length="60465024" type="audio/mpeg"/>
+			<itunes:summary>Guests: James Whelton, Junya Ishihara, Reina Masumoto, and Yuki Mihashi. (And Yosuke Toyota from the middle of recording.) This episode includes where James go around during Japan trip, his experiences in startup in Dubai, and differences in style between Startup and CoderDojo.
+
+For English speakers, give it a listen from 1.35. ;) This podcast is conducted in English, but includes Japanese a little bit. But no worries! All Japanese talks are translated into English just after them by me (@yasulab).
+
+収録日: 2018/12/05
+https://coderdojo.jp/podcasts/10
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3779</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[009 - 広島の CoderDojo コミュニティ]]></title>
+			<description><![CDATA[CoderDojo 紙屋町 (旧: CoderDojo 広島) の活動をされている鼠屋さん、安藤さんと、広島における活動や DojoBudokai の話、子どもと接するときに考えていることなどについてお話してきました。
+
+収録日: 2017/09/16
+https://coderdojo.jp/podcasts/9
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/009----CoderDojo-euhiuo</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-9</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Sat, 16 Sep 2017 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033752/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717544-44100-2-645ecc7f6f12c1e4.mp3" length="52018781" type="audio/mpeg"/>
+			<itunes:summary>CoderDojo 紙屋町 (旧: CoderDojo 広島) の活動をされている鼠屋さん、安藤さんと、広島における活動や DojoBudokai の話、子どもと接するときに考えていることなどについてお話してきました。
+
+収録日: 2017/09/16
+https://coderdojo.jp/podcasts/9
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3251</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[008 - [PR] 未来にコミットしたい (CASE Shinjuku)]]></title>
+			<description><![CDATA[第三者からみた CoderDojo のイメージと、関係者からみた CoderDojo のイメージとを対比させながら、150坪もある新宿区高田馬場のシェアオフィス＆コワーキングスペース「CASE Shinjuku」の仲居頭である森下ことみさんと、そのお仲間である大串肇さん (通称: メガネさん) と一緒に収録しました。また、CoderDojo コミュニティが過去に遭遇した課題や、CoderDojo の広がり方の傾向、CASE Shinjuku と CoderDojo Japan とが共通して共感していることなどについてお話ししました
+
+収録日: 2017/07/07
+https://coderdojo.jp/podcasts/8
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/008---PR--CASE-Shinjuku-euhiun</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-8</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Fri, 07 Jul 2017 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033751/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717547-44100-2-d998fe02493d282c.mp3" length="54149954" type="audio/mpeg"/>
+			<itunes:summary>第三者からみた CoderDojo のイメージと、関係者からみた CoderDojo のイメージとを対比させながら、150坪もある新宿区高田馬場のシェアオフィス＆コワーキングスペース「CASE Shinjuku」の仲居頭である森下ことみさんと、そのお仲間である大串肇さん (通称: メガネさん) と一緒に収録しました。また、CoderDojo コミュニティが過去に遭遇した課題や、CoderDojo の広がり方の傾向、CASE Shinjuku と CoderDojo Japan とが共通して共感していることなどについてお話ししました
+
+収録日: 2017/07/07
+https://coderdojo.jp/podcasts/8
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3384</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[007 - Hack for Dojo（ハックフォー道場）]]></title>
+			<description><![CDATA[CoderDojo Kanazawa の寺本さん (@teramotodaiki)、CoderDojo Kashiwa の宮島さん (@mjk_0513) と、どうやってパソコンを集めたのか、どんなOSを入れると良さそうかといった運営面のノウハウと、10代の頃からアクションを起こし続けている二人が今に至ったキッカケや、学校の外側にあるコミュニティと触れる面白さついてお伺いしました。
+
+収録日: 2017/04/25
+https://coderdojo.jp/podcasts/7
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/007---Hack-for-Dojo-euhiv4</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-7</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Tue, 25 Apr 2017 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033764/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717551-48000-2-f0feec7051ee0c25.mp3" length="52468224" type="audio/mpeg"/>
+			<itunes:summary>CoderDojo Kanazawa の寺本さん (@teramotodaiki)、CoderDojo Kashiwa の宮島さん (@mjk_0513) と、どうやってパソコンを集めたのか、どんなOSを入れると良さそうかといった運営面のノウハウと、10代の頃からアクションを起こし続けている二人が今に至ったキッカケや、学校の外側にあるコミュニティと触れる面白さついてお伺いしました。
+
+収録日: 2017/04/25
+https://coderdojo.jp/podcasts/7
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3279</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[006 - [PR] 未踏ジュニアとコーダー道場]]></title>
+			<description><![CDATA[未踏ジュニア代表の鵜飼さん (@ukkaripon) さんに、未踏ジュニアについて伺ってきました。どのような目的で、どんなプログラムなのか、また、鵜飼さんの思いや、立ち上げの背景についてもお話ししました。
+
+収録日: 2017/04/24
+https://coderdojo.jp/podcasts/6
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/006---PR-euhitt</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-6</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Mon, 24 Apr 2017 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033725/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717535-44100-1-8f415545eb66917a.mp3" length="28041089" type="audio/mpeg"/>
+			<itunes:summary>未踏ジュニア代表の鵜飼さん (@ukkaripon) さんに、未踏ジュニアについて伺ってきました。どのような目的で、どんなプログラムなのか、また、鵜飼さんの思いや、立ち上げの背景についてもお話ししました。
+
+収録日: 2017/04/24
+https://coderdojo.jp/podcasts/6
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3505</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[005 - DecaDojo とは？]]></title>
+			<description><![CDATA[DecaDojo の成り立ちについて、DecaDojo in Saitama の運営メンバーに伺ってきました。
+
+https://coderdojo.jp/podcasts/5
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/005---DecaDojo-euhiu3</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-5</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Sat, 22 Apr 2017 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033731/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717543-48000-2-935a6f3fc2894b6e.mp3" length="52371072" type="audio/mpeg"/>
+			<itunes:summary>DecaDojo の成り立ちについて、DecaDojo in Saitama の運営メンバーに伺ってきました。
+
+https://coderdojo.jp/podcasts/5
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3273</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[004 - DojoCon Japan のキッカケ]]></title>
+			<description><![CDATA[CoderDojo 西宮・梅田のチャンピオンであり、一般社団法人 CoderDojo Japan の理事であり、DojoCon Japan 2016 と DojoCon Japan 2017 の実行委員長である細谷崇さん (@tkc49) と一緒に、DojoCon Japan についてお話ししました。
+
+収録日 : 2017/04/16
+https://coderdojo.jp/podcasts/4
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/004---DojoCon-Japan-euhiuc</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-4</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Sun, 16 Apr 2017 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033740/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717537-48000-2-835901890a5eed22.mp3" length="30532224" type="audio/mpeg"/>
+			<itunes:summary>CoderDojo 西宮・梅田のチャンピオンであり、一般社団法人 CoderDojo Japan の理事であり、DojoCon Japan 2016 と DojoCon Japan 2017 の実行委員長である細谷崇さん (@tkc49) と一緒に、DojoCon Japan についてお話ししました。
+
+収録日 : 2017/04/16
+https://coderdojo.jp/podcasts/4
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>1908</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[003 - 沖縄の CoderDojo の始まり]]></title>
+			<description><![CDATA[沖縄県那覇市南風原で CoderDojo Okinawa を運営されている比嘉さんと収録しました。CoderDojo Okinawa が一度休止になったものの、代表を比嘉さんに引き継いて活動が再開した話や、パソコンが 20〜30 台集まった話などをしています。雑談タイムでは、観光を兼ねて沖縄の CoderDojo に来てみてはどうか、沖縄でノマドワークしてはどうかという話をしています。
+
+収録日 : 2017/04/15
+https://coderdojo.jp/podcasts/3
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/003----CoderDojo-euhiue</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-3</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Sat, 15 Apr 2017 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033742/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717557-48000-2-9ebc581812c6394c.mp3" length="41211648" type="audio/mpeg"/>
+			<itunes:summary>沖縄県那覇市南風原で CoderDojo Okinawa を運営されている比嘉さんと収録しました。CoderDojo Okinawa が一度休止になったものの、代表を比嘉さんに引き継いて活動が再開した話や、パソコンが 20〜30 台集まった話などをしています。雑談タイムでは、観光を兼ねて沖縄の CoderDojo に来てみてはどうか、沖縄でノマドワークしてはどうかという話をしています。
+
+収録日 : 2017/04/15
+https://coderdojo.jp/podcasts/3
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>2575</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[002 - 柏と CoderDojo と Scratch]]></title>
+			<description><![CDATA[小・中学生で Scratch を学び、高校で CoderDojo を始めた宮島さん (@mjk_0513) が、今は何を学び、どんな活動をしているのか聞いてみました。また、CoderDojo Kashiwa が柏市と一緒に進めている取り組みや、上海における教育事例についても伺いました ;)
+
+収録日 : 2017/04/13
+https://coderdojo.jp/podcasts/2
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/002----CoderDojo--Scratch-euhiu1</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-2</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Thu, 13 Apr 2017 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033729/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717569-44100-1-4408dff733b24d74.mp3" length="24148008" type="audio/mpeg"/>
+			<itunes:summary>小・中学生で Scratch を学び、高校で CoderDojo を始めた宮島さん (@mjk_0513) が、今は何を学び、どんな活動をしているのか聞いてみました。また、CoderDojo Kashiwa が柏市と一緒に進めている取り組みや、上海における教育事例についても伺いました ;)
+
+収録日 : 2017/04/13
+https://coderdojo.jp/podcasts/2
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>3018</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+		<item>
+			<title><![CDATA[001 - 日本の CoderDojo の成り立ち]]></title>
+			<description><![CDATA[jishiha さん (CoderDojo 調布) と、日本の CoderDojo の成り立ちについて話しました。
+
+収録日 : 2017/03/25
+https://coderdojo.jp/podcasts/1
+]]></description>
+			<link>https://anchor.fm/coderdojo-japan/episodes/001----CoderDojo-euhits</link>
+			<guid isPermaLink="false">https://soundcloud.com/coderdojo-japan/dojocast-1</guid>
+			<dc:creator><![CDATA[一般社団法人 CoderDojo Japan]]></dc:creator>
+			<pubDate>Sat, 25 Mar 2017 00:00:00 GMT</pubDate>
+			<enclosure url="https://anchor.fm/s/54d501e8/podcast/play/31033724/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2021-3-9%2F173717536-44100-1-77618951c5e882c6.mp3" length="22887860" type="audio/mpeg"/>
+			<itunes:summary>jishiha さん (CoderDojo 調布) と、日本の CoderDojo の成り立ちについて話しました。
+
+収録日 : 2017/03/25
+https://coderdojo.jp/podcasts/1
+</itunes:summary>
+			<itunes:explicit>No</itunes:explicit>
+			<itunes:duration>2857</itunes:duration>
+			<itunes:image href="https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/14132458/14132458-1618047363696-f70ec27d2fba8.jpg"/>
+		</item>
+	</channel>
+</rss>

--- a/app/views/podcasts/index.html.erb
+++ b/app/views/podcasts/index.html.erb
@@ -19,16 +19,12 @@
     <h3 id="live" style="text-align: center; padding-top: 70px;">🎙
       最新エピソードを聴く</h3>
 
-
     <div class="container" style="line-height: 1.9em; margin-bottom: -100px;">
       <section class="doc" style="padding: 30px 0px 0px 0px;">
 	<% if @episodes.first %>
-	  <iframe width="100%" height="120" scrolling="no" frameborder="yes" class="lazyload" 
-	   data-src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/<%= @episodes.first.track_id %>&auto_play=false&buying=false&sharing=false&download=true&show_artwork=false&show_playcount=false&show_user=false">
-	  </iframe>
+	  <iframe class="lazyload" src="https://anchor.fm/coderdojo-japan/embed/episodes/<%= @episodes.first.permalink %>" width="100%px" height="120" scrolling="no" frameborder="yes"></iframe>
 	<% end %>
 	<br>
-
       </section>
     </div>
 

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -33,9 +33,7 @@
 
 <div class="container" style="line-height: 1.9em; margin-bottom: -100px;">
   <section class="doc" style="padding: 50px 0px 50px 0px;">
-    <iframe width="100%" height="120" scrolling="no" frameborder="yes"
-      src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/<%= @episode.track_id %>&auto_play=false&buying=false&sharing=false&download=true&show_artwork=false&show_playcount=false&show_user=false">
-    </iframe>
+    <iframe class="lazyload" src="https://anchor.fm/coderdojo-japan/embed/episodes/<%= @episode.permalink %>" width="100%px" height="120" scrolling="no" frameborder="yes"></iframe>
     <br />
 
     <%= raw @content %>

--- a/lib/tasks/podcasts.rake
+++ b/lib/tasks/podcasts.rake
@@ -13,7 +13,6 @@ namespace :podcasts do
     SOUNDCLOUD_RSS = Rails.env.test? ?
       'anchorfm_sample.rss' :
       'https://anchor.fm/s/54d501e8/podcast/rss'
-      #'https://feeds.soundcloud.com/users/soundcloud:users:626746926/sounds.rss'
     rss = RSS::Parser.parse(SOUNDCLOUD_RSS, false)
 
     if rss.items.length.zero?

--- a/lib/tasks/podcasts.rake
+++ b/lib/tasks/podcasts.rake
@@ -11,8 +11,9 @@ namespace :podcasts do
     logger.info('==== START podcasts:upsert ====')
 
     SOUNDCLOUD_RSS = Rails.env.test? ?
-      'soundcloud_sample.rss' :
-      'https://feeds.soundcloud.com/users/soundcloud:users:626746926/sounds.rss'
+      'anchorfm_sample.rss' :
+      'https://anchor.fm/s/54d501e8/podcast/rss'
+      #'https://feeds.soundcloud.com/users/soundcloud:users:626746926/sounds.rss'
     rss = RSS::Parser.parse(SOUNDCLOUD_RSS, false)
 
     if rss.items.length.zero?
@@ -22,8 +23,8 @@ namespace :podcasts do
 
     Podcast.transaction do
       rss.items.each_with_index do |item, index|
-        track_id = item.guid.content.split('/').last.to_i
-        episode  = Podcast.find_by(track_id: track_id) || Podcast.new(track_id: track_id)
+        track_id = item.guid.content.split('-').last.to_i
+        episode  = Podcast.find_by(id: track_id) || Podcast.new(id: track_id)
 
         episode.new_record? ?
           logger.info("Creating: #{item.title   }") :


### PR DESCRIPTION
[Anchor.fm](https://anchor.fm/coderdojo-japan) を触ってみたところ、各種ポッドキャストアプリの対応も簡単で、かつ、料金プラン的にもお得だったので、試しにポッドキャスト部分 (DojoCast) を Anchor.fm に移行できないか試してみる Pull Request です 🚜💨

cf. Switching your podcast to Anchor - Anchor Help Center
https://help.anchor.fm/hc/en-us/articles/360023100411-Switching-your-podcast-to-Anchor

## Progress

- [x] Change RSS feed to Anchor.fm 6eedb5d1
- [x] Fetch corresponding items from the new RSS feed 6eedb5d1
- [x] Replace SoundCloud embedded player with other player eced8a0 
- [ ] Update `/podcasts.rss` (feed.rss.builder) with the new RSS
- [ ] Refactor variables and comments related to SoundCloud