### PR TITLE
2022年02月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4692,3 +4692,16 @@
   event_id:
   participants: 3
   evented_at: 2022/01/16 10:00
+# 2022/02/01 - 2022/02/28
+- dojo_id: 86
+  event_id:
+  participants: 1
+  evented_at: 2022/02/20 13s:00 #オンライン開催
+- dojo_id: 83
+  event_id:
+  participants: 3
+  evented_at: 2022/02/06 10:00 #オンライン開催
+- dojo_id: 113
+  event_id:
+  participants: 2
+  evented_at: 2022/02/19 15:15


### PR DESCRIPTION
### やったこと
- 2022年02月分のFacebookイベントを集計しました
- `bundle exec rails statistics:aggregation[202202,202202,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました