### PR TITLE
Temporarily comment out #1535 that failed tasks for /events page

### DIFF
--- a/lib/event_service/client.rb
+++ b/lib/event_service/client.rb
@@ -23,8 +23,9 @@ module EventService
 
         f.adapter  Faraday.default_adapter
       end
+      # TODO: According to the report by users, the following code fails to aggregate data for  /events page.
       # connpass は https://connpass.com/robots.txt を守らない場合は、アクセス制限を施すので、下記の sleep を入れるようにした https://connpass.com/about/api/
-      sleep 5 if endpoint.include?(EventService::Providers::Connpass::ENDPOINT)
+      #sleep 5 if endpoint.include?(EventService::Providers::Connpass::ENDPOINT)
     end
   end
 end


### PR DESCRIPTION
#1535 により近日開催の道場のデータが更新されなくなった可能性があるため、原因が判明するまでの間、一時的にコメントアウトとしました。 @nanophate 