### PR TITLE
🔒 テストデータのドメインを RFC 2606 準拠の example.com/org/net に修正

### DIFF
--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Statistics::Aggregation do
     let(:yaml_provider) { instance_double(EventService::Providers::StaticYaml) }
 
     before do
-      d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com', prefecture_id: 13)
-      d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com', prefecture_id: 13)
+      d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.example.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://example.com/dojo1', prefecture_id: 13)
+      d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.example.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://example.org/dojo2', prefecture_id: 13)
       create(:dojo_event_service, dojo_id: d1.id, name: :connpass, group_id: 9876)
       create(:dojo_event_service, dojo_id: d2.id, name: :doorkeeper, group_id: 5555)
 
-      create(:dojo, id: 194, name: 'Dojo194', email: 'info@dojo194.com', description: 'CoderDojo194', tags: %w(CoderDojo194), url: 'https://dojo194.com', prefecture_id: 13)
+      create(:dojo, id: 194, name: 'Dojo194', email: 'info@dojo194.example.com', description: 'CoderDojo194', tags: %w(CoderDojo194), url: 'https://example.com/dojo194', prefecture_id: 13)
       allow(EventService::Providers::StaticYaml).to receive(:new).and_return(yaml_provider)
       allow(yaml_provider).to receive(:fetch_events).and_return([
         { 'dojo_id' => 194, 'event_url' => 'https://example.com/event/12345', 'evented_at' => '2023-12-10 14:00', 'participants' => 1 }
@@ -153,10 +153,10 @@ RSpec.describe Statistics::Aggregation do
 
     context 'find_dojos_by(services)' do
       before :each do
-        @d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://dojo1.com', prefecture_id: 13)
-        @d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://dojo2.com', prefecture_id: 13)
-        @d3 = create(:dojo, name: 'Dojo3', email: 'info@dojo3.com', description: 'CoderDojo3', tags: %w(CoderDojo3), url: 'https://dojo3.com', prefecture_id: 13)
-        @d4 = create(:dojo, name: 'Dojo4', email: 'info@dojo4.com', description: 'CoderDojo4', tags: %w(CoderDojo4), url: 'https://dojo4.com', prefecture_id: 13)
+        @d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.example.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://example.com/dojo1', prefecture_id: 13)
+        @d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.example.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://example.org/dojo2', prefecture_id: 13)
+        @d3 = create(:dojo, name: 'Dojo3', email: 'info@dojo3.example.com', description: 'CoderDojo3', tags: %w(CoderDojo3), url: 'https://example.net/dojo3', prefecture_id: 13)
+        @d4 = create(:dojo, name: 'Dojo4', email: 'info@dojo4.example.com', description: 'CoderDojo4', tags: %w(CoderDojo4), url: 'https://example.com/dojo4', prefecture_id: 13)
         create(:dojo_event_service, dojo_id: @d1.id, name: :connpass,   group_id: 9876)
         create(:dojo_event_service, dojo_id: @d2.id, name: :doorkeeper, group_id: 5555)
         create(:dojo_event_service, dojo_id: @d2.id, name: :connpass,   group_id: 9877)


### PR DESCRIPTION
## 問題

`spec/lib/statistics/aggregation_spec.rb` のテストデータで、実在する可能性のあるドメイン（`dojo1.com`, `dojo194.com` など）を使用していました。これらのドメインは実際に誰かが所有している可能性があり、テストデータとして不適切です。

## 解決策

RFC 2606 で定められた、文書やテスト目的で予約されているドメインに修正しました：
- `example.com`
- `example.org`
- `example.net`

## 変更内容

### URL の修正
- `https://dojo1.com` → `https://example.com/dojo1`
- `https://dojo2.com` → `https://example.org/dojo2`
- `https://dojo3.com` → `https://example.net/dojo3`
- `https://dojo194.com` → `https://example.com/dojo194`

### メールアドレスの修正
- `info@dojo1.com` → `info@dojo1.example.com`
- `info@dojo2.com` → `info@dojo2.example.com`
- など

## テスト結果
```
15 examples, 0 failures
```

## 参考 URL

これらのドメインは IANA によって恒久的に予約されており、実際のインターネット上で使用されることはありません。

- https://www.iana.org/domains/reserved
- https://www.rfc-editor.org/rfc/rfc2606.html

  > ### [3](https://www.rfc-editor.org/rfc/rfc2606.html#section-3). Reserved Example Second Level Domain Names
  > 
  > The Internet Assigned Numbers Authority (IANA) also currently has the following second level domain names reserved which can be used as examples.
  > 
  > - example.com
  > - example.net
  > - example.org

- https://www.rfc-editor.org/rfc/rfc6761.html

  > ### [6.5](https://www.rfc-editor.org/rfc/rfc6761.html#section-6.5).  Domain Name Reservation Considerations for Example Domains
  > 
  > The domains "example.", "example.com.", "example.net.", "example.org.", and any names falling within those domains, are special in the following ways: