### PR TITLE
📝 created_at を自動設定項目として明記し、入力ミスを防ぐ

### DIFF
--- a/doc/how_to_add_dojo.md
+++ b/doc/how_to_add_dojo.md
@@ -48,7 +48,6 @@ Zen: https://zen.coderdojo.com/dojos/jp/okinawa-ken/okinawa-okinawa-prefecture/n
 
 ```yaml
 - order: '472018'
-  created_at: '2019-06-15'
   name: 那覇
   counter: 1                       # 省略化。連名道場のときに使います (後述)
   prefecture_id: 47
@@ -66,7 +65,7 @@ Zen: https://zen.coderdojo.com/dojos/jp/okinawa-ken/okinawa-okinawa-prefecture/n
 | 項目名 | 内容 |
 |:---|:---|
 | `id` | **入力しない。** タスク実行時に自動で追加されます (詳細は後述) |
-| `created_at` | 掲載申請日の年月日 |
+| `created_at` | **入力しない。** タスク実行時に自動で追加されます  (詳細は後述) |
 | `order` | [全国地方公共団体コード](http://www.soumu.go.jp/denshijiti/code.html) (詳細は後述) |
 | `name` | Dojo名 |
 | `counter` | 省略化。[連名道場](https://github.com/coderdojo-japan/coderdojo.jp/issues/610)を登録する際に使います |
@@ -92,7 +91,7 @@ yaml ファイルに各項目を追記したら次のコマンドを実行し、
 $ bundle exec rails dojos:update_db_by_yaml
 ```
 
-その後、DB に反映された id を yaml に書き出すため、次のコマンドを実行します。
+その後、DB に反映された `id` や `created_at` を YAML ファイルに書き出すため、次のコマンドを実行します。
 
 ```bash
 $ bundle exec rails dojos:migrate_adding_id_to_yaml
@@ -106,7 +105,7 @@ $ bundle exec rails dojos:migrate_adding_id_to_yaml
 ActiveRecord::Base.connection.execute("SELECT setval('dojos_id_seq', coalesce((SELECT MAX(id)+1 FROM dojos), 1), false)")
 ```
 
-yaml ファイルに id および order が動的に更新されたことを確認できたら `:new: Add CoderDojo 那覇 in 沖縄県` といったコミットをし、Pull Request を送ります。
+YAML ファイルに `id` および `created_at` が追加されたことを確認できたら `:new: Add CoderDojo 那覇 in 沖縄県` といったコミットをし、Pull Request を送ります。
 
 Pull Request 例: https://github.com/coderdojo-japan/coderdojo.jp/pull/274
 


### PR DESCRIPTION
Fix https://github.com/coderdojo-japan/coderdojo.jp/issues/1770

## 概要
新規Dojoの追加時における `created_at` フィールドの入力ミスを防ぐため、ドキュメントを更新しました。

## 背景
- PR #1769 で `created_at` の年を誤って入力（2015年と2025年を間違える）した問題が発生
- Issue: https://github.com/coderdojo-japan/coderdojo.jp/issues/1770

## 解決方法
`rails dojos:update_db_by_yaml` タスクは新規レコードに対して自動的に現在時刻を `created_at` に設定する仕組みになっています：

```ruby
d.created_at = d.new_record? ? Time.zone.now : dojo['created_at'] || d.created_at
```

この仕組みを活かし、新規Dojoの追加時には `created_at` を手動入力させないことで、入力ミスを構造的に防ぎます。

## 変更内容
1. YAMLサンプルから `created_at` の記載を削除
2. 項目説明で `created_at` を「**入力しない**」項目として明記（`id` と同様）
3. `rails dojos:migrate_adding_id_to_yaml` の説明を更新（`id` だけでなく `created_at` も追加されることを明記）

## テスト
- [x] ドキュメントの変更内容を確認
- [x] 既存のrakeタスクの動作に影響がないことを確認

## 関連

- https://github.com/coderdojo-japan/coderdojo.jp/issues/1770