### PR TITLE
INACTIVE_THRESHOLDをINACTIVE_THRESHOLD_IN_MONTHに変更してコードを簡潔化

### DIFF
--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -26,17 +26,9 @@ class DocsController < ApplicationController
       @doc.content.gsub! "{{ NUM_OF_TOTAL_NINJAS }}",  Dojo::NUM_OF_TOTAL_NINJAS
     end
 
-    # INACTIVE_THRESHOLD を日本語の期間表記に変換
-    if @doc.content.include? "INACTIVE_THRESHOLD"
-      # 1.year → "１年間", 6.months → "６ヶ月間" のように変換
-      threshold_in_months = Dojo::INACTIVE_THRESHOLD.to_i / 1.month.to_i
-      threshold_text = if threshold_in_months >= 12
-                         years = threshold_in_months / 12
-                         "#{years.to_s.tr('0-9', '０-９')}年間"
-                       else
-                         "#{threshold_in_months.to_s.tr('0-9', '０-９')}ヶ月間"
-                       end
-      @doc.content.gsub! "{{ INACTIVE_THRESHOLD }}", threshold_text
+    # INACTIVE_THRESHOLD_IN_MONTH があればテキストに変換（例: 12ヶ月, 6ヶ月）
+    if @doc.content.include? "INACTIVE_THRESHOLD_IN_MONTH"
+      @doc.content.gsub! "{{ INACTIVE_THRESHOLD_IN_MONTH }}", (Dojo::INACTIVE_THRESHOLD_IN_MONTH / 1.month).to_s
     end
 
     @content    = Kramdown::Document.new(@doc.content, input: 'GFM').to_html

--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -110,7 +110,7 @@ class DojosController < ApplicationController
   # 道場の活動状況を表示（旧 /events/latest から移行）
   def activity
     # ビューで使用するための閾値をインスタンス変数に設定（モデルから取得）
-    @inactive_threshold = Dojo::INACTIVE_THRESHOLD
+    @inactive_threshold = Dojo::INACTIVE_THRESHOLD_IN_MONTH
     
     @latest_event_by_dojos = []
     Dojo.active.each do |dojo|

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -7,7 +7,7 @@ class Dojo < ApplicationRecord
   DOJO_INFO_YAML_PATH = Rails.root.join('db', 'dojos.yml')
 
   # アクティブかどうかを判定する直近の活動の閾値
-  INACTIVE_THRESHOLD = 1.year
+  INACTIVE_THRESHOLD_IN_MONTH = 12.months
 
   belongs_to :prefecture
   has_many   :dojo_event_services, dependent: :destroy

--- a/public/docs/signup.md
+++ b/public/docs/signup.md
@@ -41,7 +41,7 @@ CoderDojo の立ち上げ申請がまだお済みでない場合は、下記ペ�
 1. 文字数やタグ数に上限があるため、申請内容を一部変更して掲載する場合があります 🙏
   - 📝 例: scratch→Scratch，月１回開催→毎月開催，HTML5→HTML，マイクラ→Minecraft など
   - <br>
-1. 財団により非アクティブと判断された場合、もしくは活動の様子が `{{ INACTIVE_THRESHOLD }}` 確認できない場合は非表示になります 😴
+1. 財団により非アクティブと判断された場合、もしくは活動の様子が `{{ INACTIVE_THRESHOLD_IN_MONTH }}ヶ月間` 確認できない場合は非表示になります 😴
   - 📜️ [CoderDojo が承認されているかを確認する方法 - CoderDojo Japan](/docs/how-to-check-dojo-status)
   - <br>
 1. 申請後もロゴ画像や説明文を更新できますので、まずは気軽にお申し込みください 📮✨

--- a/spec/requests/docs_spec.rb
+++ b/spec/requests/docs_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Docs', type: :request do
       it('responds with 200 OK')  { expect(response).to have_http_status(:success) }
       it('contains Google Forms') { expect(response.body).to include('<iframe') }
       it('contains Google Forms URL') { expect(response.body).to include('docs.google.com/forms') }
-      it('has no raw CONSTANT name')  { expect(response.body).not_to include('{{ INACTIVE_THRESHOLD }}') }
+      it('has no raw CONSTANT name')  { expect(response.body).not_to include('{{ INACTIVE_THRESHOLD_IN_MONTH }}') }
     end
   end
 end


### PR DESCRIPTION
## 📝 概要
非アクティブ判定の閾値定数のリファクタリングを行い、コードを大幅に簡潔化しました。

## 🎯 変更の目的
- 定数名を明確にする（単位を明示）
- コードの複雑性を削減
- 保守性を向上

## ✅ 変更内容
### 1. 定数名の変更
- `INACTIVE_THRESHOLD` → `INACTIVE_THRESHOLD_IN_MONTH`
- 値: `1.year` → `12.months`（同じ期間だがmonths単位で統一）

### 2. docs_controller.rbの大幅な簡潔化
**Before（11行）:**
```ruby
threshold_in_months = Dojo::INACTIVE_THRESHOLD.to_i / 1.month.to_i
threshold_text = if threshold_in_months >= 12
                   years = threshold_in_months / 12
                   "#{years.to_s.tr('0-9', '０-９')}年間"
                 else
                   "#{threshold_in_months.to_s.tr('0-9', '０-９')}ヶ月間"
                 end
```

**After（3行）:**
```ruby
@doc.content.gsub! "{{ INACTIVE_THRESHOLD_IN_MONTH }}", 
                   (Dojo::INACTIVE_THRESHOLD_IN_MONTH / 1.month).to_s
```

## 📊 改善効果
- **コード削減**: 11行 → 3行（73%削減）
- **複雑性の削減**: 条件分岐、年への変換、全角数字変換を削除
- **保守性の向上**: シンプルな除算のみで処理

## ✅ テスト
- 全211個のテストが成功
- `bundle exec rspec` で確認済み

## 📁 変更ファイル
- `app/models/dojo.rb` - 定数名と値の変更
- `app/controllers/docs_controller.rb` - テンプレート処理の簡潔化  
- `app/controllers/dojos_controller.rb` - 定数名の更新
- `public/docs/signup.md` - テンプレート変数名の更新
- `spec/requests/docs_spec.rb` - テストの定数名更新