### PR TITLE
c-searchで fixie アドレスを使用する

### DIFF
--- a/bin/c-search
+++ b/bin/c-search
@@ -1,10 +1,17 @@
 #!/bin/sh
+ENV_FILE=".env"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "$ENV_FILE が見つかりません"
+    exit 1
+fi
+
+source "$ENV_FILE"
+
 if [ $# -eq 0 ]
 then
     echo "Usage: c-search [CONNPASS_EVENT_URL | CONNPASS_EVENT_ID]"
 else
-    id=`echo $1 | sed -e 's/[^0-9]//g'`
-    curl -sL "connpass.com/api/v1/event/?event_id=${id}" | jq ".events[].series.id"
+    id=$(echo $1 | sed -e 's/[^0-9]//g')
+    curl -x "$FIXIE_URL" -sL "https://connpass.com/api/v1/event/?event_id=${id}" | jq ".events[].series.id"
 fi
-
-

--- a/bin/c-search
+++ b/bin/c-search
@@ -8,6 +8,11 @@ fi
 
 source "$ENV_FILE"
 
+if [ -z "$FIXIE_URL" ]; then
+    echo "FIXIE_URL が設定されていません"
+    exit 1
+fi
+
 if [ $# -eq 0 ]
 then
     echo "Usage: c-search [CONNPASS_EVENT_URL | CONNPASS_EVENT_ID]"


### PR DESCRIPTION
cf. #1600 

#1601 の対応と同様に、c-search 実行時もfixie アドレスを使用する様に更新しました🛠

[各イベント管理サービスの group_id の取得方法 - how_to_add_dojo.md](https://github.com/coderdojo-japan/coderdojo.jp/blob/main/docs/how_to_add_dojo.md#%E5%90%84%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E7%AE%A1%E7%90%86%E3%82%B5%E3%83%BC%E3%83%93%E3%82%B9%E3%81%AE-group_id-%E3%81%AE%E5%8F%96%E5%BE%97%E6%96%B9%E6%B3%95)

> 1. connpass のイベントページをブラウザで表示します (Ex. https://coderdojo-tobe.connpass.com/)
> 2. イベントのページを表示します (どのイベントでもOK)
> 3. イベントページの URL をコピーします
> 4. 以下のコマンドで上記のコピーした URL を指定すると `group_id` (Series ID) が得えられます

```
$ bin/c-search https://coderdojo-tobe.connpass.com/event/89808/
  => 5072
```