### PR TITLE
Heroku の GitHub の連携で CI 結果がパスしても Heroku 側で検知してデプロイできないので Action を使ってデプロイしたい

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,10 +77,11 @@ jobs:
     env:
       IDOBATA_GITHUB_ACTIONS: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}
     runs-on: ubuntu-latest
-    if: always() && (env.IDOBATA_GITHUB_ACTIONS != null)
+    if: always()
     steps:
       - name: 🔔 Notify results
         uses: yasslab/idobata_notify@main
+        if: env.IDOBATA_GITHUB_ACTIONS != null
         with:
-          idobata_hook_url: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}
+          idobata_hook_url: ${{ env.IDOBATA_GITHUB_ACTIONS }}
           status: ${{ needs.test.result }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,3 +83,4 @@ jobs:
         uses: yasslab/idobata_notify@main
         with:
           idobata_hook_url: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}
+          status: ${{ needs.test.result }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
 
   deploy:
     needs: test
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,10 @@ jobs:
 
   notify:
     needs: [test, deploy]
+    env:
+      IDOBATA_GITHUB_ACTIONS: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && (env.IDOBATA_GITHUB_ACTIONS != null)
     steps:
       - name: 🔔 Notify results
         uses: yasslab/idobata_notify@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,24 @@ jobs:
             bundle exec rspec spec
           fi
 
-      - name: 🔔 Notify results
-        env:
-          IDOBATA_GITHUB_ACTIONS: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}
-        uses: yasslab/idobata_notify@main
-        if: always() && (env.IDOBATA_GITHUB_ACTIONS != null)
+  deploy:
+    needs: test
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
         with:
-          idobata_hook_url: ${{ env.IDOBATA_GITHUB_ACTIONS }}
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}
+
+  notify:
+    needs: [test, deploy]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: 🔔 Notify results
+        uses: yasslab/idobata_notify@main
+        with:
+          idobata_hook_url: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}


### PR DESCRIPTION
## やりたいこと

Actions を使って Heroku Deploy するようにしたい。

## 背景

GitHub 連携でデプロイできないので、代わりのデプロイ方法を用意したい

> What code deployment methods are available while we’re unable to reconnect to GitHub via the Heroku dashboard?
>
> [Integrating with Version Control Providers Besides GitHub](https://devcenter.heroku.com/articles/integrating-with-version-control-providers-besides-github)
> [Deploying with Git](https://devcenter.heroku.com/categories/deploying-with-git)

https://status.heroku.com/incidents/2413