### PR TITLE
同期メソッドで note_date と note_link も含めて完全同期

### DIFF
--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -148,6 +148,10 @@ class DojosController < ApplicationController
     sync_event_date(36,  35) # 生駒は奈良の開催日を参照
     sync_event_date(294, 35) # 平群は奈良の開催日を参照
 
+    # 南柏 (ID: 112) と柏の葉 (ID: 311) は柏 (ID: 23) と同じイベントサービスを使用
+    sync_event_date(112, 23) # 南柏は、柏の開催日を参照
+    sync_event_date(311, 23) # 柏の葉は柏の開催日を参照
+
     # アクティブな道場と非アクティブな道場を分けてソート
     active_dojos   = @latest_event_by_dojos.select { |d| d[:is_active] }
     inactive_dojos = @latest_event_by_dojos.reject { |d| d[:is_active] }
@@ -184,6 +188,8 @@ class DojosController < ApplicationController
     if source_dojo && target_dojo
       target_dojo[:latest_event_at]  = source_dojo[:latest_event_at]
       target_dojo[:latest_event_url] = source_dojo[:latest_event_url]
+      target_dojo[:note_date]        = source_dojo[:note_date]
+      target_dojo[:note_link]        = source_dojo[:note_link]
     end
   end
 


### PR DESCRIPTION
## 📝 概要
同じイベントサービスを共有する道場グループ間で、完全な日付情報の同期を実現しました。

## 🔍 問題の詳細

### 発見された問題
柏グループの道場で表示日付に不整合がありました：
- **柏（ID: 23）**: 2026-01-04 を表示（note_date が優先）
- **南柏（ID: 112）**: 2021-05-16 を表示（latest_event_at のみ）
- **柏の葉（ID: 311）**: 2021-05-16 を表示（latest_event_at のみ）

### 原因
`sync_event_date` メソッドが部分的な同期しか行っていなかった：
```ruby
# 修正前：2つの情報のみ同期
target_dojo[:latest_event_at]  = source_dojo[:latest_event_at]
target_dojo[:latest_event_url] = source_dojo[:latest_event_url]
# note_date と note_link は同期されない ❌
```

## ✅ 解決策

### 実装内容
`sync_event_date` メソッドを拡張して、4つの情報すべてを同期：
```ruby
# 修正後：完全な同期
target_dojo[:latest_event_at]  = source_dojo[:latest_event_at]
target_dojo[:latest_event_url] = source_dojo[:latest_event_url]
target_dojo[:note_date]        = source_dojo[:note_date]  # 新規追加 ✅
target_dojo[:note_link]        = source_dojo[:note_link]  # 新規追加 ✅
```

## 📊 効果

### 柏グループの表示日付
| 道場名 | 修正前 | 修正後 |
|--------|--------|--------|
| 柏 | 2026-01-04 | 2026-01-04 |
| 南柏 | 2021-05-16 ❌ | 2026-01-04 ✅ |
| 柏の葉 | 2021-05-16 ❌ | 2026-01-04 ✅ |

### 奈良グループ（既存の同期も改善）
同様に、奈良・生駒・平群の道場も完全な同期により一貫性が向上します。

## 🎯 対象道場

現在の同期設定：
- **奈良グループ**
  - 奈良（ID: 35）→ 生駒（ID: 36）、平群（ID: 294）
- **柏グループ**
  - 柏（ID: 23）→ 南柏（ID: 112）、柏の葉（ID: 311）

## 🧪 テスト
- [x] Rails runner で柏グループの同期を検証
- [x] すべての道場で同じ日付（2026-01-04）が表示されることを確認
- [x] ビューでの表示ロジックと整合性があることを確認

## 💡 レビューポイント
- [ ] 完全な情報同期が適切か
- [ ] パフォーマンスへの影響は問題ないか
- [ ] 他のグループも同様の同期が必要か

## 📚 関連PR
- #1785 - 奈良グループ（奈良・生駒・平群）の同期処理を初回実装
- #1786 - ソート順の改善（和歌山・つくば等、最新の活動日付を優先）

## 📚 補足
柏道場のnoteには「柏・南柏・柏の葉が、合同でイベント管理 (2026-01-04)」と記載があり、実際に3つの道場が協力して活動していることが確認できます。この修正により、その実態が正しく反映されるようになります。