### PR TITLE
2022年9月分Facebookイベント集計

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -8,11 +8,11 @@
 #  group_id: 
 #  url: 
 
-# 新所沢 （イベントが作成されたらgroup_idとurlを追加する）
-#- dojo_id: 287
-#  name: doorkeeper
-#  group_id: ??
-#  url: ??
+# 新所沢
+- dojo_id: 287
+  name: doorkeeper
+  group_id: 12898
+  url: https://coderdojo-shintokorozawa.doorkeeper.jp/
 
 # 池田池橋
 - dojo_id: 286

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4806,3 +4806,17 @@
   event_id:
   participants: 3
   evented_at: 2022/08/07 10:00
+
+# 2022/09/01 - 2022/09/30
+- dojo_id: 25
+  event_id:
+  participants: 2
+  evented_at: 2022/09/11 10:00
+- dojo_id: 86
+  event_id:
+  participants: 2
+  evented_at: 2022/09/18 10:30
+- dojo_id: 83
+  event_id:
+  participants: 2
+  evented_at: 2022/09/04 10:00


### PR DESCRIPTION
2022年9月分のFacebookイベントを集計しました👍

また、集計可能となったDojoのイベントサービス情報を追加しました👍
