### PR TITLE
✉️ News タイトルに「寄贈」が含まれる場合は 🎁 絵文字を付与

### DIFF
--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -12,11 +12,12 @@ class News < ApplicationRecord
     return title if has_custom_emoji
 
     # Add preset Emoji to its prefix if title does not have Emoji.
-    emoji = case url
-            when %r{/podcasts/\d+}
+    emoji = if url.match?(%r{/podcasts/\d+})
               '📻'
-            when %r{prtimes\.jp}
+            elsif url.match?(%r{prtimes\.jp})
               '📢'
+            elsif title.include?('寄贈')
+              '🎁'
             else
               '📰'
             end

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe News, type: :model do
     end
 
     context '先頭文字が絵文字でない場合' do
+      it 'タイトルに「寄贈」が含まれる場合は🎁を付与する' do
+        news = build(:news, title: 'ノートPC 233台を寄贈しました', url: 'https://news.coderdojo.jp/2025/12/18/pc-donation')
+        expect(news.formatted_title).to eq '🎁 ノートPC 233台を寄贈しました'
+      end
+
+      it 'ポッドキャストURLはタイトルの「寄贈」より優先される' do
+        news = build(:news, title: 'ポッドキャストで寄贈について話しました', url: 'https://coderdojo.jp/podcasts/50')
+        expect(news.formatted_title).to eq '📻 ポッドキャストで寄贈について話しました'
+      end
+
       it 'ポッドキャストのURLには📻を付与する' do
         news = build(:news, title: 'エピソード33', url: 'https://coderdojo.jp/podcasts/33')
         expect(news.formatted_title).to eq '📻 エピソード33'


### PR DESCRIPTION
## 概要

ニュースタイトルに「寄贈」という文字が含まれる場合、プレフィックス絵文字として 🎁 を表示するように改善しました。

<img width="803" height="289" alt="image" src="https://github.com/user-attachments/assets/bbd35322-1f19-4d66-8ac0-85529e2b4017" />

## 変更内容

`News#formatted_title` メソッドに条件を追加：
- タイトルに「寄贈」が含まれる場合 → 🎁 絵文字を付与
- PC寄贈やその他の寄贈関連のニュースが視覚的に識別しやすくなります

## 優先順位

絵文字の優先順位は以下の通りです：

1. タイトルの先頭に既にカスタム絵文字がある場合 → そのまま表示
2. Internal URLs (e.g. `/podcasts/` → 📻)
3. PR TIMES URL → 📢
4. タイトルに「寄贈」が含まれる → 🎁
5. その他 → 📰

## テスト

- 「寄贈」を含むタイトルのテストケースを追加
- URLベースの絵文字が「寄贈」より優先されることを確認
- 全18テストがパス

```
18 examples, 0 failures
```