### PR TITLE
test: Dockerfile と .ruby-version の Ruby バージョン一致を検証するテストを追加

### DIFF
--- a/spec/ruby_version_spec.rb
+++ b/spec/ruby_version_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 # Gemfile (ruby file:) と CI (ruby-version: .ruby-version) はそれを参照している。
 # 一方 Dockerfile の FROM だけは Docker の仕様上ファイルを読めず、ベタ書きせざるを得ない。
 # そのため、両者がズレたまま気付かない事故を防ぐテストを置いている。
+#
+# 完全 DRY 化（ARG + build-arg）を見送った理由など、検討の経緯は PR #1836 を参照。
+# https://github.com/coderdojo-japan/coderdojo.jp/pull/1836
 RSpec.describe 'Ruby version consistency' do
   let(:ruby_version) { Rails.root.join('.ruby-version').read.strip }
 

--- a/spec/ruby_version_spec.rb
+++ b/spec/ruby_version_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+# Ruby のバージョンは .ruby-version を単一の真実の源とし、
+# Gemfile (ruby file:) と CI (ruby-version: .ruby-version) はそれを参照している。
+# 一方 Dockerfile の FROM だけは Docker の仕様上ファイルを読めず、ベタ書きせざるを得ない。
+# そのため、両者がズレたまま気付かない事故を防ぐテストを置いている。
+RSpec.describe 'Ruby version consistency' do
+  let(:ruby_version) { Rails.root.join('.ruby-version').read.strip }
+
+  it 'Dockerfile の FROM が .ruby-version と一致する' do
+    from_line = Rails.root.join('Dockerfile').read[/\AFROM ruby:(\S+)/, 1]
+
+    expect(from_line).to eq(ruby_version),
+      "Dockerfile の Ruby (#{from_line.inspect}) が .ruby-version (#{ruby_version.inspect}) と一致しません。" \
+      '両方を同じバージョンに更新してください。'
+  end
+end


### PR DESCRIPTION
## 背景

Ruby のバージョンが **2箇所** に書かれており、二重管理になっていました。

| 用途 | 参照元 |
|------|--------|
| 本番（Heroku buildpack） | `.ruby-version` ✅ |
| Gemfile | `ruby file: '.ruby-version'` ✅ |
| CI（brakeman.yml） | `ruby-version: .ruby-version` ✅ |
| **Dockerfile（ローカル開発のみ）** | **ベタ書き** ⚠️ |

Docker の `FROM` はリテラルか `ARG` しか受け付けず、`$(cat .ruby-version)` のようなファイル読み込みができないため、Dockerfile だけベタ書きにせざるを得ません。

## 変更内容

両者がズレたまま気付かない事故を防ぐため、**CI で検知するテスト**を追加しました（`spec/ruby_version_spec.rb`）。

ズレると次のメッセージで落ちます:

```
Dockerfile の Ruby ("9.9.9") が .ruby-version ("3.4.4") と一致しません。
両方を同じバージョンに更新してください。
```

## 検証（TDD）

- 🔴 **RED**: Dockerfile を `ruby:9.9.9` に変えると失敗することを確認
- 🟢 **GREEN**: 一致していれば通過
- ✅ **回帰なし**: 全 218 examples, 0 failures

## 検討したが見送った案

**`ARG RUBY_VERSION` + build-arg + direnv による完全 DRY 化**

```dockerfile
ARG RUBY_VERSION
FROM ruby:${RUBY_VERSION}
```

完全 DRY にはなりますが、direnv が効かない文脈（素の `docker build`・**devcontainer**・CI）でビルドが壊れるリスクがあります。Docker はローカル開発専用（本番は Heroku buildpack が `.ruby-version` を読む）なので、**完全 DRY の価値よりワークフローの安定を優先**しました。Rails 公式が生成する Dockerfile もリテラル埋め込みを採用しています。

なお `FROM ruby:3.4` のようにピンを緩める案は**罠**です。`Gemfile` の `ruby file: '.ruby-version'` は完全一致を要求するため、イメージ側の patch が進んだ瞬間 `bundle` が RubyVersionMismatch で落ちます。