### PR TITLE
活動状況ページのソート順を改善（最新の活動日付を優先）

### DIFF
--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -154,13 +154,17 @@ class DojosController < ApplicationController
 
     # それぞれのグループ内でソート
     active_dojos.sort_by! do |dojo|
-      sort_date = dojo[:latest_event_at] || dojo[:note_date] || dojo[:created_at]
+      # より新しい日付を使用してソート（活発な道場ほど下に表示）
+      dates = [dojo[:latest_event_at], dojo[:note_date], dojo[:created_at]].compact
+      sort_date = dates.max || dojo[:created_at]
       [sort_date, dojo[:order]]
     end
 
     # 非アクティブな道場は最新の開催日から古い順（降順）にソート
     inactive_dojos.sort_by! do |dojo|
-      sort_date = dojo[:latest_event_at] || dojo[:note_date] || dojo[:created_at]
+      # より新しい日付を使用してソート
+      dates = [dojo[:latest_event_at], dojo[:note_date], dojo[:created_at]].compact
+      sort_date = dates.max || dojo[:created_at]
       [-sort_date.to_i, dojo[:order]]  # マイナスを付けて降順にする
     end
 


### PR DESCRIPTION
## 📝 概要
活動状況ページ（/dojos/activity）のソート順を改善し、実際に活発な道場が正しくリストの下部（レビュー不要）に配置されるようにしました。

## 🔍 問題の詳細

### 発見された問題
和歌山道場が活発にもかかわらず、リストの上位に表示されていました：
- **イベント履歴**: 2017-03-12（古い）
- **ノート内の日付**: 2025-08-17（新しい、実際の活動状況）
- **現在のロジック**: 古いイベント履歴を優先 → 2017年でソート → 上位表示 ❌

### 原因
現在のソートロジックは以下の優先順位で日付を選択：
```ruby
# OR条件：最初に見つかった日付を使用
sort_date = dojo[:latest_event_at] || dojo[:note_date] || dojo[:created_at]
```

## ✅ 解決策

### 実装内容
より新しい日付を使用してソートするように修正：
```ruby
# MAX条件：最も新しい日付を使用
dates = [dojo[:latest_event_at], dojo[:note_date], dojo[:created_at]].compact
sort_date = dates.max || dojo[:created_at]
```

### 改善後の動作
- **和歌山道場**: 2025-08-17でソート → リスト下部へ（直近開催） ✅
- **つくば道場**: 2026-01-17でソート → さらに下部へ（直近開催） ✅

## 📊 効果

| 道場名 | 変更前のソート日付 | 変更後のソート日付 | 結果 |
|--------|-------------------|-------------------|------|
| 和歌山 | 2017年（古いイベント） | 2025年（最新のnote） | 正しく下部へ移動 |
| つくば | 2026年（変更なし） | 2026年（変更なし） | 適切な位置を維持 |

## 🧪 テスト
- [x] 既存のテストがすべて通過
- [x] Rails runner で具体的な道場のソート順を検証
- [x] アクティブ・非アクティブ両方に同じロジックを適用

## 💡 レビューポイント
- [ ] ソートロジックの変更が適切か
- [ ] パフォーマンスへの影響は問題ないか
- [ ] レビュー用途としての使いやすさは向上したか

## 📚 補足
この修正により、実際の活動状況がより正確に反映され、レビューが必要な道場（古い活動日付）が上位に、活発な道場（新しい活動日付）が下位に正しく配置されるようになります。