### PR TITLE
Dynamic Render Path警告の解消（Book.exist?の安全化）

### DIFF
--- a/app/controllers/sotechsha2_pages_controller.rb
+++ b/app/controllers/sotechsha2_pages_controller.rb
@@ -1,7 +1,0 @@
-class Sotechsha2PagesController < ApplicationController
-  def index; end
-
-  def show
-    render "sotechsha2_pages/#{params[:page]}"
-  end
-end

--- a/app/controllers/sotechsha_pages_controller.rb
+++ b/app/controllers/sotechsha_pages_controller.rb
@@ -1,7 +1,0 @@
-class SotechshaPagesController < ApplicationController
-  def index; end
-
-  def show
-    render "sotechsha_pages/#{params[:page]}"
-  end
-end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -19,9 +19,14 @@ class Book
     end
 
     def exist?(title, page)
-      page.nil? ?
-        self.find(title).any? :
-        self.find(title).map(&:filename).include?(page + ".html")
+      return false unless page.present?
+  
+      view_paths = [
+        Rails.root.join("app/views/books/#{title}/#{page}.html.erb"),
+        Rails.root.join("app/views/#{title}/#{page}.html.erb")
+      ]
+  
+      view_paths.any? { |path| File.exist?(path) }
     end
   end
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,29 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "69b5a133fab8ea617d2581423cefaf077b9366e683c5fac715647bddeec7f50a",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/sotechsha_pages_controller.rb",
-      "line": 5,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => \"sotechsha_pages/#{params[:page]}\", {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "SotechshaPagesController",
-        "method": "show"
-      },
-      "user_input": "params[:page]",
-      "confidence": "Medium",
-      "cwe_id": [
-        22
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Command Injection",
       "warning_code": 14,
       "fingerprint": "7307f11036b1ab86f410d8d967d3972618705df73cafdd17f8e311c10c76c1f1",
@@ -185,29 +162,6 @@
       "confidence": "Weak",
       "cwe_id": [
         79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "c54623ebce2c2053b95088b9da8112aee962e7cadd79bd9b4b9afdedaddc15b1",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/sotechsha2_pages_controller.rb",
-      "line": 5,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => \"sotechsha2_pages/#{params[:page]}\", {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Sotechsha2PagesController",
-        "method": "show"
-      },
-      "user_input": "params[:page]",
-      "confidence": "Medium",
-      "cwe_id": [
-        22
       ],
       "note": ""
     },


### PR DESCRIPTION
cf. #1727 
cf. #1729 
cf. #1736 

`config/brakeman.ignore` に登録されていた `Dynamic Render Path` の警告を解消しました！

## やったこと
- `Book.exist?` メソッドで対象ディレクトリ内のファイル存在確認を行うよう修正
- 不要となった `SotechshaPagesController` / `Sotechsha2PagesController` を削除
- 解消済みの警告を `.ignore` から削除