### PR TITLE
refactor: 開催日を記録日に変更 (/dojos/activity)

### DIFF
--- a/app/views/dojos/activity.html.erb
+++ b/app/views/dojos/activity.html.erb
@@ -19,8 +19,8 @@
     <div class='form__terms list'>
       <ul style='list-style-type: "\2713\0020"; font-size: smaller;'>
 	<li>「掲載日」は<%= link_to '統計情報 (道場別) ', dojos_path %> と同じロジックで表示しています。</li>
-	<li>「開催日」は<%= link_to '統計情報 (開催数)',  stats_path %> から直近の開催日を表示しています。</li>
-	<li>「開催日」のデータは <a href='https://doorkeeper.jp/'>Doorkeeper</a> と <a href='http://connpass.com/'>connpass</a> にのみ対応しています。</li>
+	<li>「記録日」は<%= link_to '統計情報 (開催数)',  stats_path %> や活動の確認/記録日を表示しています。</li>
+	<li>「記録日」は <a href='https://doorkeeper.jp/'>Doorkeeper</a> と <a href='http://connpass.com/'>connpass</a> の場合、自動で更新されます。</li>
       </ul>
     </div>
   </p>
@@ -47,7 +47,7 @@
           <small>
             🗓
             <br class='ignore-pc'>
-            <a href='<%= events_path %>'>開催日</a>
+            <a href='<%= events_path %>'>記録日</a>
           </small>
         </th>
         <th>

--- a/spec/requests/dojos_spec.rb
+++ b/spec/requests/dojos_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe "Dojos", type: :request do
     it "displays proper column headers" do
       get activity_dojos_path
       expect(response.body).to include("掲載日")
-      expect(response.body).to include("開催日")
+      expect(response.body).to include("記録日")
       expect(response.body).to include("ノート")
     end
     
@@ -530,16 +530,16 @@ RSpec.describe "Dojos", type: :request do
       
       dojo_row = dojo_row_match[0]
       
-      # The 開催日 (event date) column should show the newer note date (2025-03-16)
+      # The 記録日 (recorded date) column should show the newer note date (2025-03-16)
       # not the older event history date (2017-03-12)
       expect(dojo_row).to include("2025-03-16"), 
-        "Expected to see note date 2025-03-16 in 開催日 column, but found: #{dojo_row}"
+        "Expected to see note date 2025-03-16 in 記録日 column, but found: #{dojo_row}"
       
       expect(dojo_row).not_to include("2017-03-12"), 
         "Should not show old event history date 2017-03-12 when newer note date exists"
     end
 
-    it "should link to note URL when displaying note date in 開催日 column" do
+    it "should link to note URL when displaying note date in 記録日 column" do
       get activity_dojos_path
       
       # Find the dojo row
@@ -550,7 +550,7 @@ RSpec.describe "Dojos", type: :request do
       
       # Should contain a link to the note URL
       expect(dojo_row).to include("https://coderdojo-wakayama.hatenablog.com/entry/2025/03/16/230604"),
-        "Expected to find note URL in the 開催日 column"
+        "Expected to find note URL in the 記録日 column"
     end
     
     it "handles multiple date formats in note (YYYY-MM-DD and YYYY/MM/DD)" do
@@ -641,22 +641,22 @@ RSpec.describe "Dojos", type: :request do
       
       dojo_row = dojo_row_match[0]
       
-      # Extract just the 開催日 column to check the date display
+      # Extract just the 記録日 column to check the date display
       td_matches = dojo_row.scan(/<td[^>]*>(.*?)<\/td>/m)
       
-      # Based on debug output: td_matches[1] is the 開催日 column
+      # Based on debug output: td_matches[1] is the 記録日 column
       # (道場名 column seems to be skipped in regex due to complex link structure)
-      event_date_column = td_matches[1]&.first # 開催日 column
+      event_date_column = td_matches[1]&.first # 記録日 column
       
-      expect(event_date_column).not_to be_nil, "Could not find 開催日 column"
+      expect(event_date_column).not_to be_nil, "Could not find 記録日 column"
       
-      # Should show the newer event history date (2025-08-01) in the 開催日 column
+      # Should show the newer event history date (2025-08-01) in the 記録日 column
       expect(event_date_column).to include("2025-08-01"),
-        "Expected to see newer event history date 2025-08-01 in 開催日 column, but found: #{event_date_column}"
+        "Expected to see newer event history date 2025-08-01 in 記録日 column, but found: #{event_date_column}"
       
-      # The 開催日 column should not contain the older note date
+      # The 記録日 column should not contain the older note date
       expect(event_date_column).not_to include("2025-03-16"),
-        "Should not show older note date 2025-03-16 in 開催日 column when newer event history exists"
+        "Should not show older note date 2025-03-16 in 記録日 column when newer event history exists"
     end
   end
 end


### PR DESCRIPTION
## 概要
/dojos/activity ページの「開催日」という表記を「記録日」に変更しました。

<img width="472" height="231" alt="image" src="https://github.com/user-attachments/assets/57ea681a-1b72-4c58-804e-481b0ea87b92" />


## 変更理由
- 実際にはイベント開催日だけでなく、備考欄の活動記録日も含まれている
- より中立的で正確な表現にするため

## 変更内容
- `app/views/dojos/activity.html.erb`
  - ヘッダーの「開催日」→「記録日」
  - 説明文の改善
    - 「統計情報から直近の開催日」→「統計情報や活動の確認/記録日」
    - 「にのみ対応」→「の場合、自動で更新されます」
- `spec/requests/dojos_spec.rb`
  - テストの表記も同様に更新（13箇所）

## テスト
✅ すべてのテストが通過することを確認済み