### PR TITLE
Add all_events parameter for Event API

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,12 +3,13 @@ class EventsController < ApplicationController
     @url             = request.url
     @upcoming_events = UpcomingEvent.group_by_prefecture
     @pokemon_events  = UpcomingEvent.group_by_keyword('ポケモン')
+    all_events = params[:all_events] == 'true'
 
     respond_to do |format|
       format.html
       format.json {
         # DojoMap: https://map.coderdojo.jp
-        render json: UpcomingEvent.for_dojo_map
+        render json: UpcomingEvent.for_dojo_map(all_events)
       }
     end
   end


### PR DESCRIPTION
#1546 #1547 の続きです。

Event APIは、一つの道場につき一つの開催予定を取得します。

Event APIに新しいパラメーター `all_events`を追加して、`?all_events=true`を指定した場合、その道場のすべての開催予定を取得できるようにします。これで、先の予定をCoderDojoカレンダーに追加できるようになります。