### PR TITLE
kata ページ内の近日開催の道場へのリンクを修正

### DIFF
--- a/app/views/docs/kata.html.erb
+++ b/app/views/docs/kata.html.erb
@@ -87,7 +87,7 @@
 	<p>CoderDojo の雰囲気は掴めたでしょうか? もっと詳しく知るには<strong>実際に参加してみるのが近道</strong>です。<%= link_to '日本の道場一覧', root_path(anchor: 'dojos') %></a>や<%= link_to '近日開催の道場', events_path %>、もしくは<%= link_to '地図情報（DojoMap）', dojomap_url %> から最寄りの道場を探してみましょう!</p>
 
 	<div class='btn-cover' style="margin-top: 20px; margin-bottom: 100px;">
-	  <%= link_to '/event', class: 'btn-blue' do %>
+	  <%= link_to '/events', class: 'btn-blue' do %>
 	    📆
 	    近日開催から探す
 	  <% end %>


### PR DESCRIPTION
`/kata#welcome` にある「📆 近日開催から探す」のリンクが切れていたため、修正しました🛠️


🔽 更新後
https://i.gyazo.com/bb6e42fae93fc45cfb6692a19955c5af.gif