### PR TITLE
Add newline if multiple Pokémon workshops come up in /events

### DIFF
--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -24,6 +24,7 @@
       - @pokemon_events.each do |event|
         %a{href: "#{event.event_url}", target: "_blank", rel: "external noopener"}
           %small #{event.event_at.strftime('%-m月%d日 %H:%M〜')} @ #{event.dojo_event_service.dojo.name}
+        %br
 
   = render partial: 'upcoming_events', locals: { upcoming_events: @upcoming_events }
 


### PR DESCRIPTION
２つ以上のイベントがある場合は改行して見やすくしました 🛠💨

## Before / After

![image](https://user-images.githubusercontent.com/155807/132081406-ed6716ee-6527-4684-a342-684ed55cbb99.png)
