### PR TITLE
dojo_event_services.yamlで滝沢dojoにdoorkeeperを追加

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -245,10 +245,10 @@
   name: kokucheese
   group_id:
   url: http://kokucheese.com/main/host/codoMe/
-# - dojo_id: 109　#2022/04/15 イベント未登録のためID未定
-#   name: doorkeeper
-#   group_id:
-#   url: https://coderdojo-takizawa.doorkeeper.jp/
+- dojo_id: 109 #2022/04以降 doorkeeper で運用
+  name: doorkeeper
+  group_id: 12365
+  url: https://coderdojo-takizawa.doorkeeper.jp/
 
 # きたかみ
 - dojo_id: 107

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -245,6 +245,10 @@
   name: kokucheese
   group_id:
   url: http://kokucheese.com/main/host/codoMe/
+# - dojo_id: 109　#2022/04/15 イベント未登録のためID未定
+#   name: doorkeeper
+#   group_id:
+#   url: https://coderdojo-takizawa.doorkeeper.jp/
 
 # きたかみ
 - dojo_id: 107


### PR DESCRIPTION
### やったこと

- dojo_event_services.yamlにて、CoderDojo滝沢にdoorkeeperのデータを追加しました。
- `rails dojo_event_services:upsert` `bundle exec rake upcoming_events:aggregation[doorkeeper]`を実行しました
- ローカルで 近日開催の道場に表示されることを確認しました

![スクリーンショット 2022-04-22 17 21 08](https://user-images.githubusercontent.com/41533420/164649011-13d82080-e1d4-49dd-9851-faf355f5e7d4.png)

