### PR TITLE
2022年8月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4796,3 +4796,13 @@
   event_id:
   participants: 2
   evented_at: 2022/07/24 10:00
+
+# 2022/08/01 - 2022/08/31
+- dojo_id: 86
+  event_id:
+  participants: 2
+  evented_at: 2022/08/21 10:30
+- dojo_id: 83
+  event_id:
+  participants: 3
+  evented_at: 2022/08/07 10:00


### PR DESCRIPTION
### やったこと

- 2022年8月分のFacebookイベントを集計しました
- `bundle exec rails statistics:aggregation[202208,202208,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました