### PR TITLE
Flatten UpcomingEvents API (in beta) for DojoMap

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,7 +6,10 @@ class EventsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.json { render json: @upcoming_events }
+      format.json {
+        # DojoMap: https://map.coderdojo.jp
+        render json: UpcomingEvent.for_dojo_map
+      }
     end
   end
 end

--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -34,6 +34,28 @@ class UpcomingEvent < ApplicationRecord
         merge(Dojo.default_order).
         where('event_title like(?)', "%#{keyword}%")
     end
+
+    def for_dojo_map
+      result = []
+      dojos_and_events = eager_load(dojo_event_service: :dojo)
+        .since(Time.zone.today)
+        .merge(Dojo.default_order)
+        .group_by { |event| event.dojo_event_service.dojo }
+
+      dojos_and_events.each do |dojo, events|
+        event = events.sort_by(&:event_at).first
+        result << {
+          id:   dojo.id,
+          name: dojo.name,
+          url:  dojo.url,
+          event_title: event[:event_title],
+          event_date:  event[:event_at],
+          event_url:   event[:event_url],
+        }
+      end
+
+      result
+    end
   end
 
   def catalog

--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -37,12 +37,12 @@ class UpcomingEvent < ApplicationRecord
 
     def for_dojo_map
       result = []
-      dojos_and_events = eager_load(dojo_event_service: :dojo)
+      list_of_dojo_and_events = eager_load(dojo_event_service: :dojo)
         .since(Time.zone.today)
         .merge(Dojo.default_order)
         .group_by { |event| event.dojo_event_service.dojo }
 
-      dojos_and_events.each do |dojo, events|
+      list_of_dojo_and_events.each do |dojo, events|
         event = events.sort_by(&:event_at).first
         result << {
           id:   dojo.id,


### PR DESCRIPTION
近日開催の道場の API、特に用途が無くてそのままにしてましたが DojoMap で使えそうなのでちょっと改良しました! 🛠💨✨

- 🤔💭 利用用途の案: 近日開催のイベントがあれば `[参加する]` ボタンを追加する、など

![image](https://user-images.githubusercontent.com/155807/223066514-f83b29ce-720a-4352-98dc-ee5e922d21e6.png)
