### PR TITLE
[WIP] Add update version of heroku resource due to deprecation of free db

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
   ],
   "environments": {
     "review": {
-      "addons": ["heroku-postgresql:hobby-dev"]
+      "addons": ["heroku-postgresql:mini"]
     }
   },
   "buildpacks": [


### PR DESCRIPTION
Heroku の PG Hobby-Dev が作られなくなったので、Heroku PG Mini を使うように設定した。Heroku の無料の DB 提供が無くなった影響の変更になります。

https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq