### PR TITLE
openssl gem を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'sass-rails', '>= 5'
 # https://gihyo.jp/article/2024/01/ruby3.3-bundled-gems
 gem 'csv'
 gem 'ostruct' # Depended by 'koala' gem and shown at 'deploy' job in Actions (rake assets:precompile)
+gem 'openssl' # Avoid version mismatch with system OpenSSL
 
 gem 'rambulance'         # Error handling pages: https://github.com/yuki24/rambulance
 gem 'airbrake'           # Error Monitoring by Airbrake: https://github.com/airbrake/airbrake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ GEM
     nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
     observer (0.1.2)
+    openssl (3.3.2)
     ostruct (0.6.1)
     parallel (1.27.0)
     parser (3.3.8.0)
@@ -509,6 +510,7 @@ DEPENDENCIES
   letter_opener_web
   listen
   memory_profiler
+  openssl
   ostruct
   pg
   puma


### PR DESCRIPTION
### 背景

`bundle exec bin/c-search` 実行時、openssl に関連するエラーが発生し、group_idが取得できなかった。

`'OpenSSL::SSL::SSLSocket#connect_nonblock': SSL_connect returned=1 errno=0 peeraddr=3.169.5.37:443 state=error: certificate verify failed (unable to get certificate CRL) (OpenSSL::SSL::SSLError)`

### やったこと

- システムとプロジェクトのバージョン不整合対策として openssl gem を追加
- `bundle install`

### 確認したこと
`bundle exec bin/c-search` にURLを渡して実行した時、正常にgroup_idが取得できる

🔽 参考
```
$ bundle exec bin/c-search https://coderdojo-yame.connpass.com/

17099
```
https://github.com/coderdojo-japan/coderdojo.jp/blob/43026e9fe17e09fa213fb89737b8884211a1067c/db/dojo_event_services.yml#L30-L34

<br>

## エラー発生時と解決時のログ（詳細版）

```console
# OpenSSL 3.5 系だと動く
$ openssl --version
OpenSSL 3.5.2 5 Aug 2025 (Library: OpenSSL 3.5.2 5 Aug 2025)

$ bin/c-search https://coderdojo-shin-osaka.connpass.com/
17055

$ brew upgrade openssl
...


# OpenSSL 3.6 系だと動かない
$ openssl --version
OpenSSL 3.6.0 1 Oct 2025 (Library: OpenSSL 3.6.0 1 Oct 2025)

$ bin/c-search https://coderdojo-shin-osaka.connpass.com/
/Users/yasulab/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:46:in 'OpenSSL::SSL::SSLSocket#connect_nonblock': 
SSL_connect returned=1 errno=0 peeraddr=3.169.5.97:443
state=error: certificate verify failed (unable to get certificate CRL)
(OpenSSL::SSL::SSLError)
...


# 本 PR (#1768) を取り込むと OpenSSL 3.6 系でも動く
$ git pull origin main && bundle install
...

$ bin/c-search https://coderdojo-shin-osaka.connpass.com/
17055
```