### PR TITLE
CoderDojo平和島をCoderDojo蒲田に変更しました。

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1134,11 +1134,11 @@
 - id: 313
   order: '131113'
   created_at: '2023-11-07'
-  name: 平和島
+  name: 蒲田
   prefecture_id: 13
-  url: https://coderdojo-heiwajima.connpass.com/
-  logo: "/img/dojos/heiwajima.webp"
-  description: 大田区平和島で毎月開催
+  url: https://coderdojo-kamata.connpass.com/
+  logo: "/img/dojos/default.webp"
+  description: 大田区蒲田で不定期開催
   tags:
   - Scratch
 - id: 17


### PR DESCRIPTION
平和島の開催場所が閉鎖になりましたので、
CoderDojo蒲田に変更してもらいました。
こちらの情報も変更お願い致します。