### PR TITLE
2021年7月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4582,3 +4582,21 @@
   event_id:
   participants: 2
   evented_at: 2021/06/20 10:00
+
+# 2021/07/01 - 2021/07/31
+- dojo_id: 25
+  event_id:
+  participants: 3
+  evented_at: 2021/07/10 18:00
+- dojo_id: 86
+  event_id:
+  participants: 0
+  evented_at: 2021/07/17 18:30
+- dojo_id: 83
+  event_id:
+  participants: 2021/07/03 18:00 #オンライン開催
+  evented_at: 2
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2021/07/18 10:00

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4594,8 +4594,8 @@
   evented_at: 2021/07/17 18:30
 - dojo_id: 83
   event_id:
-  participants: 2021/07/03 18:00 #オンライン開催
-  evented_at: 2
+  participants: 2
+  evented_at: 2021/07/03 18:00 #オンライン開催
 - dojo_id: 131
   event_id:
   participants: 0


### PR DESCRIPTION
### やったこと
- 2021年07月分のFacebookイベントを集計しました
- `bundle exec rails statistics:aggregation[202107,202107,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました