### PR TITLE
Enable `config.active_record.belongs_to_required_by_default`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module CoderdojoJp
     # TODO: The following config should be switched to its default value `true`, but not urgent.
     # Rails 5.0: Require `belongs_to` associations by default. Previous versions had false.
     # https://railsguides.jp/configuring.html#config-active-record-belongs-to-required-by-default
-    config.active_record.belongs_to_required_by_default = false
+    config.active_record.belongs_to_required_by_default = true
 
     # Rails 8.0: `to_time` will always preserve the full timezone in Rails 8.1.
     config.active_support.to_time_preserves_timezone = :zone

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,11 +33,6 @@ module CoderdojoJp
     # Fixture paths
     config.fixture_paths = [Rails.root.join('spec/fixtures')]
 
-    # TODO: The following config should be switched to its default value `true`, but not urgent.
-    # Rails 5.0: Require `belongs_to` associations by default. Previous versions had false.
-    # https://railsguides.jp/configuring.html#config-active-record-belongs-to-required-by-default
-    config.active_record.belongs_to_required_by_default = true
-
     # Rails 8.0: `to_time` will always preserve the full timezone in Rails 8.1.
     config.active_support.to_time_preserves_timezone = :zone
   end

--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Statistics::Aggregation do
     let(:yaml_provider) { instance_double(EventService::Providers::StaticYaml) }
 
     before do
-      d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com')
-      d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com')
+      d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com', prefecture_id: 13)
+      d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com', prefecture_id: 13)
       create(:dojo_event_service, dojo_id: d1.id, name: :connpass, group_id: 9876)
       create(:dojo_event_service, dojo_id: d2.id, name: :doorkeeper, group_id: 5555)
 
-      create(:dojo, id: 194, name: 'Dojo194', email: 'info@dojo194.com', description: 'CoderDojo194', tags: %w(CoderDojo194), url: 'https://dojo194.com')
+      create(:dojo, id: 194, name: 'Dojo194', email: 'info@dojo194.com', description: 'CoderDojo194', tags: %w(CoderDojo194), url: 'https://dojo194.com', prefecture_id: 13)
       allow(EventService::Providers::StaticYaml).to receive(:new).and_return(yaml_provider)
       allow(yaml_provider).to receive(:fetch_events).and_return([
         { 'dojo_id' => 194, 'event_url' => 'https://example.com/event/12345', 'evented_at' => '2023-12-10 14:00', 'participants' => 1 }
@@ -153,10 +153,10 @@ RSpec.describe Statistics::Aggregation do
 
     context 'find_dojos_by(services)' do
       before :each do
-        @d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com')
-        @d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com')
-        @d3 = create(:dojo, name: 'Dojo3', email: 'info@dojo3.com', description: 'CoderDojo3', tags: %w(CoderDojo3), url: 'https://dojo3.com')
-        @d4 = create(:dojo, name: 'Dojo4', email: 'info@dojo4.com', description: 'CoderDojo4', tags: %w(CoderDojo4), url: 'https://dojo4.com')
+        @d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com', prefecture_id: 13)
+        @d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com', prefecture_id: 13)
+        @d3 = create(:dojo, name: 'Dojo3', email: 'info@dojo3.com', description: 'CoderDojo3', tags: %w(CoderDojo3), url: 'https://dojo3.com', prefecture_id: 13)
+        @d4 = create(:dojo, name: 'Dojo4', email: 'info@dojo4.com', description: 'CoderDojo4', tags: %w(CoderDojo4), url: 'https://dojo4.com', prefecture_id: 13)
         create(:dojo_event_service, dojo_id: @d1.id, name: :connpass,   group_id: 9876)
         create(:dojo_event_service, dojo_id: @d2.id, name: :doorkeeper, group_id: 5555)
         create(:dojo_event_service, dojo_id: @d2.id, name: :connpass,   group_id: 9877)

--- a/spec/lib/upcoming_events/aggregation_spec.rb
+++ b/spec/lib/upcoming_events/aggregation_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe UpcomingEvents::Aggregation do
 
   describe '.run' do
     before do
-      @d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com')
-      @d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com')
+      @d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com', prefecture_id: 13)
+      @d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com', prefecture_id: 13)
       @es1 = create(:dojo_event_service, dojo_id: @d1.id, name: :connpass,   group_id: 9876)
       @es2 = create(:dojo_event_service, dojo_id: @d2.id, name: :doorkeeper, group_id: 5555)
     end

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Dojo, :type => :model do
                  order: 0, description: "東京都世田谷区で毎週開催",
                  logo: "https://graph.facebook.com/346407898743580/picture?type=large",
                  url:  "http://tokyo.coderdojo.jp/",
-                 tags: ["Scratch", "Webサイト", "ゲーム"])
+                 tags: ["Scratch", "Webサイト", "ゲーム"],
+                 prefecture_id: 13)
   end
 
   subject { @dojo }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,4 +55,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    Rails.application.load_seed
+  end
 end


### PR DESCRIPTION
以前 Rails 5.0 にアップグレードする過程の残タスクとして、以下の設定のデフォルト値 (`true`) を上書きしたままになっていたので、本 PR でデフォルト値に戻す PR です。

```diff
# TODO: The following config should be switched to its default value `true`, but not urgent.
# Rails 5.0: Require `belongs_to` associations by default. Previous versions had false.
# https://railsguides.jp/configuring.html#config-active-record-belongs-to-required-by-default

- config.active_record.belongs_to_required_by_default = false
+ config.active_record.belongs_to_required_by_default = true
```

:warning: 分かりやすさのために上記では `false -> true` にしてますが、Rails 8.1 などにアップグレードする際に削除される（＝デフォルト値に戻る）ので、本 PR では実際には当該コードを削除する形で対応しています ✂️ ✅

- 関連 PR: #1693 
- 関連 Commit: https://github.com/coderdojo-japan/coderdojo.jp/pull/1693/commits/896e31e3c0dba75c36546479473a86cfdf87ce47
- 関連 URL: https://railsguides.jp/configuring.html#config-active-record-belongs-to-required-by-default

## やること

- [x] dba60542 `config.active_record.belongs_to_required_by_default` をデフォルト値 (`true`) にする
- [x] 62d78fcf 上記の設定変更後、テストを実行した際に発生した各種エラーを修正する

<details>
  <summary><strong>&raquo; AI による修正サポート</strong></summary>

> https://github.com/coderdojo-japan/coderdojo.jp/pull/1698  の PR を対応しています。PR 内にある各種リンク先の情報を確認し、テストを実行してください。


```bash
bundle exec rspec
```
PR https://github.com/coderdojo-japan/coderdojo.jp/pull/1698 の内容に従い、テストを実行しました。

**主な失敗内容:**
- 24件のテストが失敗しています。
- ほとんどの失敗は `ActiveRecord::RecordInvalid: バリデーションに失敗しました: Prefectureを入力してください` というエラーです。
  - これは `belongs_to :prefecture` の関連が必須（required）になったため、テストデータ作成時に `prefecture` が正しく設定されていないことが原因です。

**背景:**
- PRの説明通り、`config.active_record.belongs_to_required_by_default` のデフォルト値（`true`）に戻したことで、`belongs_to` 関連が必須になりました。
- そのため、`prefecture_id` などの外部キーがnilだとバリデーションエラーになります。

**次の対応案:**
- 失敗しているテストのFactoryやテストデータ生成部分で、`prefecture` または `prefecture_id` を必ずセットするよう修正する必要があります。

もし該当箇所の修正を進めたい場合は、どのファイルから対応したいかご指示ください。もしくは、失敗しているテストの該当Factoryやspecファイルをリストアップすることも可能です。

</details>