### PR TITLE
📝 Add internal Dojo API to write News article much easier

### DIFF
--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -1,0 +1,21 @@
+class DojosController < ApplicationController
+  def index
+    @dojo_data = []
+    Dojo.active.each do |dojo|
+      @dojo_data << {
+        name: dojo.name,
+        url:  dojo.url,
+        prefecture: dojo.prefecture.region,
+        linked_text: "<a href='#{dojo.url}'>'#{dojo.name}</a>（#{dojo.prefecture.region}）",
+      }
+    end
+
+    respond_to do |format|
+      format.json  { render json: @dojo_data }
+
+      # No corresponding View for now.
+      # Only for API: GET /dojos.json
+      format.html { redirect_to root_url(anchor: 'dojos') }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
   get "/kata"             => "docs#kata"
   #get "/debug/kata"       => "docs#kata"
 
-
+  resources :dojos,    only: %i(index) # Only API: GET /dojos.json
   resources :docs,     only: %i(index show)
   resources :podcasts, only: %i(index show)
   resources :spaces,   only: %i(index)


### PR DESCRIPTION
下記お知らせ記事の「寄贈先の CoderDojo 一覧」を簡単に作りたい。
与えられた Dojo 名と一致した Dojo のリンク付きテキストを返し、
今後同様のセクションを作るときは本 API で Dojo 一覧のリストを用意する。

「CoderDojo 一覧」が用意されているお知らせ記事の例
https://news.coderdojo.jp/2022/05/16/1500-microbits-to-coderdojo/

## CoderDojo 一覧の例
上記記事では **手書き** で用意したが、ケアレスミスの可能性もあり、かつ、１時間以上かかった。今後は本 API を活用して自動的に生成したい 😌 ✨ (楽したい... 😂)

```html
# CoderDojo の出力パターン
"<a href='#{dojo.url}'>'#{dojo.name}</a>（#{dojo.prefecture.region}）",
```
<img width="373" alt="image" src="https://user-images.githubusercontent.com/155807/168762437-2dd34be1-bbda-4df9-89d9-37445bf0b651.png">


## API の出力例 `GET /dojos.json`

```json
{
  name: "柏",
  url: "https://www.coderdojo-kashiwa.com/",
  prefecture: "関東",
  linked_text: "<a href='https://www.coderdojo-kashiwa.com/'>'柏</a>（関東）"
}
```
<img width="587" alt="image" src="https://user-images.githubusercontent.com/155807/168762021-3d69e00d-491b-4a39-9a12-24286f44a32a.png">
