### PR TITLE
URLと開催場所の変更（三島/沼津）

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1634,8 +1634,8 @@
   name: 三島・沼津
   prefecture_id: 22
   logo: "/img/dojos/mishima-numazu.png"
-  url: https://coderdojo-mn.org/
-  description: 国立沼津高専で隔月開催
+  url: https://coderdojo-mn.com/
+  description: 静岡県立工科短期大学校で隔月開催
   tags:
   - Scratch
   - Viscuit


### PR DESCRIPTION
・URL変更の連絡漏れ
・コロナのため国立沼津高専の外部貸し出しが停止したため、場所を変更。