### PR TITLE
2021年9月分Facebookイベント集計

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -216,7 +216,7 @@
 - dojo_id: 85
   name: facebook # connpass: https://coderdojonatori.connpass.com/
   group_id: 1379707208756830
-  url: https://www.facebook.com/coderdojonatori/events/
+  url: https://www.facebook.com/coderdojonatori/events/ # 限定公開になったか削除されているようです。
 
 # 登米
 - dojo_id: 4

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4610,3 +4610,13 @@
   event_id:
   participants: 0
   evented_at: 2021/08/15 10:30
+
+# 2021/09/01 - 2021/09/30
+- dojo_id: 86
+  event_id:
+  participants: 0
+  evented_at: 2021/09/19 13:00 #オンライン開催
+- dojo_id: 83
+  event_id:
+  participants: 4
+  evented_at: 2021/09/05 10:00 #オンライン開催


### PR DESCRIPTION
### やったこと
- 2021年09月分のFacebookイベントを集計しました
-  `dojo_event_services.yaml`にコメントを追加しました
- `bundle exec rails statistics:aggregation[20219,202109,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました
