### PR TITLE
2022年11月・12月分Facebookイベント集計

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -15,10 +15,10 @@
   url: https://coderdojo-sumiyoshi.connpass.com
 
 # 大船
-#- dojo_id: 296
-#  name: facebook
-#  group_id: 
-#  url: https://www.facebook.com/CoderDojoOfuna/
+- dojo_id: 296
+  name: facebook
+  group_id: 10453213456789123
+  url: https://www.facebook.com/CoderDojoOfuna/
 
 # 田町@VMware
 #- dojo_id: 295

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -4826,3 +4826,27 @@
   event_id:
   participants: 1
   evented_at: 2022/10/02 10:00
+
+# 2022/11/01 - 2022/11/30
+- dojo_id: 25
+  event_id:
+  participants: 4
+  evented_at: 2022/11/13 10:00
+- dojo_id: 83
+  event_id:
+  participants: 3
+  evented_at: 2022/11/06 10:00
+- dojo_id: 131
+  event_id:
+  participants: 2
+  evented_at: 2022/11/27 10:00
+
+# 2022/12/01 - 2022/12/31
+- dojo_id: 83
+  event_id:
+  participants: 4
+  evented_at: 2022/12/04 10:00
+- dojo_id: 131
+  event_id:
+  participants: 3
+  evented_at: 2022/12/18 10:00


### PR DESCRIPTION
### やったこと
- 2022年11月・12月分のFacebookイベントを集計しました
- 月別にコマンドの実行を確認しました
  - `$ bundle exec rails statistics:aggregation[202211,202211,facebook,]`
  - `$ bundle exec rails statistics:aggregation[202212,202212,facebook,]`
- 大船dojo に`group_id` を追加し、コメントアウトを外しました
