### PR TITLE
official dumper gem causes nil with retrieving db infomation so switching to patched yasslab/dumper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '~> 6.0'
 gem 'puma'
 gem "puma_worker_killer"
 gem 'pg'
-gem 'dumper'
+gem 'dumper', git: 'https://github.com/yasslab/dumper' # For database backup
 gem 'bootsnap'
 
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/yasslab/dumper
+  revision: 1160175e1089e78887de89c21a303101cb56c096
+  specs:
+    dumper (1.7.2)
+      multipart-post (>= 1.1.5)
+      posix-spawn (>= 0.3.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -117,10 +125,6 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    dumper (1.7.3)
-      multi_json (>= 1.0)
-      multipart-post (>= 1.1.5)
-      posix-spawn (>= 0.3.6)
     erubi (1.12.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
@@ -438,7 +442,7 @@ DEPENDENCIES
   capybara
   coffee-rails
   dotenv-rails
-  dumper
+  dumper!
   factory_bot_rails
   faraday
   faraday_middleware


### PR DESCRIPTION
## 分かったこと

- Dumper.io のバックアップがうまくいっていない事の報告を受けた
- Rails 6.x にあげた事で、https://github.com/dumperhq/dumper/issues/14 で起きる同様のエラーに遭遇した

## やったこと

yasslab/dumper で Rails 6.x 系以降でも DB 情報を呼び出せるように修正を行なった Patch した Gem を使うように変更して修正