### PR TITLE
🆕 Add CoderDojo 砧 in 東京都

### DIFF
--- a/db/dojo_event_services.yaml
+++ b/db/dojo_event_services.yaml
@@ -27,6 +27,12 @@
 ### 以下、Dojo 情報まとめ ###
 ### (dojos.yaml の追加順) ###
 
+# 砧（東京都世田谷区）
+#- dojo_id: 343
+#  name: connpass
+#  group_id: ???
+#  url: https://codeclub.org/ja/clubs/4e31fc13-205c-4738-9b62-2722d890f6ed
+
 # 赤坂国際（東京都港区）- 独自のイベント管理システム?
 #- dojo_id: 341
 #  name:

--- a/db/dojos.yaml
+++ b/db/dojos.yaml
@@ -1337,6 +1337,17 @@
   - HTML
   - CSS
   - JavaScript
+- id: 343
+  order: '131121'
+  created_at: '2025-08-12'
+  name: 砧
+  prefecture_id: 13
+  logo: "/img/dojos/default.webp"
+  url: https://connpass.com/event/363462/
+  description: 世田谷区で毎月1回開催
+  tags:
+  - Scratch
+  - micro:bit
 - id: 19
   order: '131130'
   is_active: false


### PR DESCRIPTION
### やったこと

- 砧dojoの追加
- 統計システムへの追加（ `group_id` が取得できなかったため、コメントアウトにて）
- ローカルで表示確認
<img width="281" height="342" alt="スクリーンショット 2025-08-12 11 49 59" src="https://github.com/user-attachments/assets/2805b420-b13f-4e87-ac46-9967e5655481" />