### PR TITLE
正規表現のセキュリティ改善：$ を \z に置き換え

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,7 +106,7 @@ module ApplicationHelper
   def prefecture_name_in_english(prefecture_name)
     # 都道府県名の英語表記を返す簡易マッピング
     # 「都」「府」「県」を除去してから検索
-    name_without_suffix = prefecture_name.gsub(/[都府県]$/, '')
+    name_without_suffix = prefecture_name.gsub(/[都府県]\z/, '')
 
     prefecture_names = {
       '北海道' => 'Hokkaido',


### PR DESCRIPTION
## 概要
正規表現でのセキュリティベストプラクティスに従い、文字列末尾の判定で `$` を `\z` に置き換えました。

## なぜ必要か
Ruby の正規表現において：
- `$` は改行文字の前でもマッチしてしまう
- `\z` は真の文字列末尾のみにマッチする
- セキュリティの観点から `\z` の使用が推奨される

## 変更内容
- `app/helpers/application_helper.rb` の `prefecture_name_in_english` メソッド
  - `/[都府県]$/` → `/[都府県]\z/`

## テスト
- 全211テストが通過
- 既存の機能に影響なし

## 参考
- PR #1782 で同様の修正（`^` → `\A`）を実施済み
- Ruby のセキュリティベストプラクティス