### PR TITLE
:new: Add CoderDojo 蒲田 in 東京都 (Renamed from '平和島')

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -27,6 +27,12 @@
 ### 以下、Dojo 情報まとめ ###
 ### (dojos.yaml の追加順) ###
 
+# 蒲田
+#- dojo_id: 321
+#  name: connpass
+#  group_id: イベントが追加されたら group_id を取得してコメントアウトを外す
+#  url: https://coderdojo-kamata.connpass.com/
+
 # 長野
 - dojo_id: 320
   name: connpass

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1133,12 +1133,23 @@
   - Swift
 - id: 313
   order: '131113'
+  is_active: false
   created_at: '2023-11-07'
   name: 平和島
   prefecture_id: 13
   url: https://coderdojo-heiwajima.connpass.com/
   logo: "/img/dojos/heiwajima.webp"
   description: 大田区平和島で毎月開催
+  tags:
+  - Scratch
+- id: 321
+  order: '131113'
+  created_at: '2024-06-10'
+  name: 蒲田
+  prefecture_id: 13
+  url: https://coderdojo-kamata.connpass.com/
+  logo: "/img/dojos/default.webp"
+  description: 大田区蒲田で不定期開催
   tags:
   - Scratch
 - id: 17


### PR DESCRIPTION
Close: #1605

- 関連PR: https://github.com/coderdojo-japan/coderdojo.jp/pull/1605

<img width="836" alt="image" src="https://github.com/coderdojo-japan/coderdojo.jp/assets/155807/e478d0bb-2a32-44f4-b1b6-29d4ac56a16b">
