### PR TITLE
[WIP] トップページの news セクションを RSS から自動生成

### DIFF
--- a/lib/tasks/fetch_news.rake
+++ b/lib/tasks/fetch_news.rake
@@ -1,0 +1,62 @@
+require 'rss'
+require 'open-uri'
+require 'yaml'
+require 'active_support/broadcast_logger'
+
+namespace :news do
+  desc 'RSS フィードから最新ニュースを取得し、db/news.yml に書き出す'
+  task fetch: :environment do
+    # ロガー設定（ファイル＋コンソール出力）
+    file_logger = ActiveSupport::Logger.new('log/news.log')
+    console     = ActiveSupport::Logger.new(STDOUT)
+    logger      = ActiveSupport::BroadcastLogger.new(file_logger, console)
+
+    logger.info('==== START news:fetch ====')
+
+    # テスト／ステージング環境ではサンプルファイル、本番は実サイトのフィード
+    feed_urls = if Rails.env.test? || Rails.env.staging?
+      [ Rails.root.join('spec', 'fixtures', 'sample_news.rss').to_s ]
+    else
+      [
+        'https://coderdojo.jp/feed',
+        # 必要に応じて他 Dojo の RSS もここに追加可能
+        # 'https://coderdojotokyo.org/feed',
+      ]
+    end
+
+    # RSS 取得＆パース
+    items = feed_urls.flat_map do |url|
+      logger.info("Fetching RSS → #{url}")
+      begin
+        URI.open(url) do |rss|
+          feed = RSS::Parser.parse(rss, false)
+          feed.items.map do |item|
+            {
+              'url'          => item.link,
+              'title'        => item.title,
+              'published_at' => item.pubDate.to_s
+            }
+          end
+        end
+      rescue => e
+        logger.warn("⚠️ Failed to fetch #{url}: #{e.message}")
+        []
+      end
+    end
+
+    # 重複排除＆日付降順ソート
+    unique = items.uniq { |i| i['url'] }
+    sorted = unique.sort_by { |i| i['published_at'] }.reverse
+
+    # id を追加
+    sorted.each { |i| i['id'] = i['url'] }
+
+    # YAML に書き出し
+    File.open('db/news.yml', 'w') do |f|
+      f.write({ 'news' => sorted }.to_yaml)
+    end
+
+    logger.info("✅ Wrote #{sorted.size} items to db/news.yml")
+    logger.info('====  END news:fetch  ====')
+  end
+end

--- a/spec/fixtures/sample_news.rss
+++ b/spec/fixtures/sample_news.rss
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Sample News Feed</title>
+    <link>https://coderdojo.jp/</link>
+    <description>テスト用のサンプルニュースフィード</description>
+
+    <item>
+      <title>テスト記事①</title>
+      <link>https://example.com/articles/1</link>
+      <pubDate>Mon, 01 Jun 2025 10:00:00 +0900</pubDate>
+      <description>サンプル記事の本文①</description>
+    </item>
+
+    <item>
+      <title>テスト記事②</title>
+      <link>https://example.com/articles/2</link>
+      <pubDate>Tue, 02 Jun 2025 11:30:00 +0900</pubDate>
+      <description>サンプル記事の本文②</description>
+    </item>
+
+  </channel>
+</rss>


### PR DESCRIPTION
Fixes #1577

## この PR でやりたいこと
- 手作業で更新しているニュース一覧を RSS から自動取得して YAML 化し、CI／Actions で定期更新できるようにする

## この PR でやること
- [ ] 1. **以下の RSS フィードをチェックするタスクを lib/tasks/fetch_news.rake に実装**  
     - 対象フィード：  `https://coderdojo.jp/#news`（実際には `https://coderdojo.jp/feed` など）  
   - `lib/tasks` 配下に新規ファイルを作成  

- [ ] 2. **RSS から記事タイトル／公開日／URL を抽出し YAML に追記・更新**  
   - 出力先：`db/news.yml`  
   - 重複排除：URL を ID として `uniq`  
   - 通常 DB ではなく、コミット可能な YAML 経由で参照・更新できる設計

- [ ] 3. **上記タスクを GitHub Actions で毎朝 9:00 JST に実行**  
   - 定期スケジュール：`cron: '0 0 * * *'` （UTC0 = JST9:00）  
   - `db/news.yml` を自動コミット

- [ ] 4. **別途、CI（例: Heroku リリーススクリプト）で YAML から DB に保存**  
   - `scripts/release.sh` などの既存スクリプトと連携  
   - CI ログは外部に公開されない設計

## この PR でやらないこと 
- 他 Dojo のブログ RSS をまとめて `/blogs` で表示（拡張案）  