### PR TITLE
Fix DojoCast RSS feed builder for Apple Podcasts

### DIFF
--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -1,15 +1,15 @@
 class PodcastsController < ApplicationController
   def index
-    @title           = 'DojoCast'
-    @description     = 'CoderDojo に関わる人々をハイライトする Podcast 📻✨'
-    @episodes        = Podcast.order(:published_date).reverse
-    @url             = request.url
+    @title         = 'DojoCast'
+    @description   = 'CoderDojo に関わる人々をハイライトする Podcast 📻✨'
+    @episodes      = Podcast.order(:published_date).reverse
+    @url           = request.url
 
     # GET /podcasts.rss
-    @art_work_url    = "https://coderdojo.jp/podcasts/cover.jpg"
-    @author          = "一般社団法人 CoderDojo Japan"
-    @copyright       = "Copyright © 2012-#{Time.current.year} #{@author}"
-    @soundcloud_user = 'coderdojo-japan'
+    @art_work_url  = "https://coderdojo.jp/podcasts/cover.jpg"
+    @author        = "一般社団法人 CoderDojo Japan"
+    @copyright     = "Copyright © 2012-#{Time.current.year} #{@author}"
+    @anchorfm_user = 'coderdojo-japan'
 
     respond_to do |format|
       format.html

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -2,12 +2,12 @@ class Podcast < ApplicationRecord
   self.table_name = 'podcasts'
   DIR_PATH        = 'public/podcasts'
 
-  validates :track_id,       presence: true, uniqueness: true
   validates :title,          presence: true
   validates :content_size,   presence: true
   validates :duration,       presence: true
   validates :permalink,      presence: true
   validates :permalink_url,  presence: true
+  validates :enclosure_url,  presence: true
   validates :published_date, presence: true
 
   # instance methods

--- a/app/views/podcasts/feed.rss.builder
+++ b/app/views/podcasts/feed.rss.builder
@@ -42,7 +42,7 @@ xml.rss :version => '2.0',
         xml.itunes       :explicit, 'clean'
         xml.pubDate      episode.published_date.rfc2822
         xml.enclosure({
-          url:    "http://feeds.soundcloud.com/stream/#{episode.track_id}-#{@soundcloud_user}-#{episode.permalink}.mp3",
+          url:    episode.enclosure_url,
           length: episode.content_size,
           type:   'audio/mpeg' })
         xml.itunes       :duration, episode.duration

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -51,5 +51,3 @@
 </div>
 
 <%= render 'shared/introduce_podcast_apps' %>
-
-<script src="https://w.soundcloud.com/player/api.js" type="text/javascript"></script>

--- a/db/migrate/20210724043650_change_track_id_to_enclosure_url.rb
+++ b/db/migrate/20210724043650_change_track_id_to_enclosure_url.rb
@@ -1,0 +1,6 @@
+class ChangeTrackIdToEnclosureUrl < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :podcasts, :track_id, :enclosure_url
+    change_column :podcasts, :enclosure_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_034208) do
+ActiveRecord::Schema.define(version: 2021_07_24_043650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2021_03_05_034208) do
   end
 
   create_table "podcasts", force: :cascade do |t|
-    t.integer "track_id", null: false
+    t.string "enclosure_url", null: false
     t.string "title", null: false
     t.text "description"
     t.integer "content_size", null: false
@@ -68,7 +68,7 @@ ActiveRecord::Schema.define(version: 2021_03_05_034208) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "published_date", null: false
-    t.index ["track_id"], name: "index_podcasts_on_track_id", unique: true
+    t.index ["enclosure_url"], name: "index_podcasts_on_enclosure_url", unique: true
   end
 
   create_table "pokemons", force: :cascade do |t|

--- a/docs/how_to_upload_podcasts.md
+++ b/docs/how_to_upload_podcasts.md
@@ -6,9 +6,9 @@ DojoCast に新しい Podcast を追加する方法 (2020/07/26現在)
 
 1. **mp3 データを準備する**
    - :scroll: 収録方法: [:tv: StreamYard で同時ライブ配信をカンタンに (実例解説付き)](https://note.com/yasulab/n/n9bfdd69a6b01)
-2. **収録した音声ファイルを編集し、SoundCloud にアップロードする**
-   - :notes: アップロード先: [https://soundcloud.com/coderdojo-japan/](https://soundcloud.com/coderdojo-japan/)
-3. **Rake タスクを実行し、Podcasts テーブルに SoundCloud のトラックデータを取り込む**
+2. **収録した音声ファイルを編集し、Anchor.fm にアップロードする**
+   - :notes: アップロード先: [https://anchor.fm/coderdojo-japan](https://anchor.fm/coderdojo-japan)
+3. **Rake タスクを実行し、Podcasts テーブルに Anchor.fm のトラックデータを取り込む**
 
    ```
    $ bundle exec rake podcasts:upsert

--- a/spec/factories/podcasts.rb
+++ b/spec/factories/podcasts.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :podcast, class: Podcast do
-    track_id       { 123 }
     title          { 'title' }
     description    { 'description' }
     content_size   { 0 }
     duration       { 0 }
     permalink      { 'title' }
-    permalink_url  { 'http://aaa.bbb/title' }
+    permalink_url  { 'https://aaa.bbb/title' }
+    enclosure_url  { 'https://ccc.ddd/title.mp3' }
     published_date { Time.zone.today }
   end
 end

--- a/spec/lib/tasks/podcasts_spec.rb
+++ b/spec/lib/tasks/podcasts_spec.rb
@@ -17,15 +17,16 @@ RSpec.describe 'DojoCast:', podcast: true do
     before :each do
       Podcast.destroy_all
       @episode = create(:podcast,
-                 track_id:  111001,
                  title:     '999 - podcast 999',
                  duration:  '00:16:40',
-                 permalink: 'podcast-999')
+                 permalink: 'podcast-999',
+                 enclosure_url:  'https://aaa.bbb/title.mp3',
+)
     end
 
     let(:task) { 'podcasts:upsert' }
 
-    xit 'successfuly fetch from SoundCloud RSS' do
+    xit 'successfuly fetch from Anchor.fm RSS' do
       allow_any_instance_of(Podcast).to receive(:id).and_return(
         [
           { 'id'            => 123456001,
@@ -34,8 +35,8 @@ RSpec.describe 'DojoCast:', podcast: true do
             'content_size'  => 124542711,
             'duration'      => 5189815,
             'user_id'       => 123456789,
-            'permalink'     => 'podcast-999',
-            'permalink_url' => 'https://soundcloud.com/coderdojojp/podcast-999',
+            'permalink'     => '999-title',
+            'permalink_url' => 'https://anchor.fm/coderdojo-japan/999-title',
             'created_at'    => '2099/01/23 01:00:00 +0000' }
         ]
       )
@@ -53,17 +54,16 @@ RSpec.describe 'DojoCast:', podcast: true do
       expect(new_records.count).not_to eq(1)
       first_track = new_records.find(1)
 
-      expect(first_track.track_id).to       eq(614641407)
       expect(first_track.title).to          eq('001 - 日本の CoderDojo の成り立ち')
       expect(first_track.description).to    start_with('jishiha')
       expect(first_track.content_size).to   eq(22887860)
       expect(first_track.duration).to       eq('00:47:37')
-      expect(first_track.permalink).to      eq('dojocast-1')
-      expect(first_track.permalink_url).to  eq('https://soundcloud.com/coderdojo-japan/dojocast-1')
+      expect(first_track.permalink).to      eq('999-title')
+      expect(first_track.permalink_url).to  eq('https://anchor.fm/coderdojo-japan/999-title')
       expect(first_track.published_date).to eq('2017-03-25'.to_date)
     end
 
-    it 'failed to fetch from SoundCloud RSS' do
+    it 'failed to fetch from Anchor.fm RSS' do
       allow_any_instance_of(Podcast).to receive(:id).and_return(
         [
           { 'id'            => 123456001,
@@ -73,7 +73,7 @@ RSpec.describe 'DojoCast:', podcast: true do
             'duration'      => 5189815,
             'user_id'       => 123456789,
             'permalink'     => 'podcast-001',
-            'permalink_url' => 'https://soundcloud.com/coderdojojp/podcast-001',
+            'permalink_url' => 'https://anchor.fm/coderdojo-japan/999-title',
             'created_at'    => '2019/01/23 01:00:00 +0000' }
         ]
       )


### PR DESCRIPTION
Previous PR (#1350) enables to load [/podcasts](https://coderdojo.jp/podcasts) from web browsers but still not working in RSS feed because it refers to episodes on SoundCloud.

This PR tells [Apple Podcasts](https://podcasts.apple.com/jp/podcast/dojocast/id1458122473?l=en) to change references of DojoCast's episodes from [SoundCloud](https://soundcloud.com/coderdojo-japan) to [Anchor.fm](https://anchor.fm/coderdojo-japan) via RSS feed: https://coderdojo.jp/podcasts.rss

## Things to be done
- [x] Update `/podcasts.rss` (feed.rss.builder) with the new RSS af6b551
- [x] Fix failed test suites 6f0f4c71 8508146
- [x] Refactor documents related to SoundCloud eda6b1b 