### PR TITLE
2023年7月,8月分Facebookイベント集計

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -83,7 +83,7 @@
 
 # 上市 @ 富山県
 - dojo_id:  298
-  name:     facebook
+  name: facebook
   group_id: 100090400606237
   url: https://www.facebook.com/coderdojo.kamiichi
 

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -5086,3 +5086,31 @@
   event_id:
   participants: 0
   evented_at: 2023/06/25 10:00
+
+# 2023/07/01 - 2023/07/31
+- dojo_id: 296
+  event_id:
+  participants: 2
+  evented_at: 2023/07/16 10:00
+- dojo_id: 83
+  event_id:
+  participants: 3
+  evented_at: 2023/07/02 10:00
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2023/07/30 10:00
+
+# 2023/08/01 - 2023/08/31
+- dojo_id: 296
+  event_id:
+  participants: 2
+  evented_at: 2023/08/20 10:00
+- dojo_id: 83
+  event_id:
+  participants: 3
+  evented_at: 2023/08/06 10:00
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2023/08/17 10:00


### PR DESCRIPTION
### やったこと

- 2023年7月,8月分Facebookイベントを集計しました
- `rails statistics:aggregation[202307,202308,facebook,]`の実行を確認しました
- 追加されたデータが正しいか確認しました
- 合わせて`db/dojo_event_services.yaml` で半角スペースを調整しました