### PR TITLE
八尾 dojo を更新

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -38,11 +38,15 @@
   group_id: 13146
   url: https://dojonihonmatsu.doorkeeper.jp/
 
-# 八尾@yotteco
-#- dojo_id: 291
-#  name: facebook
-#  group_id: 
-#  url: https://zen.coderdojo.com/dojos/jp/yao-osaka/ba1-wei3-yotteco
+# 八尾
+- dojo_id: 291 
+  name: facebook  # @yotteco イベントページなし
+  group_id: 100087493006122
+  url: https://www.facebook.com/profile.php?id=100087493006122
+# - dojo_id: 291 イベントサービスが別途用意されたら「@くまのみぎて」も追記する
+# name: 
+# group_id: 
+# url: 
 
 # 紫雲
 #- dojo_id: 290

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -2467,11 +2467,12 @@
 - id: 291
   order: '272124'
   created_at: '2022-11-18'
-  name: 八尾@yotteco
+  name: 八尾
+  counter: 2
   prefecture_id: 27
   logo: "/img/dojos/yao-yotteco.webp"
-  url: https://www.facebook.com/profile.php?id=100087493006122
-  description: 八尾市萱振町で毎月開催
+  url: https://twitter.com/CoderDojoYao
+  description: 八尾市で毎月開催
   tags:
   - Flutter
   - Scratch


### PR DESCRIPTION
### 八尾 dojo を更新しました

CoderDojo 八尾、「yotteco」「くまのみぎて」の対応です。

- `counter: 2` を追加
- urlを `https://twitter.com/CoderDojoYao` に変更
- description: から町名を削除して「八尾市で毎月開催」に変更
- `dojo_event_services.yaml` で、コメントアウトを外し@yotteco の Facebook ページを記載

現在表示しているロゴマークが上記URLで使用されているものと同じだったため、今回は変更していません。

🔽更後
![スクリーンショット 2023-01-27 12 52 55](https://user-images.githubusercontent.com/41533420/215007337-b1077d0d-6aab-470a-8f3f-fd39dd123c41.png)
