### PR TITLE
📊 Publish CoderDojo Stats in 2022

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -2,8 +2,8 @@ class StatsController < ApplicationController
   def show
     @url                 = request.url
 
-    # 2012年1月1日〜2021年12月31日までの集計結果
-    period        = Time.zone.local(2012).beginning_of_year..Time.zone.local(2021).end_of_year
+    # 2012年1月1日〜2022年12月31日までの集計結果
+    period        = Time.zone.local(2012).beginning_of_year..Time.zone.local(2022).end_of_year
     stats         = Stat.new(period)
 
     # 推移グラフ

--- a/app/models/high_charts_builder.rb
+++ b/app/models/high_charts_builder.rb
@@ -32,8 +32,8 @@ class HighChartsBuilder
         f.series(type: 'column', name: '開催回数', yAxis: 0, data: data[:increase_nums])
         f.series(type: 'line',   name: '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
-          { title: { text: '開催回数' }, tickInterval:  400, max: 2000 },
-          { title: { text: '累積合計' }, tickInterval: 1400, max: 7000, opposite: true }
+          { title: { text: '開催回数' }, tickInterval:  500, max: 2000 },
+          { title: { text: '累積合計' }, tickInterval: 2000, max: 8000, opposite: true }
         ]
         f.chart(width: 600, alignTicks: false)
         f.colors(["#F4C34F", "#BD2561"])


### PR DESCRIPTION
## 📊 CoderDojo Stats in 2022 ✨ 

<img width="473" alt="image" src="https://user-images.githubusercontent.com/155807/210168388-8ef03e36-55bd-42b4-ba4b-f694dd747f00.png">

<br>

<img width="483" alt="image" src="https://user-images.githubusercontent.com/155807/210168396-3f42e34d-84b2-4692-a942-e0d3bf553bb6.png">

詳細: https://coderdojo.jp/stats

<br>


## あとでやる: 「道場数の推移」グラフについて
**CoderDojo Foundation による CoderDojo Inactivity Check が2023年1月から再開予定** とのことなので、当該チェックが Zen DB に反映され次第、Japan DB を再度更新し、下記コミットを Revert する。

詳細: https://github.com/coderdojo-japan/coderdojo.jp/commit/02e784e4

> Temporarily hide 道場数の推移 because:
> 
> Activity check by the foundation is temporarily stopped since 2020,
> so we can't detect if dojo status is Pending or Inactive, meaning that
> '道場数の推移' in 2020-2021 includes inactive dojos, which would be
> misleading to understand the stats of CoderDojo community in Japan.

<br>

## 関連 Pull Requests
- :octocat: 2021: https://github.com/coderdojo-japan/coderdojo.jp/pull/1405
- :octocat: 2020: https://github.com/coderdojo-japan/coderdojo.jp/pull/1142
- :octocat: 2019: https://github.com/coderdojo-japan/coderdojo.jp/pull/685

<br>