### PR TITLE
pg_stat_statements拡張機能を追加するSQLを追加

### DIFF
--- a/db/migrate/20250430110802_add_pg_stat_statements_extension.rb
+++ b/db/migrate/20250430110802_add_pg_stat_statements_extension.rb
@@ -1,0 +1,17 @@
+class AddPgStatStatementsExtension < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |direction|
+      direction.up do
+        execute <<-SQL
+          CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+        SQL
+      end
+
+      direction.down do
+        execute <<-SQL
+          DROP EXTENSION pg_stat_statements;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_15_124619) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_30_110802) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"


### PR DESCRIPTION
db/schema.rbに差分が出てしまうためpg_stat_statements拡張機能を追加するSQLを追加しました。
`IF NOT EXISTS`句を使っているので、既存のDBにpg_stat_statementsが存在しても問題ありません。