### PR TITLE
Command Injection警告の解消（Slack通知処理の安全化）

### DIFF
--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,0 +1,34 @@
+require "net/http"
+require "uri"
+require "json"
+
+class SlackNotifier
+  class << self
+    # @param message [String] 通知するメッセージ
+    # @param webhook_url [String] SlackのWebhook URL
+    # @return [Boolean] 送信成功なら true / 失敗なら false
+    def post_message(message, webhook_url)
+      return false if webhook_url.blank?
+
+      uri = URI.parse(webhook_url)
+
+      request = Net::HTTP::Post.new(uri)
+      request["Content-Type"] = "application/json"
+      request.body = { text: message.to_s }.to_json
+
+      response = Net::HTTP.start(
+        uri.host,
+        uri.port,
+        use_ssl: uri.scheme == "https",
+        open_timeout: 5,
+        read_timeout: 5
+      ) { |http| http.request(request) }
+
+      Rails.logger.info("Slack通知レスポンスコード: #{response.code}")
+      response.code.to_i.between?(200, 299)
+    rescue StandardError => e
+      Rails.logger.warn("Slack通知エラー: #{e.class} #{e.message}")
+      false
+    end
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,29 +24,6 @@
       "note": ""
     },
     {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "7307f11036b1ab86f410d8d967d3972618705df73cafdd17f8e311c10c76c1f1",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "lib/statistics/aggregation.rb",
-      "line": 163,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"#{msg}\"}' #{slack_hook_url} -o /dev/null -w \"slack: %{http_code}\"`",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Statistics::Statistics::Aggregation::Notifier",
-        "method": "s(:self).notify"
-      },
-      "user_input": "msg",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "8ba988098c444755698e4e65d38a94f4095948c1a9bc6220c7e2a4636c3c04d7",
@@ -242,29 +219,6 @@
       "confidence": "Weak",
       "cwe_id": [
         79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "e5394a11f2e9bb6bc213b7ebd34fbcead20048858592aa19e5ae2961f33c636d",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "lib/upcoming_events/aggregation.rb",
-      "line": 89,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"#{msg}\"}' #{slack_hook_url} -o /dev/null -w \"slack: %{http_code}\"`",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "UpcomingEvents::UpcomingEvents::Aggregation::Notifier",
-        "method": "s(:self).notify"
-      },
-      "user_input": "msg",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
       ],
       "note": ""
     }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,29 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "69b5a133fab8ea617d2581423cefaf077b9366e683c5fac715647bddeec7f50a",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/sotechsha_pages_controller.rb",
-      "line": 5,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => \"sotechsha_pages/#{params[:page]}\", {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "SotechshaPagesController",
-        "method": "show"
-      },
-      "user_input": "params[:page]",
-      "confidence": "Medium",
-      "cwe_id": [
-        22
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "8ba988098c444755698e4e65d38a94f4095948c1a9bc6220c7e2a4636c3c04d7",
@@ -162,29 +139,6 @@
       "confidence": "Weak",
       "cwe_id": [
         79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "c54623ebce2c2053b95088b9da8112aee962e7cadd79bd9b4b9afdedaddc15b1",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/sotechsha2_pages_controller.rb",
-      "line": 5,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => \"sotechsha2_pages/#{params[:page]}\", {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Sotechsha2PagesController",
-        "method": "show"
-      },
-      "user_input": "params[:page]",
-      "confidence": "Medium",
-      "cwe_id": [
-        22
       ],
       "note": ""
     },

--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -160,7 +160,7 @@ module Statistics
 
         def notify(msg)
           $stdout.puts msg
-          puts `curl -X POST -H 'Content-type: application/json' --data '{"text":"#{msg}"}' #{slack_hook_url} -o /dev/null -w "slack: %{http_code}"` if notifierable?
+          SlackNotifier.post_message(msg, slack_hook_url) if notifierable?
         end
       end
     end

--- a/lib/upcoming_events/aggregation.rb
+++ b/lib/upcoming_events/aggregation.rb
@@ -86,7 +86,7 @@ module UpcomingEvents
 
         def notify(msg)
           $stdout.puts msg
-          puts `curl -X POST -H 'Content-type: application/json' --data '{"text":"#{msg}"}' #{slack_hook_url} -o /dev/null -w "slack: %{http_code}"` if notifierable?
+          SlackNotifier.post_message(msg, slack_hook_url) if notifierable?
         end
       end
     end


### PR DESCRIPTION
cf. #1727 
cf. #1729

`config/brakeman.ignore` に登録されていた `Command Injection` の警告を解消しました！

### やったこと
- `lib/statistics/aggregation.rb:163` の警告を修正
- `lib/upcoming_events/aggregation.rb:89` の警告を修正
- 解消済みの警告を `.ignore` から削除