### PR TITLE
活動状況ページで非アクティブ道場も表示し、降順でソート

### DIFF
--- a/app/views/dojos/activity.html.erb
+++ b/app/views/dojos/activity.html.erb
@@ -74,7 +74,7 @@
       </tr>
       <% @latest_event_by_dojos.each do |dojo| %>
         <tr>
-          <td>
+          <td class="<%= 'inactive-item' unless dojo[:is_active] %>">
             <small>
               <%= link_to dojo_path(dojo[:id]) do %>
                 <%= dojo[:name] %><br>
@@ -82,10 +82,10 @@
               <% end %>
             </small>
           </td>
-          <td>
+          <td class="<%= 'inactive-item' unless dojo[:is_active] %>">
             <small><%= dojo[:created_at].strftime("%Y-%m-%d") %></small>
           </td>
-          <td>
+          <td class="<%= 'inactive-item' unless dojo[:is_active] %>">
             <small>
               <% if dojo[:note_date] && dojo[:latest_event_at] %>
                 <!-- 両方の日付がある場合：より新しい方を表示 -->
@@ -128,7 +128,7 @@
               <% end %>
             </small>
           </td>
-          <td>
+          <td class="<%= 'inactive-item' unless dojo[:is_active] %>">
             <small><small>
               <% search_query = URI.encode_www_form(q: "CoderDojo #{dojo[:name].split('@').first.strip}") %>
               <% search_range = URI.encode_www_form(tbs: "qdr:m12") # 過去12ヶ月の検索結果 %>
@@ -138,7 +138,7 @@
               <%= link_to '12ヶ月', [search_url, search_range].join('&'), target: "_blank" %>
             </small></small>
           </td>
-          <td>
+          <td class="<%= 'inactive-item' unless dojo[:is_active] %>">
             <small><small>
               <%= link_to dojo[:url], target: "_blank" do %>
                 Website
@@ -146,7 +146,7 @@
               <% end %>
             </small></small>
           </td>
-          <td class="url-cell">
+          <td class="url-cell <%= 'inactive-item' unless dojo[:is_active] %>">
             <small>
               <span title="<%= dojo[:note] %>">
                 <%= raw Addressable::URI.unescape(truncate_with_preserved_links(dojo[:note], length: 60)) %>


### PR DESCRIPTION

<img width="806" height="739" alt="image" src="https://github.com/user-attachments/assets/f7ed1ea4-4c1b-42d1-b070-b9fd732b160d" />

## 概要
/dojos/activity ページで非アクティブな道場も表示し、レビューしやすいよう降順でソートする機能を追加しました。

## 変更内容

### 1. 非アクティブ道場の表示
- アクティブな道場の後に非アクティブな道場を表示
- /dojos ページと同様にグレー背景（`inactive-item` クラス）を適用

### 2. ソート順の改善
- **アクティブな道場**: 従来通り昇順（古い→新しい）
- **非アクティブな道場**: 降順（新しい→古い）でソート
- 上から下へ順番にレビューしやすいよう配慮

### 3. テストの追加
- 非アクティブ道場の表示を確認するテスト
- ソート順を確認するテスト
- EventHistory を使った実際のデータ形式でのテスト

## 動作確認
- [x] 全テストが通過（`bundle exec rspec spec/requests/dojos_spec.rb`）
- [x] 活動中道場: 201件
- [x] 非活動道場: 130件
- [x] 合計: 331件

## スクリーンショット
（必要に応じて追加）

## 関連Issue
なし

## レビュー観点
- [ ] 非アクティブ道場の表示が適切か
- [ ] ソート順がレビューしやすいか
- [ ] パフォーマンスへの影響は問題ないか