### PR TITLE
タグ分布グラフの表示を調整

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -39,7 +39,14 @@ class StatsController < ApplicationController
               tickInterval: 40, max: 240
       f.series type: 'column', name: "対応道場数", yAxis: 0, showInLegend: false,
                data: tags.values.take(number_of_tags).reverse,
-               dataLabels: { enabled: true, y: 20, align: 'center' }
+               dataLabels: { 
+                enabled: true,
+                y: 20,
+                align: 'center', 
+                style: {
+                  textShadow: false
+                }
+               }
 
       f.chart width: 600, alignTicks: false
       f.colors ["#A0CEFB", "#A0CEFB"]


### PR DESCRIPTION
close: #1507

タグ分布のグラフで、数字についていた白抜き風のスタイルを非表示にしました。

🔽変更後
![スクリーンショット 2023-02-27 13 47 54](https://user-images.githubusercontent.com/41533420/221477085-34e3e81a-8445-49c3-b2fa-8a0620773696.png)
