### PR TITLE
:new: Add CoderDojo 横浜師岡 in 神奈川県

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -8,6 +8,12 @@
 #  group_id: 
 #  url: 
 
+# 横浜師岡
+- dojo_id: 288
+  name: connpass
+  group_id: 12941
+  url: https://coderdojo-morooka.connpass.com
+
 # 新所沢
 - dojo_id: 287
   name: doorkeeper

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1320,6 +1320,19 @@
   - micro:bit
   - Hour of Code
   - HackforPlay
+- id: 288
+  order: '141097'
+  created_at: '2022-10-10'
+  name: 横浜師岡
+  prefecture_id: 14
+  logo: "/img/dojos/japan.png"
+  url: https://coderdojo-morooka.connpass.com
+  description: 横浜市港北区の師岡町で毎月開催
+  tags:
+  - Scratch
+  - ScratchJr
+  - Minecraft
+  - Python
 - id: 76
   order: '141135'
   created_at: '2017-04-03'


### PR DESCRIPTION
### やったこと
横浜師岡dojoの追加
統計システムへの追加
ローカルで表示確認

![スクリーンショット 2022-10-11 12 02 12](https://user-images.githubusercontent.com/41533420/194987439-2a46a622-b5d3-4330-a924-dc10983f91ca.png)
