### PR TITLE
Rakeタスクのリファクタリング

### DIFF
--- a/lib/tasks/fetch_news.rake
+++ b/lib/tasks/fetch_news.rake
@@ -76,12 +76,12 @@ namespace :news do
     
     new_items.each do |new_item|
       if existing_items_hash.key?(new_item['url'])
-        # 既存アイテムの更新
         existing_item = existing_items_hash[new_item['url']]
-        updated_item = existing_item.merge(new_item)  # 新しい情報で更新
-        updated_items << updated_item
+        # タイトルまたは公開日が変わった場合のみ更新
+        if existing_item['title'] != new_item['title'] || existing_item['published_at'] != new_item['published_at']
+          updated_items << existing_item.merge(new_item)
+        end
       else
-        # 完全に新しいアイテム
         truly_new_items << new_item
       end
     end

--- a/lib/tasks/import_news.rake
+++ b/lib/tasks/import_news.rake
@@ -8,17 +8,31 @@ namespace :news do
 
     # entries を計算
     entries = raw['news'] || []
+    new_count = 0
+    updated_count = 0
 
     entries.each do |attrs|
       news = News.find_or_initialize_by(url: attrs['url'])
+      is_new = news.new_record?
+
       news.assign_attributes(
         title:        attrs['title'],
         published_at: attrs['published_at']
       )
-      news.save!
-      puts "[news] #{news.published_at.to_date} #{news.title}"
+      
+      if is_new || news.changed?
+        news.save!
+        if is_new
+          new_count += 1
+          status = 'new'
+        else
+          updated_count += 1
+          status = 'updated'
+        end
+        puts "[News] #{news.published_at.to_date} #{news.title} (#{status})"
+      end
     end
 
-    puts "Imported #{entries.size} items."
+    puts "Imported #{new_count + updated_count} items (#{new_count} new, #{updated_count} updated)."
   end
 end

--- a/lib/tasks/import_news.rake
+++ b/lib/tasks/import_news.rake
@@ -32,7 +32,7 @@ namespace :news do
         new_count += 1 if is_new
         updated_count += 1 unless is_new
 
-        logger.info "[News] #{news.published_at.to_date} #{news.title} (#{status})"  # ← puts から logger.info に変更
+        logger.info "[News] #{news.published_at.to_date} #{news.title} (#{status})"
       end
     end
 


### PR DESCRIPTION
Fixes. #1716 
cf. #1704 （cf. #1577 ）

`lib/tasks/fetch_news.rake`
### 解決すべき問題
- [x] **ネストが深く読みづらい問題**
- [x] **常に全ての既存アイテムが更新されてしまう問題**
     - `fetch_news.rake` → 差分がある場合のみ更新するように修正
     ↪︎ `title` または `published_at` に差分がある場合だけ `updated_items` に追加
     -  `import_news.rake` → 更新があった場合のみ `save!`
     ↪︎ `news.changed?` で変更があるか判定。
         新規 or 変更時だけ保存（既存データはそのまま）。
       （ログに新規/更新のステータスも出力）