### PR TITLE
Remove entrykit for M1 Mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5
+FROM ruby:3.0.6
 
 ENV LANG C.UTF-8
 
@@ -11,12 +11,6 @@ RUN apt-get update -qq \
 
 ENV ENTRYKIT_VERSION 0.4.0
 
-RUN wget https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
-    && tar -xvzf entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
-    && rm entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
-    && mv entrykit /bin/entrykit \
-    && chmod +x /bin/entrykit \
-    && entrykit --symlink
 
 RUN mkdir /app
 
@@ -24,6 +18,4 @@ WORKDIR /app
 
 RUN bundle config build.nokogiri --use-system-libraries
 
-ENTRYPOINT [ \
-    "prehook", "ruby -v", "--", \
-    "prehook", "bundle install -j3 --quiet", "--"]
+ENTRYPOINT [ "./entrypoint.rb" ]

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -1,0 +1,7 @@
+#! /usr/bin/env ruby
+
+system("ruby -v")
+system("gem install bundler:2.4.7")
+system("bundle install -j3 --quiet")
+
+exec *ARGV


### PR DESCRIPTION
#1548 で報告したM1 Macでdocker-compose upでエラーが出る件への対処です。
- https://ksss9.hatenablog.com/entry/2021/02/08/002737 に従って、Dockerfileからentrykitを削除し、entrypoint.rbを追加しました。
- Dockerfileで、Rubyのバージョンを3.0.6にあげています。
- entrypoint.rbで、Gemfile.lock似合わせて、bundler 2.4.7をインストールしています。次のエラーが出たためです。
```
Warning: the running version of Bundler (2.2.33) is older than the version that created the lockfile (2.4.7). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.4.7`.
```