### PR TITLE
Add facebook event 2023 05 06

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -1332,7 +1332,7 @@
   url: https://coderdojo-matsubara.doorkeeper.jp/
 
 # 六ツ野
-- dojo_id: 203
+- dojo_id: 203 # 限定公開になったか削除されているようです。
   name: facebook
   group_id: 1821472277930255
   url: https://www.facebook.com/CoderDojo.Mutsuno/

--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -8,24 +8,23 @@
 #  group_id: 
 #  url: 
 
-# ほんごう: 個人アカウントのため取得できない
-# https://connpass.com/event/281123/
-#- dojo_id: 302
-#  name: connpass
-#  group_id: 
-#  url: 
+# ほんごう
+- dojo_id: 302
+  name: connpass
+  group_id: 13821
+  url: https://coderdojo-hongo.connpass.com/
 
-# 岩国 イベントが追加されたら group_id を取得する
-# - dojo_id: 301
-#   name: connpass
-#   group_id:
-#   url:
+# 岩国
+- dojo_id: 301
+  name: connpass
+  group_id: 13747
+  url: https://coderdojo-iwakuni.connpass.com/
 
-# 磐田 イベントが追加されたら group_id を取得する
-# - dojo_id: 300
-#   name: connpass
-#   group_id: 
-#   url: https://coderdojo-iwata.connpass.com
+# 磐田
+- dojo_id: 300
+  name: connpass
+  group_id: 13678
+  url: https://coderdojo-iwata.connpass.com
 
 # たかおか上市 @ 富山県
 - dojo_id:  299

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -5062,3 +5062,27 @@
   event_id:
   participants: 1
   evented_at: 2023/04/21 18:00
+
+# 2023/05/01 - 2023/05/31
+- dojo_id: 296
+  event_id:
+  participants: 3
+  evented_at: 2023/05/28 10:00
+- dojo_id: 25
+  event_id:
+  participants: 6
+  evented_at: 2023/05/14 10:00
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2023/05/21 10:00
+
+# 2023/06/01 - 2023/06/30
+- dojo_id: 296
+  event_id:
+  participants: 4
+  evented_at: 2023/06/25 10:00
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2023/06/25 10:00


### PR DESCRIPTION
### やったこと

- 2023年5月,6月分Facebookイベントを集計しました
- `rails statistics:aggregation[202305,202306,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました
- 合わせて`db/dojo_event_services.yaml` を更新しました

🔽 コマンド実行後の表示確認(ほんごうは現在開始前のイベントがないため表示されません)
![スクリーンショット 2023-07-05 10 49 53](https://github.com/coderdojo-japan/coderdojo.jp/assets/41533420/57f41a6c-d7f9-485c-b8d2-a8426b59afb5)

![スクリーンショット 2023-07-05 10 50 11](https://github.com/coderdojo-japan/coderdojo.jp/assets/41533420/fd6a7605-20f9-4bb1-bd5d-6d13d484894a)
