### PR TITLE
devcontainerの設定を修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,14 +3,17 @@
 // Config options: https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ruby
 {
   "name": "coderdojo.jp",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "rails",
+  "workspaceFolder": "/app",
+  "overrideCommand": true,
 
-  // Universal is well-customized image for Codespaces:
-  // https://hub.docker.com/_/microsoft-devcontainers-universal
-  "image": "mcr.microsoft.com/devcontainers/universal:latest",
-
-  // Use Ruby image if you want to pin Ruby version like '3.2'
-  // https://github.com/devcontainers/images/tree/main/src/ruby
-  //"image": "mcr.microsoft.com/devcontainers/ruby:3.0",
+  "containerEnv": {
+    "DATABASE_USER": "postgres",
+    "DATABASE_PASSWORD": "password",
+    "DATABASE_HOST": "db",
+    "DATABASE_PORT": "5432"
+  },
 
   // Enable learners to choose an affordable spec, starting at minimum one.
   //"hostRequirements": {
@@ -21,12 +24,10 @@
 
   "waitFor": "onCreateCommand",
   "onCreateCommand": "gem install solargraph -N",
-  //"onCreateCommand": "",
   //# => Solargraph gem not found. Run `gem install solargraph` or update your Gemfile.
   "updateContentCommand": "bundle install",
-  "postCreateCommand": "",
   "postAttachCommand": {
-    "server": "rails server"
+    "server": "rm -f /app/tmp/pids/server.pid && rails server -b 0.0.0.0"
   },
   "customizations": {
     "codespaces": {
@@ -47,7 +48,7 @@
 	//"ruby.lint": { "rubocop": true },
 	//"ruby.intellisense": "rubyLocate",
 	"editor.tabSize": 2,
-	"editor.renderWhitespace": false,
+	"editor.renderWhitespace": "none",
 	"files.associations": { "*.erb": "erb" },
 	"emmet.includeLanguages": { "erb": "html" },
 	


### PR DESCRIPTION
devcontainerが起動しなくなっていたので修正しました。

- ベースのimageが`mcr.microsoft.com/devcontainers/universal:latest`だとM1 Macでアーキテクチャが合わないようだったので、rubyのimageにしました。
- 既存のdocker composeを生かして、dbもセットアップできるようにしました
  - 既存のdocker-compose.ymlには手を加えない形にするために、devcontainer.jsonにdb用の環境変数を設定しています 
- 現在はrenderWhitespaceはstringを指定するようになっていたので、`none`を設定しました