### PR TITLE
feat(dojos): 道場の個別ページにロゴを表示する

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -661,6 +661,14 @@ body>footer a:hover {
   margin: 0 auto;
 }
 
+// 道場の個別ページ (/dojos/:id) でロゴを囲むリンク。
+// .dojo-picture が display: block のため、包む <a> をインラインのままにすると
+// クリック領域が行いっぱいに広がってしまう。inline-block で画像サイズに収める。
+.dojo-picture-link {
+  display: inline-block;
+  margin: 25px 0;
+}
+
 .dojo-name {
   display: block;
   margin: .5em 0;
@@ -1079,17 +1087,17 @@ section {
 /* Stats and Dojos table styling */
 .stats-table {
   table-layout: auto;
-  
+
   th {
     padding: 10px;
     text-align: center;
   }
-  
+
   td {
     padding: 1px 10px 1px 10px;
     text-align: right;
     font-size: smaller;
-    
+
     &.url-cell {
       white-space:   normal;         /* 改行を許可 */
       word-wrap:     break-word;     /* 古めのブラウザ向け */
@@ -1097,12 +1105,12 @@ section {
       word-break:    break-all;      /* 英数字が続く場合の保険 (必要に応じて) */
       text-align:    left;
     }
-    
+
     &.inactive-item {
       background-color: gainsboro;
     }
   }
-  
+
   // Activity page specific style for expired events
   span.expired a {
     color: red;

--- a/app/views/dojos/show.html.erb
+++ b/app/views/dojos/show.html.erb
@@ -10,9 +10,10 @@
 <section id="events" class="text-center" style="margin-bottom: 100px;">
   <br>
   <h1>☯️
-    CoderDojo <%= @dojo.name %> - 統計情報<br><small>（公開情報のみ掲載）</small>
+    CoderDojo <%= @dojo.name %> - 統計情報
   </h1>
-  <br>
+  <%= link_to lazy_image_tag(@dojo.logo, alt: "CoderDojo #{@dojo.name}", class: 'dojo-picture'), @dojo.url,
+              class: 'dojo-picture-link', target: "_blank", rel: "external noopener" %>
   <p style="margin: 0 0px 40px 10px; line-height: 1.5em;">
     <%= link_to "CoderDojo #{@dojo[:name]}", @dojo[:url] %>に関する<br class='ignore-pc'>公開されている統計情報をまとめたページです。
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -175,7 +175,42 @@
         79
       ],
       "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "e86b8054ce40ae9caeeafa36440f0f982cd6a57d8d54dc772334a8ac70390b3a",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/dojos/show.html.erb",
+      "line": 15,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(lazy_image_tag(Dojo.find(params[:id]).logo, :alt => (\"CoderDojo #{Dojo.find(params[:id]).name}\"), :class => \"dojo-picture\"), Dojo.find(params[:id]).url, :class => \"dojo-picture-link\", :target => \"_blank\", :rel => \"external noopener\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "DojosController",
+          "method": "show",
+          "line": 103,
+          "file": "app/controllers/dojos_controller.rb",
+          "rendered": {
+            "name": "dojos/show",
+            "file": "app/views/dojos/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "dojos/show"
+      },
+      "user_input": "Dojo.find(params[:id]).url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "Dojo の URL は db/dojos.yml で管理され、PR レビューを経てのみ変更される信頼済みデータのため。同一パターンの shared/_dojo.html.erb:3 も同じ理由で ignore 済み。詳細は PR #1840 を参照。"
     }
   ],
-  "brakeman_version": "7.1.0"
+  "brakeman_version": "7.1.0",
+  "updated": "2026-07-11 19:35:20 +0900"
 }

--- a/spec/requests/dojos_spec.rb
+++ b/spec/requests/dojos_spec.rb
@@ -5,33 +5,33 @@ RSpec.describe "Dojos", type: :request do
     before do
       # テストデータの準備
       # 2020年に作成されたアクティブな道場
-      @dojo_2020_active = create(:dojo, 
+      @dojo_2020_active = create(:dojo,
         name: "Test Dojo 2020",
         created_at: "2020-06-01",
         inactivated_at: nil
       )
-      
+
       # 2020年に作成、2021年に非アクティブ化
       @dojo_2020_inactive = create(:dojo,
         name: "Test Dojo 2020 Inactive",
         created_at: "2020-01-01",
         inactivated_at: "2021-03-01"
       )
-      
+
       # 2021年に作成されたアクティブな道場
       @dojo_2021_active = create(:dojo,
         name: "Test Dojo 2021",
         created_at: "2021-01-01",
         inactivated_at: nil
       )
-      
+
       # 2019年に作成、2020年に非アクティブ化（2020年末時点では非アクティブ）
       @dojo_2019_inactive = create(:dojo,
         name: "Test Dojo 2019 Inactive",
         created_at: "2019-01-01",
         inactivated_at: "2020-06-01"
       )
-      
+
       # counter > 1 の道場
       @dojo_multi_branch = create(:dojo,
         name: "Multi Branch Dojo",
@@ -40,7 +40,7 @@ RSpec.describe "Dojos", type: :request do
         counter: 3
       )
     end
-    
+
     describe "year parameter validation" do
       it "accepts valid years (2012 to current year)" do
         current_year = Date.current.year
@@ -49,33 +49,33 @@ RSpec.describe "Dojos", type: :request do
           expect(response).to have_http_status(:success)
         end
       end
-      
+
       it "rejects years before 2012" do
         get dojos_path(year: 2011, format: :json)
         expect(response).to redirect_to(dojos_path(anchor: 'table'))
         expect(flash[:inline_alert]).to include("2012年から")
       end
-      
+
       it "rejects future years" do
         future_year = Date.current.year + 1
         get dojos_path(year: future_year, format: :json)
         expect(response).to redirect_to(dojos_path(anchor: 'table'))
         expect(flash[:inline_alert]).to include("指定された年は無効です")
       end
-      
+
       it "handles invalid year strings" do
         get dojos_path(year: "invalid", format: :json)
         expect(response).to redirect_to(dojos_path(anchor: 'table'))
         expect(flash[:inline_alert]).to include("無効")
       end
     end
-    
+
     describe "year filtering functionality" do
       context "when no year parameter is provided" do
         it "returns all dojos (active and inactive)" do
           get dojos_path(format: :json)
           json_response = JSON.parse(response.body)
-          
+
           dojo_ids = json_response.map { |d| d["id"] }
           expect(dojo_ids).to include(@dojo_2020_active.id)
           expect(dojo_ids).to include(@dojo_2020_inactive.id)
@@ -83,18 +83,18 @@ RSpec.describe "Dojos", type: :request do
           expect(dojo_ids).to include(@dojo_2019_inactive.id)
           expect(dojo_ids).to include(@dojo_multi_branch.id)
         end
-        
+
         it "includes inactive dojos in HTML format" do
           get dojos_path(format: :html)
           expect(assigns(:dojos).map { |d| d[:id] }).to include(@dojo_2020_inactive.id)
         end
-        
+
         it "displays default message for all periods" do
           get dojos_path(format: :html)
           expect(response.body).to include('全期間の道場を表示中（非アクティブ含む）')
           expect(response.body).to include('alert-info')
         end
-        
+
         it "includes inactive dojos in CSV format" do
           get dojos_path(format: :csv)
           csv = CSV.parse(response.body, headers: true)
@@ -102,59 +102,59 @@ RSpec.describe "Dojos", type: :request do
           expect(csv_ids).to include(@dojo_2020_inactive.id)
         end
       end
-      
+
       context "when year=2020 is specified" do
         it "returns only dojos active at the end of 2020" do
           get dojos_path(year: 2020, format: :json)
           json_response = JSON.parse(response.body)
-          
+
           dojo_ids = json_response.map { |d| d["id"] }
           # 2020年末時点でアクティブだった道場のみ含まれる
           expect(dojo_ids).to include(@dojo_2020_active.id)
           expect(dojo_ids).to include(@dojo_multi_branch.id)
-          
+
           # 2020年末時点で非アクティブだった道場は含まれない
           expect(dojo_ids).not_to include(@dojo_2019_inactive.id)
-          
+
           # 2021年に作成された道場は含まれない
           expect(dojo_ids).not_to include(@dojo_2021_active.id)
-          
+
           # 2021年に非アクティブ化された道場は2020年末時点ではアクティブなので含まれる
           expect(dojo_ids).to include(@dojo_2020_inactive.id)
         end
-        
+
         it "filters correctly in HTML format" do
           get dojos_path(year: 2020, format: :html)
-          
+
           dojo_ids = assigns(:dojos).map { |d| d[:id] }
           expect(dojo_ids).to include(@dojo_2020_active.id)
           expect(dojo_ids).not_to include(@dojo_2019_inactive.id)
           expect(dojo_ids).not_to include(@dojo_2021_active.id)
         end
-        
+
         it "does not show inactivated styling for dojos active in 2020" do
           get dojos_path(year: 2020, format: :html)
-          
+
           # HTMLレスポンスを取得
           html = response.body
-          
+
           # 2021年に非アクティブ化された道場（Test Dojo 2020 Inactive）が含まれていることを確認
           expect(html).to include("Test Dojo 2020 Inactive")
-          
+
           # その道場の行を探す（IDで特定）
           dojo_row_match = html.match(/Test Dojo 2020 Inactive.*?<\/tr>/m)
           expect(dojo_row_match).not_to be_nil
-          
+
           dojo_row = dojo_row_match[0]
-          
+
           # 重要: この道場は2021年3月に非アクティブ化されたが、
           # 2020年末時点ではアクティブだったので、inactive-item クラスを持たないべき
           expect(dojo_row).not_to include('class="inactive-item"')
         end
-        
+
         it "filters correctly in CSV format" do
           get dojos_path(year: 2020, format: :csv)
-          
+
           csv = CSV.parse(response.body, headers: true)
           csv_ids = csv.map { |row| row["ID"].to_i }
           expect(csv_ids).to include(@dojo_2020_active.id)
@@ -162,80 +162,80 @@ RSpec.describe "Dojos", type: :request do
           expect(csv_ids).not_to include(@dojo_2021_active.id)
         end
       end
-      
+
       context "when year=2021 is specified" do
         it "returns dojos active at the end of 2021" do
           get dojos_path(year: 2021, format: :json)
           json_response = JSON.parse(response.body)
-          
+
           dojo_ids = json_response.map { |d| d["id"] }
           # 2021年末時点でアクティブな道場
           expect(dojo_ids).to include(@dojo_2020_active.id)
           expect(dojo_ids).to include(@dojo_2021_active.id)
           expect(dojo_ids).to include(@dojo_multi_branch.id)
-          
+
           # 2021年3月に非アクティブ化された道場は含まれない
           expect(dojo_ids).not_to include(@dojo_2020_inactive.id)
           expect(dojo_ids).not_to include(@dojo_2019_inactive.id)
         end
-        
+
         it "does not show any inactivated dojos for year 2021" do
           get dojos_path(year: 2021, format: :html)
-          
+
           html = response.body
-          
+
           # 2021年末時点でアクティブな道場のみが含まれる
           expect(html).to include("Test Dojo 2020")      # アクティブ
           expect(html).to include("Test Dojo 2021")      # アクティブ
           expect(html).to include("Multi Branch Dojo")   # アクティブ
-          
+
           # 2021年に非アクティブ化された道場は含まれない
           expect(html).not_to include("Test Dojo 2020 Inactive")
           expect(html).not_to include("Test Dojo 2019 Inactive")
-          
+
           # すべての表示された道場は inactive-item クラスを持たないべき
           # （2021年末時点ではすべてアクティブなので）
           expect(html.scan('class="inactive-item"').count).to eq(0)
         end
       end
     end
-    
+
     describe "counter field in output" do
       it "includes counter field in JSON response" do
         get dojos_path(format: :json)
         json_response = JSON.parse(response.body)
-        
+
         multi_branch = json_response.find { |d| d["id"] == @dojo_multi_branch.id }
         expect(multi_branch["counter"]).to eq(3)
       end
-      
+
       it "includes counter column in CSV with sum total" do
         get dojos_path(format: :csv)
         csv = CSV.parse(response.body, headers: true)
-        
+
         # ヘッダーに道場数が含まれる
         expect(csv.headers).to include("道場数")
-        
+
         # 各道場のcounter値が含まれる
         multi_branch_row = csv.find { |row| row["ID"] == @dojo_multi_branch.id.to_s }
         expect(multi_branch_row["道場数"]).to eq("3")
       end
-      
+
       it "includes counter field in CSV data rows" do
         get dojos_path(format: :csv)
-        
+
         csv = CSV.parse(response.body, headers: true)
         # 各道場のcounter値が正しく含まれることを確認
         multi_branch_row = csv.find { |row| row["ID"] == @dojo_multi_branch.id.to_s }
         expect(multi_branch_row["道場数"]).to eq("3")
-        
+
         normal_dojo_row = csv.find { |row| row["ID"] == @dojo_2020_active.id.to_s }
         expect(normal_dojo_row["道場数"]).to eq("1")
       end
-      
+
       it "filters counter values correctly for specific year" do
         get dojos_path(year: 2020, format: :csv)
-        
+
         csv = CSV.parse(response.body, headers: true)
         # 2020年末時点でアクティブな道場のみが含まれることを確認
         dojo_ids = csv.map { |row| row["ID"].to_i }
@@ -245,50 +245,50 @@ RSpec.describe "Dojos", type: :request do
         expect(dojo_ids).not_to include(@dojo_2021_active.id)  # 2021年作成なので含まれない
       end
     end
-    
+
     describe "CSV format specifics" do
       it "includes correct headers" do
         get dojos_path(format: :csv)
         csv = CSV.parse(response.body, headers: true)
-        
+
         # 全期間の場合は閉鎖日カラムが追加される
         expect(csv.headers).to eq(['ID', '道場名', '道場数', '都道府県', 'URL', '設立日', '状態', '閉鎖日'])
       end
-      
+
       it "does not include total row for better data consistency" do
         get dojos_path(format: :csv)
         csv = CSV.parse(response.body)
-        
+
         # 合計行が含まれないことを確認（データ一貫性のため）
         csv.each do |row|
           # IDカラムに「合計」という文字列が含まれないことを確認
           expect(row[0]).not_to eq("合計") if row[0]
         end
-        
+
         # 全ての行がデータ行またはヘッダー行であることを確認
         expect(csv.all? { |row| row.compact.any? }).to be true
       end
-      
+
       it "formats dates correctly" do
         get dojos_path(format: :csv)
         csv = CSV.parse(response.body, headers: true)
-        
+
         first_dojo = csv.first
         expect(first_dojo["設立日"]).to match(/\d{4}-\d{2}-\d{2}/)
       end
-      
+
       it "shows active/inactive status correctly" do
         get dojos_path(format: :csv)
         csv = CSV.parse(response.body, headers: true)
-        
+
         active_row = csv.find { |row| row["ID"] == @dojo_2020_active.id.to_s }
         expect(active_row["状態"]).to eq("アクティブ")
-        
+
         inactive_row = csv.find { |row| row["ID"] == @dojo_2020_inactive.id.to_s }
         expect(inactive_row["状態"]).to eq("非アクティブ")
       end
     end
-    
+
     describe "HTML format year selection UI" do
       it "shows year selection form with auto-submit" do
         get dojos_path
@@ -298,7 +298,7 @@ RSpec.describe "Dojos", type: :request do
         expect(response.body).to include('2012')
         expect(response.body).to include(Date.current.year.to_s)
       end
-      
+
       it "displays selected year message when filtered" do
         get dojos_path(year: 2020)
         expect(response.body).to include('2020年末時点')
@@ -309,7 +309,7 @@ RSpec.describe "Dojos", type: :request do
         # inline_infoメッセージが表示されることを確認
         expect(response.body).to include('alert-info')
       end
-      
+
       it "includes CSV and JSON download links with year parameter" do
         get dojos_path(year: 2020)
         expect(response.body).to include('CSV')
@@ -327,7 +327,7 @@ RSpec.describe "Dojos", type: :request do
         created_at: 1.week.ago,
         inactivated_at: nil
       )
-      
+
       # 非アクティブな道場を作成
       @inactive_dojo = create(:dojo,
         name: "Inactive Dojo",
@@ -335,40 +335,40 @@ RSpec.describe "Dojos", type: :request do
         inactivated_at: 1.year.ago
       )
     end
-    
+
     it "returns http success" do
       get activity_dojos_path
       expect(response).to have_http_status(:success)
     end
-    
+
     it "displays the activity status page" do
       get activity_dojos_path
       expect(response.body).to include("道場別の活動記録まとめ")
     end
-    
+
     it "includes both active and inactive dojos" do
       get activity_dojos_path
       expect(response.body).to include(@active_dojo.name)
       expect(response.body).to include(@inactive_dojo.name)
     end
-    
+
     it "displays inactive dojos with inactive-item class" do
       get activity_dojos_path
       doc = Nokogiri::HTML(response.body)
-      
+
       # 非アクティブな道場の行を探す（リンク内にある名前を探す）
       inactive_link = doc.xpath("//a[contains(., '#{@inactive_dojo.name}')]").first
       expect(inactive_link).not_to be_nil
-      
+
       # そのリンクを含む行（tr）を取得
       inactive_row = inactive_link.xpath("ancestor::tr").first
       expect(inactive_row).not_to be_nil
-      
+
       # その行のすべてのセルに inactive-item クラスがあることを確認
       inactive_cells = inactive_row.css('td')
       expect(inactive_cells.all? { |cell| cell['class']&.include?('inactive-item') }).to be true
     end
-    
+
     it "sorts inactive dojos by latest event date in descending order" do
       # 複数の非アクティブな道場を作成（異なる作成日で）
       older_inactive_dojo = create(:dojo,
@@ -376,13 +376,13 @@ RSpec.describe "Dojos", type: :request do
         created_at: 2.years.ago,  # より古い作成日
         inactivated_at: 6.months.ago
       )
-      
+
       newer_inactive_dojo = create(:dojo,
-        name: "Newer Inactive Dojo",  
+        name: "Newer Inactive Dojo",
         created_at: 1.year.ago,  # より新しい作成日
         inactivated_at: 3.months.ago
       )
-      
+
       # db/static_event_histories.yml の形式に合わせてEventHistory を作成
       # より古いイベント
       EventHistory.create!(
@@ -395,7 +395,7 @@ RSpec.describe "Dojos", type: :request do
         service_group_id: 'static',
         event_id: 1
       )
-      
+
       # より新しいイベント
       EventHistory.create!(
         dojo_id: newer_inactive_dojo.id,
@@ -407,62 +407,62 @@ RSpec.describe "Dojos", type: :request do
         service_group_id: 'static',
         event_id: 2
       )
-      
+
       get activity_dojos_path
       doc = Nokogiri::HTML(response.body)
-      
+
       # 全ての道場の名前を取得（テーブルの最初のセルのリンクから）
       dojo_links = doc.css('table tr td:first-child a')
       dojo_names = dojo_links.map(&:text).map(&:strip)
-      
+
       # 非アクティブな道場の中で、newer_inactive_dojo が older_inactive_dojo より先に表示されることを確認
       newer_index = dojo_names.find_index { |name| name.include?(newer_inactive_dojo.name) }
       older_index = dojo_names.find_index { |name| name.include?(older_inactive_dojo.name) }
-      
+
       expect(newer_index).not_to be_nil
       expect(older_index).not_to be_nil
       expect(newer_index).to be < older_index
     end
-    
+
     it "redirects from old URL /events/latest" do
       get "/events/latest"
       expect(response).to redirect_to(activity_dojos_path)
     end
-    
+
     it "displays proper column headers" do
       get activity_dojos_path
       expect(response.body).to include("経過日")
       expect(response.body).to include("記録日")
       expect(response.body).to include("ノート")
     end
-    
+
     it "displays days passed for active dojos" do
       get activity_dojos_path
       # 経過日は日数で表示される
       expect(response.body).to include("日")
     end
-    
+
     it "displays dojo ID same as /dojos page" do
       get activity_dojos_path
       # /dojos ページと同じように ID が表示される
       expect(response.body).to include("(ID: #{@active_dojo.id})")
       expect(response.body).to include("道場名")
     end
-    
+
     it "displays URLs without http://, https://, and www. in note column" do
       # URLを含むnoteを持つ道場を作成
-      create(:dojo, 
+      create(:dojo,
         name: "Test Dojo",
         note: "Active https://www.example.com/ and http://www.example.net/ and https://example.org/",
         inactivated_at: nil
       )
-      
+
       get activity_dojos_path
-      
+
       # ノート欄の表示テキストに http://, https://, www. が含まれないことを確認
       doc = Nokogiri::HTML(response.body)
       note_cells = doc.css('td.url-cell')
-      
+
       test_cell = note_cells.find { |cell| cell.text.include?("example") }
       expect(test_cell).not_to be_nil
       expect(test_cell.text).not_to include("https://")
@@ -472,21 +472,21 @@ RSpec.describe "Dojos", type: :request do
       expect(test_cell.to_html).to include('href="https://www.example.com/"')
       expect(test_cell.to_html).to include('href="http://www.example.net/"')
     end
-    
+
     it "displays Facebook URLs as fb.com in note column" do
       # Facebook URLを含むnoteを持つ道場を作成
-      create(:dojo, 
+      create(:dojo,
         name: "Test Dojo with Facebook",
         note: "Check out https://www.facebook.com/groups/coderdojo and https://facebook.com/events/123",
         inactivated_at: nil
       )
-      
+
       get activity_dojos_path
-      
+
       # ノート欄の表示テキストで facebook.com が fb.com に短縮されていることを確認
       doc = Nokogiri::HTML(response.body)
       note_cells = doc.css('td.url-cell')
-      
+
       fb_cell = note_cells.find { |cell| cell.text.include?("fb.com") }
       expect(fb_cell).not_to be_nil
       expect(fb_cell.text).to include("fb.com/groups/coderdojo")
@@ -508,51 +508,51 @@ RSpec.describe "Dojos", type: :request do
         inactivated_at: nil,
         note: "Active for years - 2025-03-16 https://coderdojo-wakayama.hatenablog.com/entry/2025/03/16/230604"
       )
-      
+
       # Create an old event history record for this dojo
       @old_event = EventHistory.create!(
         dojo_id: @test_dojo.id,
         dojo_name: @test_dojo.name,
         service_name: "facebook",
-        event_id: "1761517970842435", 
+        event_id: "1761517970842435",
         participants: 10,
         evented_at: Time.zone.parse("2017-03-12 14:30:00"),
         event_url: "https://www.facebook.com/events/1761517970842435"
       )
     end
-    
+
     it "should prioritize newer note date over older event history" do
       get activity_dojos_path
-      
+
       # Find the dojo row in the response
       dojo_row_match = response.body.match(/#{@test_dojo.name}.*?<\/tr>/m)
       expect(dojo_row_match).not_to be_nil, "Could not find dojo row for #{@test_dojo.name}"
-      
+
       dojo_row = dojo_row_match[0]
-      
+
       # The 記録日 (recorded date) column should show the newer note date (2025-03-16)
       # not the older event history date (2017-03-12)
-      expect(dojo_row).to include("2025-03-16"), 
+      expect(dojo_row).to include("2025-03-16"),
         "Expected to see note date 2025-03-16 in 記録日 column, but found: #{dojo_row}"
-      
-      expect(dojo_row).not_to include("2017-03-12"), 
+
+      expect(dojo_row).not_to include("2017-03-12"),
         "Should not show old event history date 2017-03-12 when newer note date exists"
     end
 
     it "should link to note URL when displaying note date in 記録日 column" do
       get activity_dojos_path
-      
+
       # Find the dojo row
       dojo_row_match = response.body.match(/#{@test_dojo.name}.*?<\/tr>/m)
       expect(dojo_row_match).not_to be_nil
-      
+
       dojo_row = dojo_row_match[0]
-      
+
       # Should contain a link to the note URL
       expect(dojo_row).to include("https://coderdojo-wakayama.hatenablog.com/entry/2025/03/16/230604"),
         "Expected to find note URL in the 記録日 column"
     end
-    
+
     it "handles multiple date formats in note (YYYY-MM-DD and YYYY/MM/DD)" do
       # Test with slash format
       slash_format_dojo = create(:dojo,
@@ -561,7 +561,7 @@ RSpec.describe "Dojos", type: :request do
         inactivated_at: nil,
         note: "Active - last event 2025/03/16 using Google Forms"
       )
-      
+
       # Create old event history
       EventHistory.create!(
         dojo_id: slash_format_dojo.id,
@@ -572,9 +572,9 @@ RSpec.describe "Dojos", type: :request do
         evented_at: Time.zone.parse("2017-01-01"),
         event_url: "https://example.com"
       )
-      
+
       get activity_dojos_path
-      
+
       # Should show the note date in standard format
       expect(response.body).to include("2025-03-16"),
         "Should parse YYYY/MM/DD format and display as YYYY-MM-DD"
@@ -588,7 +588,7 @@ RSpec.describe "Dojos", type: :request do
         inactivated_at: nil,
         note: "最終開催日: 2025年8月24日 Peatixで申込受付中"
       )
-      
+
       # Create old event history
       EventHistory.create!(
         dojo_id: japanese_format_dojo.id,
@@ -599,15 +599,15 @@ RSpec.describe "Dojos", type: :request do
         evented_at: Time.zone.parse("2017-01-01"),
         event_url: "https://example.com"
       )
-      
+
       get activity_dojos_path
-      
+
       # Find the dojo row
       dojo_row_match = response.body.match(/#{japanese_format_dojo.name}.*?<\/tr>/m)
       expect(dojo_row_match).not_to be_nil
-      
+
       dojo_row = dojo_row_match[0]
-      
+
       # Should show the Japanese date in standard format (2025-08-24)
       expect(dojo_row).to include("2025-08-24"),
         "Should parse YYYY年MM月DD日 format and display as YYYY-MM-DD"
@@ -621,7 +621,7 @@ RSpec.describe "Dojos", type: :request do
         inactivated_at: nil,
         note: "Last manual event - 2025-03-16 using Google Forms"
       )
-      
+
       # Create newer event history (newer than note date)
       newer_event = EventHistory.create!(
         dojo_id: newer_event_dojo.id,
@@ -632,31 +632,56 @@ RSpec.describe "Dojos", type: :request do
         evented_at: Time.zone.parse("2025-08-01 19:00:00"),  # Newer than note date
         event_url: "https://example-newer.com"
       )
-      
+
       get activity_dojos_path
-      
+
       # Find the dojo row
       dojo_row_match = response.body.match(/#{newer_event_dojo.name}.*?<\/tr>/m)
       expect(dojo_row_match).not_to be_nil
-      
+
       dojo_row = dojo_row_match[0]
-      
+
       # Extract just the 記録日 column to check the date display
       td_matches = dojo_row.scan(/<td[^>]*>(.*?)<\/td>/m)
-      
+
       # Based on debug output: td_matches[0] is the 記録日 column (列順変更後)
       # (道場名 column seems to be skipped in regex due to complex link structure)
       event_date_column = td_matches[0]&.first # 記録日 column
-      
+
       expect(event_date_column).not_to be_nil, "Could not find 記録日 column"
-      
+
       # Should show the newer event history date (2025-08-01) in the 記録日 column
       expect(event_date_column).to include("2025-08-01"),
         "Expected to see newer event history date 2025-08-01 in 記録日 column, but found: #{event_date_column}"
-      
+
       # The 記録日 column should not contain the older note date
       expect(event_date_column).not_to include("2025-03-16"),
         "Should not show older note date 2025-03-16 in 記録日 column when newer event history exists"
+    end
+  end
+
+  # 道場の個別ページは、道場名以外がすべて共通で視覚的な identity が無かった。
+  # 掲載申請時にロゴを用意してもらっているので、その道場のページで表示する。
+  describe "GET /dojos/:id" do
+    it "道場のロゴを表示する" do
+      dojo = create(:dojo, name: "ロゴ表示テスト", logo: "/img/dojos/saku.webp",
+                           url: "https://example.com/")
+
+      get dojo_path(dojo)
+
+      expect(response.body).to include("/img/dojos/saku.webp")
+    end
+
+    it "ロゴから道場の掲載 URL へリンクする" do
+      dojo = create(:dojo, name: "ロゴリンクテスト", logo: "/img/dojos/saku.webp",
+                           url: "https://example.org/")
+
+      get dojo_path(dojo)
+
+      doc  = Nokogiri::HTML(response.body)
+      link = doc.css("a[href='https://example.org/']").find { |a| a.css('img').any? }
+
+      expect(link).not_to be_nil, "ロゴ画像を含む、掲載 URL へのリンクが見つかりません"
     end
   end
 end


### PR DESCRIPTION
<img width="791" height="641" alt="image" src="https://github.com/user-attachments/assets/354a1ecc-a8ce-48b4-bab4-2d9750304eda" />

### 背景

`/dojos/:id`（道場の個別ページ）は**道場名以外がすべて共通**で、視覚的な identity がありませんでした。ヘッダーの絵文字（☯️）と共通のカバー写真だけで、どの道場のページも同じ見た目です。

[掲載申請の手順書](https://github.com/coderdojo-japan/coderdojo.jp/blob/main/doc/how_to_add_dojo.md)ではロゴの用意（`.png` と `.webp` の両方・TinyPNG で圧縮）を求めているのに、そのロゴが**トップページの一覧とマップでしか使われていない**状態でした。

> 337 道場のうち **249 道場（74%）が独自ロゴ**を持っています。

### やったこと

- 見出しの直後にロゴを表示し、掲載 URL へリンク
- 重複していた「（公開情報のみ掲載）」を削除
- テストを追加（ロゴが表示されること／掲載 URL へリンクすること）

#### 「（公開情報のみ掲載）」の削除について

すぐ下の説明文に「CoderDojo ◯◯に関する**公開されている**統計情報をまとめたページです。」と明記されており、**同じことを二度言っていた**ため削除しました。情報は失われていません。

### 実装上の注意点

`.dojo-picture` は `display: block` のため、包む `<a>` をインラインのままにすると**クリック領域が行いっぱいに広がってしまいます**（画像の左右の余白もクリックできてしまう）。`.dojo-picture-link` で `inline-block` にして画像サイズに収めました。

```scss
.dojo-picture-link {
  display: inline-block;
  margin: 25px 0;
}
```

余白は `<br>` ではなく `margin` で確保しています。

### 差分について

`custom.scss` と `spec/requests/dojos_spec.rb` には**行末空白の除去**による差分が含まれます（エディタの自動処理）。挙動には影響しません。実質的な変更は上記のみです。

### 動作確認

- 全テスト通過（220 examples, 0 failures ／ 新規2件を含む）
- ローカルで表示・リンク・クリック領域を確認