### PR TITLE
2022年7月分Facebookイベント集計

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1121,7 +1121,7 @@
 - dojo_id: 186
   name: facebook # 第4回からは connpass で運用
   group_id: 318691575631474
-  url: https://www.facebook.com/CoderDojo.Nago/
+  url: https://www.facebook.com/CoderDojo.Nago/ #ページ削除されているようです。
 - dojo_id: 186
   name: connpass
   group_id: 7455

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4770,3 +4770,29 @@
   event_id:
   participants: 3
   evented_at: 2022/06/5 10:00
+
+# 2022/07/01 - 2022/07/31
+- dojo_id: 6
+  event_id:
+  participants: 0
+  evented_at: 2022/07/01 17:00
+- dojo_id: 25
+  event_id:
+  participants: 2
+  evented_at: 2022/07/10 10:00
+- dojo_id: 86
+  event_id:
+  participants: 2
+  evented_at: 2022/07/17 10:30
+- dojo_id: 83
+  event_id:
+  participants: 4
+  evented_at: 2022/07/03 10:00
+- dojo_id: 113
+  event_id:
+  participants: 0
+  evented_at: 2022/07/23 15:15
+- dojo_id: 131
+  event_id:
+  participants: 2
+  evented_at: 2022/07/24 10:00


### PR DESCRIPTION
### やったこと
- 2022年7月分のFacebookイベントを集計しました
- `bundle exec rails statistics:aggregation[202105,202105,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました
- ページのリンクが切れている箇所にコメント