### PR TITLE
2023年9月分Facebookイベント集計

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -105,7 +105,7 @@
 
 # 上市 @ 富山県
 - dojo_id:  298
-  name: facebook
+  name: facebook #イベントページなし
   group_id: 100090400606237
   url: https://www.facebook.com/coderdojo.kamiichi
 
@@ -287,7 +287,7 @@
 
 # さが
 - dojo_id: 269
-  name: facebook #イベントページなし
+  name: facebook
   group_id:
   url: https://www.facebook.com/CoderDojo%E3%81%95%E3%81%8C-101932535364071
 - dojo_id: 269

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -5114,3 +5114,13 @@
   event_id:
   participants: 0
   evented_at: 2023/08/17 10:00
+
+# 2023/09/01 - 2023/09/30
+- dojo_id: 296
+  event_id:
+  participants: 3
+  evented_at: 2023/09/10 10:00
+- dojo_id: 83
+  event_id:
+  participants: 4
+  evented_at: 2023/09/03 10:00


### PR DESCRIPTION
### やったこと

- 2023年9月分のFacebookイベントを集計しました
- 以下をローカルで確認しました
  - `rails statistics:aggregation[202309,202309,facebook,]`の実行
  - 記載した数値が正しくデータベースに反映されたか
- 合わせて `db/dojo_event_services.yaml` で、状況に合わせてコメントを調整しました