### PR TITLE
2022年6月分Facebookイベント集計

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -18,9 +18,9 @@
 
 # 福山大門（広島県）：Facebook?
 #- dojo_id: 243
-#  name: 
-#  group_id: 
-#  url: 
+#  name:
+#  group_id:
+#  url:
 
 # 大府
 - dojo_id: 243
@@ -44,7 +44,7 @@
 - dojo_id: 278
   name: facebook
   group_id: 288768132053174
-  url: https://www.facebook.com/coderdojocosugi
+  url: https://www.facebook.com/coderdojocosugi #ページ削除されているようです。
 - dojo_id: 278
   name: connpass
   group_id: 12412
@@ -519,7 +519,7 @@
 
 # 木更津
 - dojo_id: 83
-  name: facebook 
+  name: facebook
   group_id: 1273279189459638
   url: https://www.facebook.com/coderdojokisarazu/events/
 - dojo_id: 83
@@ -895,7 +895,7 @@
 
 # 宮古島
 - dojo_id: 56
-  name: facebook # イベントページなし
+  name: facebook #イベントページなし
   group_id:
   url: https://www.facebook.com/coderdojo.miyakojima/
 
@@ -1257,9 +1257,9 @@
   group_id: 8197
   url: https://coderdojo-ichinomiya.connpass.com/
 
-# 大石田@PCチャレンジ倶楽部 Facebookイベントページなし
+# 大石田@PCチャレンジ倶楽部
 - dojo_id: 215
-  name: facebook
+  name: facebook #イベントページなし
   group_id: 2253119258233423
   url: https://www.facebook.com/DojoPcc/
 

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4756,3 +4756,17 @@
   event_id:
   participants: 0
   evented_at: 2022/05/20 10:00
+
+# 2022/06/01 - 2022/06/30
+- dojo_id: 25
+  event_id:
+  participants: 2
+  evented_at: 2022/06/12 10:00
+- dojo_id: 86
+  event_id:
+  participants: 3
+  evented_at: 2022/06/19 10:30
+- dojo_id: 83
+  event_id:
+  participants: 3
+  evented_at: 2022/06/5 10:00


### PR DESCRIPTION
2022年6月分のFacebookイベントを集計しました📊

以下の細かな修正を含んでいます🙏

- ページのリンクが切れている箇所にコメント
- イベントページなしの表示を統一のため整えた
- 不要なスペース削除