### PR TITLE
Fix logic for has_event_histories

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -34,7 +34,7 @@ class EventsController < ApplicationController
         name: dojo.name,
         note: dojo.note,
         url:  dojo.url,
-        has_event_histories: latest_event.nil?,
+        has_event_histories: latest_event.present?,
 
         # 過去のイベント開催日と note 内の日付を比較し、新しい方の日付を表示
         event_at: (latest_event_at < last_session_date) ?


### PR DESCRIPTION
## Summary
- correct `has_event_histories` flag when building latest events list

## Testing
- `bundle exec rspec` *(fails: rbenv: version `3.2.8` is not installed)*