### PR TITLE
`migrate_adding_id_to_yaml` で `created_at` も書き出すよう修正

### DIFF
--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -113,7 +113,7 @@ http://www.soumu.go.jp/denshijiti/code.html
       new_dojo['id']    = d.id
       new_dojo['order'] = d.order
       new_dojo['created_at'] = d.created_at&.to_date&.to_s
-      #new_dojo['name'] = d.order  # created の直後に固定させる場合の例
+      #new_dojo['name'] = d.name  # created の直後に固定させる場合の例
 
       new_dojo.merge!(dojo)
       new_dojo


### PR DESCRIPTION
close: #1770

### やったこと
`migrate_adding_id_to_yaml` を実行したとき、`id` と一緒に `created_at` も書き出すよう修正しました🛠️

**メモ:** 
YAML 内の既存の記述に影響を与えない（記載内容の並び順を既存と揃える）ため 、`new_dojo['order'] = d.order` のコメントアウトを解除しています！

### 確認したこと

- [x] タスクを実行すると`id` と `created_at` が書き出される
- [x] 更新箇所以外に既存のrakeタスクの動作に影響がない

### 確認方法
1. `db/dojos.yml `に以下のサンプルを入力
    ```
    - order: '011002'
      name: サンプル
      prefecture_id: 1
      logo: "/img/dojos/default.webp"
      url: https://example.com/
      description: 札幌市で月2回開催
      tags:
      - Scratch
      - micro:bit
      - Arduino
      - ラズベリーパイ
      - 電子工作
     ```
1. `$ bundle exec rails dojos:update_db_by_yaml` を実行
2. `$ bundle exec rails dojos:migrate_adding_id_to_yaml` を実行
3. `id` と `created_at` が書き出される
    ```
    - id: 349
      order: '011002'
      name: サンプル
      prefecture_id: 1
      logo: "/img/dojos/default.webp"
      url: https://example.com/
      description: 札幌市で月2回開催
      tags:
      - Scratch
      - micro:bit
      - Arduino
      - ラズベリーパイ
      - 電子工作
    ```
4. 不要な更新がない
    <img width="639" height="290" alt="スクリーンショット 2025-12-12 18 15 07" src="https://github.com/user-attachments/assets/75b28cff-8237-4268-a762-935832c2b631" />

MEMO: 確認後、サンプルで作成されたデータは削除しておく