### PR TITLE
Dockerで動かす場合、DoorkeeperのAPI Tokenが必要なことをREADMEに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,11 @@ https://speakerdeck.com/yasulab/case-study-rails-cms-for-coderdojo
 
 上記の他、Docker を使ったセットアップ方法もあります。[Docker](https://www.docker.com/community-edition) をインストールし、下記の手順でセットアップしてください 🛠💨
 
+Doorkeeperのイベントを取得するために、[こちらでPublic API Access Tokenを生成](https://manage.doorkeeper.jp/user/oauth/applications)しておく必要があります。
+
 1. 本リポジトリを fork 後、clone します
 1. `.env.sample` をコピーして `.env` にリネームします
+1. `.env`に、環境変数`DOORKEEPER_API_TOKEN=<生成したPublic API Access Token>` を追記します
 1. ターミナルから `$ docker-compose up` を実行します
 1. ターミナルから `$ docker-compose exec rails bin/setup` を実行します
 1. ブラウザから [localhost:3000](http://localhost:3000) にアクセスします


### PR DESCRIPTION
Dockerで動かす場合、DoorkeeperのPublic API Access Tokenを`.env`ファイルに記載する必要がありました。
（記載がないと、bin/setup が途中で停止します）

README.mdに追記しておくと、心の準備ができて良いと思います 😸 