### PR TITLE
connpass の robots.txt に合わせた API 呼び出しにするために、Sleep を入れた

### DIFF
--- a/lib/event_service/client.rb
+++ b/lib/event_service/client.rb
@@ -23,6 +23,8 @@ module EventService
 
         f.adapter  Faraday.default_adapter
       end
+      # connpass は https://connpass.com/robots.txt を守らない場合は、アクセス制限を施すので、下記の sleep を入れるようにした https://connpass.com/about/api/
+      sleep 5 if endpoint.include?(EventService::Providers::Connpass::ENDPOINT)
     end
   end
 end


### PR DESCRIPTION
## やりたいこと

Connpass のスクリプトを実行したところ、IP 制限の対象になる場合があるので、robots.txt に合わせた呼び出しの設定に変更したい