### PR TITLE
2021年11月分Facebookイベント集計

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -463,11 +463,11 @@
 
 # 木更津
 - dojo_id: 83
-  name: facebook # connpassと併用
+  name: facebook 
   group_id: 1273279189459638
   url: https://www.facebook.com/coderdojokisarazu/events/
 - dojo_id: 83
-  name: connpass
+  name: connpass # 2021/07以降 Facebook で運用
   group_id: 8670
   url: https://coderdojo-kisarazu.connpass.com/
 

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4638,3 +4638,25 @@
   event_id:
   participants: 1
   evented_at: 2021/10/31 10:00
+
+# 2021/011/01 - 2021/11/30
+- dojo_id: 25
+  event_id:
+  participants: 2
+  evented_at: 2021/11/14 10:00
+- dojo_id: 83
+  event_id:
+  participants: 2
+  evented_at: 2021/11/07 10:00
+- dojo_id: 113
+  event_id:
+  participants: 0
+  evented_at: 2021/11/20 15:15
+- dojo_id: 131
+  event_id:
+  participants: 2
+  evented_at: 2021/11/28 10:00
+- dojo_id: 203
+  event_id:
+  participants: 0
+  evented_at: 2021/11/14 10:00


### PR DESCRIPTION
### やったこと
- 2021年11月分のFacebookイベントを集計しました
- `bundle exec rails statistics:aggregation[202111,202111,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました
- `dojo_event_services.yaml`を一部修正しました