### PR TITLE
UNIX 哲学に沿って、成功時は何も表示せず失敗時 (notify_failure) のみタスク実行結果を通知する

### DIFF
--- a/lib/upcoming_events/aggregation.rb
+++ b/lib/upcoming_events/aggregation.rb
@@ -61,7 +61,9 @@ module UpcomingEvents
     class Notifier
       class << self
         def notify_success(provider)
-          notify("近日開催イベント情報#{provider_info(provider)}を収集しました")
+          # NOTE: UNIX 哲学に沿って、成功時は何も表示せず失敗時 (notify_failure) のみ通知する
+          #       https://ja.wikipedia.org/wiki/UNIX哲学#:~:text=沈黙のルール
+          # notify("近日開催イベント情報#{provider_info(provider)}を収集しました")
         end
 
         def notify_failure(provider, exception)


### PR DESCRIPTION
cf. https://ja.wikipedia.org/wiki/UNIX哲学#:~:text=沈黙のルール

> **沈黙のルール**
> 
> 余計な出力をすべきではない。他の開発者にとってただ邪魔なだけである。
> 開発者は不要な出力をしないようにプログラムを設計する必要がある。他のプログラムや開発者が、冗長な出力を解析することなく、プログラムの出力から必要な情報を選び出せるようにすることを目的とする。