### PR TITLE
2023年3月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -5030,3 +5030,17 @@
   event_id:
   participants: 1
   evented_at: 2023/02/26 10:00
+
+# 2023/03/01 - 2023/03/31
+- dojo_id: 83
+  event_id:
+  participants: 2
+  evented_at: 2023/03/05 10:00
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2023/03/26 10:00
+- dojo_id: 296
+  event_id:
+  participants: 4
+  evented_at: 2023/03/12 10:00


### PR DESCRIPTION
### やったこと

- 203年3月分のFacebookイベントを集計しました
- `bundle exec rails rails statistics:aggregation[202303,202303,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました