### PR TITLE
connpass APIの呼び出し回数を削減する

### DIFF
--- a/lib/event_service/client.rb
+++ b/lib/event_service/client.rb
@@ -23,9 +23,6 @@ module EventService
 
         f.adapter  Faraday.default_adapter
       end
-      # TODO: According to the report by users, the following code fails to aggregate data for  /events page.
-      # connpass は https://connpass.com/robots.txt を守らない場合は、アクセス制限を施すので、下記の sleep を入れるようにした https://connpass.com/about/api/
-      #sleep 5 if endpoint.include?(EventService::Providers::Connpass::ENDPOINT)
     end
   end
 end

--- a/lib/event_service/providers/connpass.rb
+++ b/lib/event_service/providers/connpass.rb
@@ -33,6 +33,8 @@ module EventService
 
           param_period_patern.each do |param_period|
             loop do
+              # connpass は https://connpass.com/robots.txt を守らない場合は、アクセス制限を施すので、下記の sleep を入れるようにした https://connpass.com/about/api/
+              sleep 5
               part = @client.get('event/', params.merge(param_period))
 
               break if part['results_returned'].zero?

--- a/lib/event_service/providers/connpass.rb
+++ b/lib/event_service/providers/connpass.rb
@@ -14,6 +14,8 @@ module EventService
 
         # NOTE: yyyymm, yyyymmdd は文字列を要素とする配列(Array[String])で指定
         def fetch_events(series_id:, yyyymm: nil, yyyymmdd: nil)
+          series_id = series_id.join(',') if series_id.is_a?(Array)
+
           params = {
             series_id: series_id,
             start: 1,

--- a/lib/upcoming_events/tasks/connpass.rb
+++ b/lib/upcoming_events/tasks/connpass.rb
@@ -8,24 +8,25 @@ module UpcomingEvents
       end
 
       def run
-        @dojos.each do |dojo|
-          dojo.dojo_event_services.for(:connpass).each do |dojo_event_service|
-            @client.fetch_events(**@params.merge(series_id: dojo_event_service.group_id)).each do |e|
-              next unless e.dig('series', 'id').to_s == dojo_event_service.group_id
-
-              record = dojo_event_service.upcoming_events.find_or_initialize_by(event_id: e['event_id'])
-              record.update!(service_name: dojo_event_service.name,
-                             event_title:  e['title'],
-                             event_url:    e['event_url'],
-                             event_at:     Time.zone.parse(e['started_at']),
-                             event_end_at: Time.zone.parse(e['ended_at']),
-                             participants: e['accepted'],
-                             event_update_at: Time.zone.parse(e['updated_at']),
-                             address:      e['address'],
-                             place:        e['place'],
-                             limit:        e['limit'])
-            end
-          end
+        group_ids = @dojos.flat_map do |dojo|
+          dojo.dojo_event_services.for(:connpass).pluck(:group_id)
+        end
+      
+        @client.fetch_events(**@params.merge(series_id: group_ids)).each do |e|
+          dojo_event_service = DojoEventService.find_by(group_id: e.dig('series', 'id').to_s)
+          next unless dojo_event_service
+      
+          record = dojo_event_service.upcoming_events.find_or_initialize_by(event_id: e['event_id'])
+          record.update!(service_name: dojo_event_service.name,
+                         event_title:  e['title'],
+                         event_url:    e['event_url'],
+                         event_at:     Time.zone.parse(e['started_at']),
+                         event_end_at: Time.zone.parse(e['ended_at']),
+                         participants: e['accepted'],
+                         event_update_at: Time.zone.parse(e['updated_at']),
+                         address:      e['address'],
+                         place:        e['place'],
+                         limit:        e['limit'])
         end
       end
 

--- a/spec/lib/event_service/providers/connpass_spec.rb
+++ b/spec/lib/event_service/providers/connpass_spec.rb
@@ -9,23 +9,16 @@ RSpec.describe EventService::Providers::Connpass do
 
     it do
       expect(subject).to be_instance_of(Hash)
-      expect(subject['results_returned']).to eq 2
+      expect(subject['results_returned']).to eq 1
+      expect(subject['events'].size).to eq 1
       expect(subject['events'].first['event_id']).to eq 12345
       expect(subject['events'].first['series']['url']).to eq 'https://coderdojo-okutama.connpass.com/'
       expect(subject['events'].first['series']['id']).to eq 9876
-      expect(subject['events'].second['event_id']).to eq 12346 # assuming the second event has id 12346
-      expect(subject['events'].second['series']['url']).to eq 'https://coderdojo-okutama2.connpass.com/'
-      expect(subject['events'].second['series']['id']).to eq 9877
     end
-end
+  end
 
   describe '#fetch_events' do
     context 'when a single series_id is given' do
-      before do
-        # Thread.currentを使用してテストのコンテキスト間でデータを共有する
-        Thread.current[:series_ids] = [9876]
-      end
-
       subject { described_class.new.fetch_events(series_id: 9876) }
 
       it do
@@ -38,14 +31,8 @@ end
     end
 
     context 'when multiple series_ids are given' do
-      before do
-        # Thread.currentを使用してテストのコンテキスト間でデータを共有する
-        Thread.current[:series_ids] = [9876, 9877]
-      end
-
       subject { described_class.new.fetch_events(series_id: [9876, 9877]) }
 
-      # Here, you need to modify connpass_response to return multiple events for different series_ids
       it do
         expect(subject).to be_instance_of(Array)
         expect(subject.size).to eq 2

--- a/spec/lib/event_service/providers/connpass_spec.rb
+++ b/spec/lib/event_service/providers/connpass_spec.rb
@@ -9,23 +9,53 @@ RSpec.describe EventService::Providers::Connpass do
 
     it do
       expect(subject).to be_instance_of(Hash)
-      expect(subject['results_returned']).to eq 1
-      expect(subject['events'].size).to eq 1
+      expect(subject['results_returned']).to eq 2
       expect(subject['events'].first['event_id']).to eq 12345
       expect(subject['events'].first['series']['url']).to eq 'https://coderdojo-okutama.connpass.com/'
       expect(subject['events'].first['series']['id']).to eq 9876
+      expect(subject['events'].second['event_id']).to eq 12346 # assuming the second event has id 12346
+      expect(subject['events'].second['series']['url']).to eq 'https://coderdojo-okutama2.connpass.com/'
+      expect(subject['events'].second['series']['id']).to eq 9877
     end
-  end
+end
 
   describe '#fetch_events' do
-    subject { described_class.new.fetch_events(series_id: 9876) }
+    context 'when a single series_id is given' do
+      before do
+        # Thread.currentを使用してテストのコンテキスト間でデータを共有する
+        Thread.current[:series_ids] = [9876]
+      end
 
-    it do
-      expect(subject).to be_instance_of(Array)
-      expect(subject.size).to eq 1
-      expect(subject.first['event_id']).to eq 12345
-      expect(subject.first['series']['url']).to eq 'https://coderdojo-okutama.connpass.com/'
-      expect(subject.first['series']['id']).to eq 9876
+      subject { described_class.new.fetch_events(series_id: 9876) }
+
+      it do
+        expect(subject).to be_instance_of(Array)
+        expect(subject.size).to eq 1
+        expect(subject.first['event_id']).to eq 12345
+        expect(subject.first['series']['url']).to eq 'https://coderdojo-okutama.connpass.com/'
+        expect(subject.first['series']['id']).to eq 9876
+      end
+    end
+
+    context 'when multiple series_ids are given' do
+      before do
+        # Thread.currentを使用してテストのコンテキスト間でデータを共有する
+        Thread.current[:series_ids] = [9876, 9877]
+      end
+
+      subject { described_class.new.fetch_events(series_id: [9876, 9877]) }
+
+      # Here, you need to modify connpass_response to return multiple events for different series_ids
+      it do
+        expect(subject).to be_instance_of(Array)
+        expect(subject.size).to eq 2
+        expect(subject.first['event_id']).to eq 12345
+        expect(subject.first['series']['url']).to eq 'https://coderdojo-okutama.connpass.com/'
+        expect(subject.first['series']['id']).to eq 9876
+        expect(subject.second['event_id']).to eq 12346 # assuming the second event has id 12346
+        expect(subject.second['series']['url']).to eq 'https://coderdojo-okutama2.connpass.com/'
+        expect(subject.second['series']['id']).to eq 9877
+      end
     end
   end
 end

--- a/spec/support/shared_contexts/statistics.rb
+++ b/spec/support/shared_contexts/statistics.rb
@@ -4,7 +4,13 @@ RSpec.shared_context 'Use stub connection of Faraday' do
       f.response :json, :content_type => /\bjson$/
       f.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
         # connpass
-        stub.get('/event/') { connpass_response }
+        stub.get('/event/') do |env|
+          if env.params["series_id"] == '9876,9877'
+            multiple_series_ids_response
+          else
+            connpass_response
+          end
+        end
 
         # doorkeeper
         stub.get('/events') { doorkeeper_response }
@@ -21,22 +27,22 @@ end
 RSpec.shared_context 'Use stubs for Connpass' do
   include_context 'Use stub connection of Faraday'
 
+  # response for multiple series_ids 9876 and 9877
+  let(:multiple_series_ids_response) do
+    [
+      200,
+      { 'Content-Type' => 'application/json' },
+      '{"results_returned": 2, "events": [{"event_url": "https://coderdojo-okutama.connpass.com/event/12345/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama.connpass.com/", "id": 9876, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12345, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"},{"event_url": "https://coderdojo-okutama.connpass.com/event/12346/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama2.connpass.com/", "id": 9877, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12346, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"}], "results_start": 200, "results_available": 518}'
+    ]
+  end
+
+  # response for single series_id 9876, and for search
   let(:connpass_response) do
-    if Thread.current[:series_ids] == [9876]
-      # response for single series_id 9876
-      [
-        200,
-        { 'Content-Type' => 'application/json' },
-        '{"results_returned": 1, "events": [{"event_url": "https://coderdojo-okutama.connpass.com/event/12345/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama.connpass.com/", "id": 9876, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12345, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"}], "results_start": 200, "results_available": 518}'
-      ]
-    else
-      # response for multiple series_ids 9876 and 9877
-      [
-        200,
-        { 'Content-Type' => 'application/json' },
-        '{"results_returned": 2, "events": [{"event_url": "https://coderdojo-okutama.connpass.com/event/12345/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama.connpass.com/", "id": 9876, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12345, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"},{"event_url": "https://coderdojo-okutama.connpass.com/event/12346/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama2.connpass.com/", "id": 9877, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12346, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"}], "results_start": 200, "results_available": 518}'
-      ]
-    end
+    [
+      200,
+      { 'Content-Type' => 'application/json' },
+      '{"results_returned": 1, "events": [{"event_url": "https://coderdojo-okutama.connpass.com/event/12345/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama.connpass.com/", "id": 9876, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12345, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"}], "results_start": 200, "results_available": 518}'
+    ]
   end
 end
 

--- a/spec/support/shared_contexts/statistics.rb
+++ b/spec/support/shared_contexts/statistics.rb
@@ -22,11 +22,21 @@ RSpec.shared_context 'Use stubs for Connpass' do
   include_context 'Use stub connection of Faraday'
 
   let(:connpass_response) do
-    [
-      200,
-      { 'Content-Type' => 'application/json' },
-      '{"results_returned": 1, "events": [{"event_url": "https://coderdojo-okutama.connpass.com/event/12345/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama.connpass.com/", "id": 9876, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12345, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"}], "results_start": 200, "results_available": 518}'
-    ]
+    if Thread.current[:series_ids] == [9876]
+      # response for single series_id 9876
+      [
+        200,
+        { 'Content-Type' => 'application/json' },
+        '{"results_returned": 1, "events": [{"event_url": "https://coderdojo-okutama.connpass.com/event/12345/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama.connpass.com/", "id": 9876, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12345, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"}], "results_start": 200, "results_available": 518}'
+      ]
+    else
+      # response for multiple series_ids 9876 and 9877
+      [
+        200,
+        { 'Content-Type' => 'application/json' },
+        '{"results_returned": 2, "events": [{"event_url": "https://coderdojo-okutama.connpass.com/event/12345/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama.connpass.com/", "id": 9876, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12345, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"},{"event_url": "https://coderdojo-okutama.connpass.com/event/12346/", "event_type": "participation", "owner_nickname": "nalabjp", "series": {"url": "https://coderdojo-okutama2.connpass.com/", "id": 9877, "title": "CoderDojo series"}, "updated_at": "2017-04-29T14:59:30+09:00", "lat": "35.801763000000", "started_at": "2017-05-07T10:00:00+09:00", "hash_tag": "CoderDojo", "title": "CoderDojo title", "event_id": 12346, "lon": "139.087656000000", "waiting": 2, "limit": 10, "owner_id": 2525, "owner_display_name": "nalabjp", "description": "CoderDojo description", "address": "Okutama-cho Tokyo", "catch": "CoderDojo catch", "accepted": 10, "ended_at": "2017-05-07T12:00:00+09:00", "place": "Tokyo"}], "results_start": 200, "results_available": 518}'
+      ]
+    end
   end
 end
 


### PR DESCRIPTION
[connpass API](https://connpass.com/about/api/)は、series_idに複数のグループをカンマ区切りで指定してイベント情報を取得できます。

グループごとにAPIを呼び出すのに比べ、呼び出し回数を大幅に削減できます。これにより、#1535 で導入したSleepを入れても、現実的な時間で情報の取得が完了します。

懸念事項が2つあります。
1. この実装だとDojoやDojoEventServiceが大量になった場合に性能問題を引き起こす可能性があります。もっと良いやり方があればぜひご指摘ください 🙇 
2. テスト(spec)ですが、series_idが1つだけのままになっています。テストするのに適した道場があればお知らせください 🙇 