### PR TITLE
docker-composeからversionを削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   rails:
     build:


### PR DESCRIPTION
最新のdocker composeはversion指定が不要なため削除しました