### PR TITLE
Add `note` column to `Dojo` model to leave a comment in YAML for future development

### DIFF
--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -957,7 +957,8 @@
   - 映像制作
 - id: 158
   order: '122303'
-  is_active: true # Re-active @ 2024/03/16 https://twitter.com/KEITAROinNRT/status/1768837516835352825
+  note: 'Re-actived @ 2024/03/16 https://twitter.com/KEITAROinNRT/status/1768837516835352825'
+  is_active: true
   created_at: '2018-11-17'
   name: 成田
   prefecture_id: 12
@@ -1181,7 +1182,8 @@
   - JavaScript
 - id: 19
   order: '131130'
-  is_active: true # Re-activated @ 2024/04/01
+  is_active: true
+  note: 'Re-activated @ 2024/04/01'
   created_at: '2020-01-30'
   name: 渋谷
   prefecture_id: 13
@@ -2387,7 +2389,8 @@
   - Minecraft
 - id: 62
   order: '242039'
-  is_active: true  # Re-activated @ 2024年5月6日 (月曜)
+  is_active: true
+  note: 'Re-activated @ 2024年5月6日 (月曜)'
   created_at: '2016-12-22'
   name: 伊勢
   prefecture_id: 24
@@ -3186,7 +3189,8 @@
   - Ruby
 - id: 245
   order: '325015'
-  is_active: true  # Re-activated @ 2024年6月17日 (月曜)
+  is_active: true
+  note: 'Re-activated @ 2024年6月17日 (月曜)'
   created_at: '2020-03-10'
   name: 津和野
   prefecture_id: 32

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -957,7 +957,7 @@
   - 映像制作
 - id: 158
   order: '122303'
-  note: 'Re-actived @ 2024/03/16 https://twitter.com/KEITAROinNRT/status/1768837516835352825'
+  note: Re-actived @ 2024/03/16 https://twitter.com/KEITAROinNRT/status/1768837516835352825
   is_active: true
   created_at: '2018-11-17'
   name: 成田
@@ -1183,7 +1183,7 @@
 - id: 19
   order: '131130'
   is_active: true
-  note: 'Re-activated @ 2024/04/01'
+  note: Re-activated @ 2024/04/01
   created_at: '2020-01-30'
   name: 渋谷
   prefecture_id: 13
@@ -2390,7 +2390,7 @@
 - id: 62
   order: '242039'
   is_active: true
-  note: 'Re-activated @ 2024年5月6日 (月曜)'
+  note: Re-activated @ 2024年5月6日 (月曜)
   created_at: '2016-12-22'
   name: 伊勢
   prefecture_id: 24
@@ -3190,7 +3190,7 @@
 - id: 245
   order: '325015'
   is_active: true
-  note: 'Re-activated @ 2024年6月17日 (月曜)'
+  note: Re-activated @ 2024年6月17日 (月曜)
   created_at: '2020-03-10'
   name: 津和野
   prefecture_id: 32

--- a/db/migrate/20240618025325_add_note_to_dojos.rb
+++ b/db/migrate/20240618025325_add_note_to_dojos.rb
@@ -1,0 +1,5 @@
+class AddNoteToDojos < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dojos, :note, :string, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_14_141908) do
+ActiveRecord::Schema.define(version: 2024_06_18_025325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2023_07_14_141908) do
     t.boolean "is_active", default: true, null: false
     t.boolean "is_private", default: false, null: false
     t.integer "counter", default: 1, null: false
+    t.string "note", default: "", null: false
   end
 
   create_table "event_histories", id: :serial, force: :cascade do |t|

--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -32,14 +32,15 @@ namespace :dojos do
       d.name          = dojo['name']
       d.counter       = dojo['counter'] || 1
       d.email         = ''
-      d.order         = dojo['order'] || search_order_number(dojo['name'])
       d.description   = dojo['description']
       d.logo          = dojo['logo']
       d.tags          = dojo['tags']
+      d.note          = dojo['note'] || '' # For internal comments for developers
       d.url           = dojo['url']
       d.created_at    = d.new_record? ? Time.zone.now : dojo['created_at'] || d.created_at
       d.updated_at    = Time.zone.now
       d.prefecture_id = dojo['prefecture_id']
+      d.order         = dojo['order'] || search_order_number(dojo['name'])
       d.is_active     = dojo['is_active'].nil? ? true : dojo['is_active']
       d.is_private    = dojo['is_private'].nil? ? false : dojo['is_private']
 


### PR DESCRIPTION
`db/dojos.yaml` を自動生成している関係で以下のタスク実行時などに
`db/dojos.yaml` に書かれているコメントが自動的に削除されてしまうため、
開発に関するコメントを書き記すためのカラム「`note`」を追加しました 📝 💨 

```console
# YAML にあるデータを DB に書き込むタスク
$ bundle exec rails dojos:update_db_by_yaml

# DB にあるデータを YAML に書き出すタスク
$ bundle exec rails dojos:migrate_adding_id_to_yaml
```

本 PR マージ後は、以下のコミットのように `note` 欄にコメントを書き込むと YAML にも残せるようになります。

- YAML への書き込み例: https://github.com/coderdojo-japan/coderdojo.jp/pull/1610/commits/82f739bc45a906b348ae668fac67d52da370898c
- YAML への書き出し例: https://github.com/coderdojo-japan/coderdojo.jp/pull/1610/commits/6aba71ca8c44bc06100ea94bd5dcf14cf31e49f7