### PR TITLE
Add latest-event-by-dojos page to track data easier

### DIFF
--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -24,4 +24,30 @@ class DojosController < ApplicationController
       format.html { redirect_to root_url(anchor: 'dojos') }
     end
   end
+
+  def recent
+    @url = request.url
+    @latest_event_by_dojos = []
+    Dojo.active.each do |dojo|
+      if dojo.event_histories.empty?
+        @latest_event_by_dojos << {
+          name: dojo.name,
+          url:  dojo.url,
+          event_at: '2000-01-23',
+          event_url: nil
+        }
+      else
+        @latest_event_by_dojos << {
+          name: dojo.name,
+          url:  dojo.url,
+          event_at:  dojo.event_histories.last.evented_at.strftime("%Y-%m-%d"),
+          event_url: dojo.event_histories.last.event_url.include?('dummy.url') ?
+            "https://www.facebook.com/#{dojo.event_histories.last.service_group_id}/events" :
+            dojo.event_histories.last.event_url
+        }
+      end
+    end
+
+    @latest_event_by_dojos.sort_by!{|dojo| dojo[:event_at]}
+  end
 end

--- a/app/views/dojos/recent.html.haml
+++ b/app/views/dojos/recent.html.haml
@@ -1,0 +1,38 @@
+- provide(:title, '道場情報 - 直近の開催日まとめ')
+- provide(:desc,  '道場別の直近開催日をまとめたページです。')
+- provide(:url,   @url)
+- provide(:meta_image,  "/img/ogp-events.jpeg")
+
+%section.cover
+  = lazy_image_tag '/events_cover.jpg', alt: 'Cover Photo on Upcoming Events', min: true
+
+%section#events.text-center{style: "margin-bottom: 100px;"}
+  %br
+  %h1 ☯️ 道場別の直近の開催日まとめ
+  %br
+  %p{style: "margin: 0 0px 40px 10px; line-height: 2.0em;"}
+    主にデータ分析や
+    \ 
+    %a{href: '/signup#terms-of-use'}<>
+      Active/Inactive
+    \ 
+    の判断などの用途で使われています。
+
+  %div{style: "margin-top: 20px;", align: 'center' }
+    %table{border: '1'}
+      %tr
+        %th{style: 'padding: 10px; text-align: center;'}
+          %small 道場名
+        %th{style: 'padding: 10px; text-align: center;'}
+          %small 開催日
+      - @latest_event_by_dojos.each do |dojo|
+        %tr
+          %td{style: 'padding: 1px 10px 1px 10px; text-align: right;'}
+            %small
+              %a{href: dojo[:url]}= dojo[:name]
+          %td{style: 'padding: 1px 10px 1px 10px;'}
+            %small
+            - if dojo[:event_url].nil?
+              = dojo[:event_at]
+            - else
+              %a{href: dojo[:event_url]}= dojo[:event_at]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
   get "/kata"             => "docs#kata"
   #get "/debug/kata"       => "docs#kata"
 
+  get '/dojos/recent'     => 'dojos#recent'
   resources :dojos,    only: %i(index) # Only API: GET /dojos.json
   resources :docs,     only: %i(index show)
   resources :podcasts, only: %i(index show)


### PR DESCRIPTION
各 CoderDojo の直近のイベント開催日をチェックしたい場面がいくつかあるので（例えば統計情報のトラックし忘れの Dojo などあれば早めに気づいたいなど）、当該データを一覧できるページを作りました。

主に内部的に使う用途のページですが、特に外部からアクセスされても困ることはないデータのため、認証などはつけていません 🔓

https://coderdojo.jp/dojos/recent
<img width="854" alt="image" src="https://github.com/coderdojo-japan/coderdojo.jp/assets/155807/b39d0ea2-b54e-4223-8bf4-c57c95b11f8c">
