### PR TITLE
2023年10月~12月分Facebookイベント集計

### DIFF
--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -5146,3 +5146,13 @@
   event_id:
   participants: 8
   evented_at: 2023/10/29 10:00
+
+# 2023/11/01 - 2023/11/30
+- dojo_id: 296
+  event_id:
+  participants: 1
+  evented_at: 2023/11/19 10:00
+- dojo_id: 83
+  event_id:
+  participants: 2
+  evented_at: 2023/11/5 10:00

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -5156,3 +5156,17 @@
   event_id:
   participants: 2
   evented_at: 2023/11/5 10:00
+  
+# 2023/12/01 - 2023/12/31
+- dojo_id: 296
+  event_id:
+  participants: 4
+  evented_at: 2023/12/10 10:00
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2023/12/17 10:00
+- dojo_id: 83
+  event_id:
+  participants: 5
+  evented_at: 2023/12/3 10:00

--- a/db/facebook_event_histories.yaml
+++ b/db/facebook_event_histories.yaml
@@ -5124,3 +5124,25 @@
   event_id:
   participants: 4
   evented_at: 2023/09/03 10:00
+
+# 2023/10/01 - 2023/10/31
+- dojo_id: 296
+  event_id:
+  participants: 4
+  evented_at: 2023/10/22 10:00
+- dojo_id: 269
+  event_id:
+  participants: 5
+  evented_at: 2023/10/09 13:00
+- dojo_id: 131
+  event_id:
+  participants: 0
+  evented_at: 2023/10/01 10:00
+- dojo_id: 83
+  event_id:
+  participants: 5
+  evented_at: 2023/10/1 10:00
+- dojo_id: 25
+  event_id:
+  participants: 8
+  evented_at: 2023/10/29 10:00


### PR DESCRIPTION
### やったこと

- 2023年10月~12月分のFacebookイベントを集計しました
- `rails statistics:aggregation[202310,202312,facebook,]`の実行を確認しました
- 記載した数値が、正しくデータベースに反映されたか確認しました

### その他
ここまでFacebookイベントは手動で集計していました。
手動による集計ではデータの正確性が確認できないため、API対応などでデータ収集できるようになるまで、以降のFacebookイベント集計は一旦休止します🙏