### PR TITLE
Add tamachi dojo

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -8,6 +8,12 @@
 #  group_id: 
 #  url: 
 
+# たまち
+- dojo_id: 289
+  name: connpass
+  group_id: 13058
+  url: https://coderdojo-tamachi.connpass.com/
+
 # 横浜師岡
 - dojo_id: 288
   name: connpass

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -908,6 +908,20 @@
   - PHP
   - Java
   - Python
+- id: 289
+  order: '131032'
+  created_at: '2022-10-23'
+  name: たまち
+  prefecture_id: 13
+  logo: "/img/dojos/coderdojo.webp"
+  url: https://coderdojo-tamachi.connpass.com/
+  description: 港区JR田町駅周辺で毎月開催
+  tags:
+  - Scratch
+  - Hour of Code
+  - 電子工作
+  - Webアプリ開発
+  - スマホアプリ開発
 - id: 58
   order: '131041'
   is_active: false

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1999,7 +1999,7 @@
   created_at: '2017-02-17'
   name: 尾張
   prefecture_id: 23
-  logo: "/img/dojos/owari.svg"
+  logo: "/img/dojos/owari.webp"
   url: https://coderdojoowari.org/
   description: 岩倉市で毎月開催
   tags:
@@ -2227,7 +2227,7 @@
   created_at: '2021-04-25'
   name: 東住吉
   prefecture_id: 27
-  logo: "/img/dojos/higashi-sumiyoshi.svg"
+  logo: "/img/dojos/higashi-sumiyoshi.webp"
   url: https://cd-hisumi.github.io/
   description: 大阪市東住吉区で不定期開催
   tags:


### PR DESCRIPTION
### やったこと

- たまちdojoの追加
  - ロゴは同じものだったので`coderdojo.webp` を使用しました
- 統計システムへの追加
- ローカルで表示確認
- 微調整（Dojoロゴ拡張子の修正）

![スクリーンショット 2022-10-24 10 34 53](https://user-images.githubusercontent.com/41533420/197438926-2e3b9a91-c281-4530-9385-97144c8a6d6f.png)
