### PR TITLE
都道府県別CoderDojoカレンダーに必要な情報をEvent APIに追加する

### DIFF
--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -54,7 +54,11 @@ class UpcomingEvent < ApplicationRecord
           event_end_at: event[:event_end_at],
           event_url:    event[:event_url],
           prefecture:   dojo.prefecture.name,
-          participants: event[:participants]
+          participants: event[:participants],
+          event_update_at: event[:event_update_at],
+          address:      event[:address],
+          place:        event[:place],
+          limit:        event[:limit]
         }
       end
 

--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -45,12 +45,16 @@ class UpcomingEvent < ApplicationRecord
       list_of_dojo_and_events.each do |dojo, events|
         event = events.sort_by(&:event_at).first
         result << {
-          id:   dojo.id,
-          name: dojo.name,
-          url:  dojo.url,
-          event_title: event[:event_title],
-          event_date:  event[:event_at],
-          event_url:   event[:event_url],
+          id:           dojo.id,
+          name:         dojo.name,
+          url:          dojo.url,
+          event_id:     event[:id],
+          event_title:  event[:event_title],
+          event_date:   event[:event_at],
+          event_end_at: event[:event_end_at],
+          event_url:    event[:event_url],
+          prefecture:   dojo.prefecture.name,
+          participants: event[:participants]
         }
       end
 

--- a/db/migrate/20230714141908_add_details_to_upcoming_events.rb
+++ b/db/migrate/20230714141908_add_details_to_upcoming_events.rb
@@ -1,0 +1,8 @@
+class AddDetailsToUpcomingEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :upcoming_events, :event_update_at, :datetime
+    add_column :upcoming_events, :address, :string
+    add_column :upcoming_events, :place, :string
+    add_column :upcoming_events, :limit, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_07_132540) do
+ActiveRecord::Schema.define(version: 2023_07_14_141908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -100,6 +100,10 @@ ActiveRecord::Schema.define(version: 2023_03_07_132540) do
     t.integer "participants", null: false
     t.string "event_title", null: false
     t.datetime "event_end_at", null: false
+    t.datetime "event_update_at"
+    t.string "address"
+    t.string "place"
+    t.integer "limit"
     t.index ["dojo_event_service_id"], name: "index_upcoming_events_on_dojo_event_service_id"
     t.index ["service_name", "event_id"], name: "index_upcoming_events_on_service_name_and_event_id", unique: true
   end

--- a/lib/upcoming_events/tasks/connpass.rb
+++ b/lib/upcoming_events/tasks/connpass.rb
@@ -19,7 +19,11 @@ module UpcomingEvents
                              event_url:    e['event_url'],
                              event_at:     Time.zone.parse(e['started_at']),
                              event_end_at: Time.zone.parse(e['ended_at']),
-                             participants: e['accepted'])
+                             participants: e['accepted'],
+                             event_update_at: Time.zone.parse(e['updated_at']),
+                             address:      e['address'],
+                             place:        e['place'],
+                             limit:        e['limit'])
             end
           end
         end

--- a/lib/upcoming_events/tasks/doorkeeper.rb
+++ b/lib/upcoming_events/tasks/doorkeeper.rb
@@ -19,7 +19,11 @@ module UpcomingEvents
                              event_url:    e['public_url'],
                              participants: e['participants'],
                              event_at:     Time.zone.parse(e['starts_at']),
-                             event_end_at: Time.zone.parse(e['ends_at']))
+                             event_end_at: Time.zone.parse(e['ends_at']),
+                             event_update_at: Time.zone.parse(e['updated_at']),
+                             address:      e['address'],
+                             place:        e['venue_name'],
+                             limit:        e['ticket_limit'])
             end
           end
         end

--- a/spec/factories/upcoming_events.rb
+++ b/spec/factories/upcoming_events.rb
@@ -9,6 +9,10 @@ FactoryBot.define do
     event_at     { '2019-05-01 10:00'.in_time_zone }
     event_end_at { '2019-05-01 13:00'.in_time_zone }
     participants { 1 }
+    event_update_at { '2019-05-01 09:00'.in_time_zone }
+    address { '東京都新宿区高田馬場１丁目２８−１０' }
+    place { 'CASE Shinjuku 三慶ビル 4階' }
+    limit { 10 }
   end
 end
 


### PR DESCRIPTION
#1546 で提案した、Event APIに項目を追加するアイデアです。

実現イメージをお伝えするために、PRを作りました。Event API自体を変更するのではなく、新しくCalendar Event API（calendar-events.json）を作った方が影響が少ないかもしれません。

ご意見伺えれば幸いです！