### PR TITLE
Fix missing URLs due to IPA website renewal

### DIFF
--- a/app/views/docs/kata.html.erb
+++ b/app/views/docs/kata.html.erb
@@ -552,7 +552,7 @@
 	    <p>個人のソフトウェア研究開発プロジェクトを応援する制度です。ラボユース生に採択された場合、サイボウズ・ラボ社員によるメンタリングや、最大103万円の奨励金などが受けられます。</p>
 	  </li>
 	  <li>
-	    <h4 id='security-camp'><a href="http://www.ipa.go.jp/jinzai/camp/index.html">セキュリティ・キャンプ</a></h4>
+	    <h4 id='security-camp'><a href="https://www.ipa.go.jp/jinzai/security-camp/about.html">セキュリティ・キャンプ</a></h4>
 	    <p>IPAが主催する、合宿形式で実践的な技術を習得するプログラムです。22歳以下の学生・生徒が対象。参加費、交通費すべて無料。</p>
 	  </li>
 	  <li>
@@ -560,15 +560,15 @@
 	    <p>17歳以下を対象とした小中高生クリエータ支援プログラムです。作りたいモノを作りながら、各業界で活躍するメンターからの定期的なフィードバックや、最大50万円の開発支援などが受けられます。</p>
 	  </li>
 	  <li>
-	    <h4 id='ipa-mitou'><a href="https://www.ipa.go.jp/jinzai/mitou/portal_index.html">未踏事業</a></h4>
-	    <p>25歳未満を対象とした人材発掘・育成事業プログラムです。独自の開発プロジェクトに対して、各業界で活躍するメンターからの定期的なフィードバックと約270万円の支援が行われます。(詳細: <a href="https://medium.com/@ukkaripon/%E6%9C%AA%E8%B8%8F%E3%81%AE%E9%AD%85%E5%8A%9B%E3%82%92%E7%9F%A5%E3%82%8D%E3%81%86-%E5%B0%8F%E4%B8%AD%E9%AB%98%E7%94%9F%E5%90%91%E3%81%91%E6%9C%AA%E8%B8%8F%E8%AA%AC%E6%98%8E%E4%BC%9A-%E3%82%92%E7%B5%82%E3%81%88%E3%81%A6-d67e88dfbcb2#.74e0d3bjz">未踏の魅力を知ろう：小中高生向け未踏説明会まとめ</a>)</p>
+	    <h4 id='ipa-mitou'><a href="https://www.ipa.go.jp/jinzai/mitou/about.html">未踏事業</a></h4>
+	    <p>25歳未満を対象とした人材発掘・育成事業プログラムです。独自の開発プロジェクトに対して、各業界で活躍するメンターからの定期的なフィードバックと約270万円の支援が行われます。</p>
 	  </li>
 	  <li>
-	    <h4 id='ipa-mitou-target'><a href="https://www.ipa.go.jp/jinzai/target/index.html">未踏ターゲット事業</a></h4>
+	    <h4 id='ipa-mitou-target'><a href="https://www.ipa.go.jp/jinzai/mitou/target/about.html">未踏ターゲット事業</a></h4>
 	    <p>中長期的視点で革新的技術を活用しイノベーションを起こしうる、先進分野のIT人材の発掘・育成を目的としたプログラムです。年度ごとにターゲット分野を定め、その分野に取り組む人材からのプロジェクト提案に対して約360万円の支援が行われます（年齢制限はありません）。</p>
 	  </li>
 	  <li>
-	    <h4 id='ipa-mitou-advanced'><a href="https://www.ipa.go.jp/jinzai/advanced/index.html">未踏アドバンスド事業</a></h4>
+	    <h4 id='ipa-mitou-advanced'><a href="https://www.ipa.go.jp/jinzai/mitou/advanced/about.html">未踏アドバンスド事業</a></h4>
 	    <p>未踏性、市場性、事業性、開発実現性を備えたITを活用した革新的なアイディア・プロトタイプを有し、ビジネスや社会課題の解決につなげたいと考えているIT人材の支援プログラムです。１つのプロジェクトに対して約1,000万円の支援が行われます（年齢制限はありません）。</p>
 	  </li>
 	</ul>

--- a/public/podcasts/11.md
+++ b/public/podcasts/11.md
@@ -26,7 +26,9 @@
 ### 未踏コミュニティ
 
 - [未踏社団 - ワーキンググループ一覧](https://www.mitou.org/projects/index.html)
-- [未踏事業 - IPA](https://www.ipa.go.jp/jinzai/mitou/portal_index.html)
+- [未踏事業 - IPA](https://www.ipa.go.jp/jinzai/mitou/about.html)
+- [未踏ターゲット](https://www.ipa.go.jp/jinzai/mitou/target/about.html)
+- [未踏アドバンスト](https://www.ipa.go.jp/jinzai/mitou/advanced/about.html)
 - [鵜飼PM - 未踏インタビュー](https://www.youtube.com/watch?v=GgJmBKaUzGs)
 - [寺本PM - 未踏インタビュー](https://www.youtube.com/watch?v=xLfofvH9lkY)
 

--- a/public/podcasts/6.md
+++ b/public/podcasts/6.md
@@ -11,5 +11,6 @@
 ## 📝 Shownote − 話したこと
 
 - [未踏ジュニア](https://jr.mitou.org/)
-- [未踏事業](https://www.ipa.go.jp/jinzai/mitou/portal_index.html)
-- [未踏アドバンスト](https://www.ipa.go.jp/jinzai/advanced/)
+- [未踏事業](https://www.ipa.go.jp/jinzai/mitou/about.html)
+- [未踏ターゲット](https://www.ipa.go.jp/jinzai/mitou/target/about.html)
+- [未踏アドバンスト](https://www.ipa.go.jp/jinzai/mitou/advanced/about.html)


### PR DESCRIPTION
以下のリニューアルに伴い 404 ページになってしまったリンクを一通り修正しました! 🛠💨✨ CI 通ったらマージしますね 🚀✨

2023/03/31 - IPAウェブサイトリニューアルのお知らせ
https://www.ipa.go.jp/news/2022/announce/topic_20230331.html

> リニューアルに伴い、各ページのURLが変更となりました。
> 各ページへのリンクをブラウザの「お気に入り」「ブックマーク」などに登録されている場合は、新しいURLへの変更をお願いします。


https://user-images.githubusercontent.com/155807/229258129-0fca8474-e87c-4940-a979-f4291caab76c.mp4

cf. https://gyazo.com/942a96391db4209858c76ba124e67fd9