### PR TITLE
Change routing #1566: /dojos/recent -> /events/latest

### DIFF
--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -24,30 +24,4 @@ class DojosController < ApplicationController
       format.html { redirect_to root_url(anchor: 'dojos') }
     end
   end
-
-  def recent
-    @url = request.url
-    @latest_event_by_dojos = []
-    Dojo.active.each do |dojo|
-      if dojo.event_histories.empty?
-        @latest_event_by_dojos << {
-          name: dojo.name,
-          url:  dojo.url,
-          event_at: '2000-01-23',
-          event_url: nil
-        }
-      else
-        @latest_event_by_dojos << {
-          name: dojo.name,
-          url:  dojo.url,
-          event_at:  dojo.event_histories.last.evented_at.strftime("%Y-%m-%d"),
-          event_url: dojo.event_histories.last.event_url.include?('dummy.url') ?
-            "https://www.facebook.com/#{dojo.event_histories.last.service_group_id}/events" :
-            dojo.event_histories.last.event_url
-        }
-      end
-    end
-
-    @latest_event_by_dojos.sort_by!{|dojo| dojo[:event_at]}
-  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,4 +13,30 @@ class EventsController < ApplicationController
       }
     end
   end
+
+  def latest
+    @url = request.url
+    @latest_event_by_dojos = []
+    Dojo.active.each do |dojo|
+      if dojo.event_histories.empty?
+        @latest_event_by_dojos << {
+          name: dojo.name,
+          url:  dojo.url,
+          event_at: '2000-01-23',
+          event_url: nil
+        }
+      else
+        @latest_event_by_dojos << {
+          name: dojo.name,
+          url:  dojo.url,
+          event_at:  dojo.event_histories.last.evented_at.strftime("%Y-%m-%d"),
+          event_url: dojo.event_histories.last.event_url.include?('dummy.url') ?
+            "https://www.facebook.com/#{dojo.event_histories.last.service_group_id}/events" :
+            dojo.event_histories.last.event_url
+        }
+      end
+    end
+
+    @latest_event_by_dojos.sort_by!{|dojo| dojo[:event_at]}
+  end
 end

--- a/app/views/events/latest.html.haml
+++ b/app/views/events/latest.html.haml
@@ -17,6 +17,15 @@
       Active/Inactive
     \ 
     の判断などの用途で使われています。
+    %br
+    %small
+      (
+      %a{href: events_path }<>
+        近日開催
+      のデータは含まず、
+      %a{href: stats_path }<>
+        過去開催
+      のデータを使っています)
 
   %div{style: "margin-top: 20px;", align: 'center' }
     %table{border: '1'}
@@ -24,7 +33,7 @@
         %th{style: 'padding: 10px; text-align: center;'}
           %small 道場名
         %th{style: 'padding: 10px; text-align: center;'}
-          %small 開催日
+          %small 直近の開催日
       - @latest_event_by_dojos.each do |dojo|
         %tr
           %td{style: 'padding: 1px 10px 1px 10px; text-align: right;'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,6 @@ Rails.application.routes.draw do
   get "/kata"             => "docs#kata"
   #get "/debug/kata"       => "docs#kata"
 
-  get '/dojos/recent'     => 'dojos#recent'
   resources :dojos,    only: %i(index) # Only API: GET /dojos.json
   resources :docs,     only: %i(index show)
   resources :podcasts, only: %i(index show)
@@ -69,8 +68,9 @@ Rails.application.routes.draw do
   #resources :stats,  only: %i(show)
   #resources :pokemons,  only: %i(index create)
 
-  # Upcoming Events
-  get "/events" => "events#index"
+  # Upcoming Events & Latest Events
+  get '/events'        => 'events#index'
+  get '/events/latest' => 'events#latest'
 
   # Redirects
   get "/releases/2016/12/12/new-backend", to: redirect('/docs/post-backend-update-history')


### PR DESCRIPTION
関連PR:

- #1566

> 各 CoderDojo の直近のイベント開催日をチェックしたい場面がいくつかあるので（例えば統計情報のトラックし忘れの Dojo などあれば早めに気づいたいなど）、当該データを一覧できるページを作りました。
> 
> 主に内部的に使う用途のページですが、特に外部からアクセスされても困ることはないデータのため、認証などはつけていません 🔓

上記 PR の URL を書き直した PR になります。

```diff
- https://coderdojo.jp/dojos/recent
+ https://coderdojo.jp/events/latest
```

https://coderdojo.jp/events/latest
<img width="854" alt="image" src="https://github.com/coderdojo-japan/coderdojo.jp/assets/155807/b39d0ea2-b54e-4223-8bf4-c57c95b11f8c">

