### PR TITLE
2022年10月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4820,3 +4820,9 @@
   event_id:
   participants: 2
   evented_at: 2022/09/04 10:00
+
+# 2022/10/01 - 2022/10/31
+- dojo_id: 83
+  event_id:
+  participants: 1
+  evented_at: 2022/10/02 10:00


### PR DESCRIPTION
- 2022年10月分のFacebookイベントを集計しました
- `bundle exec rails statistics:aggregation[202210,202210,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました