### PR TITLE
docs(kata): codeclub.org の Partners ページへのリンクに Text Fragment を追加

### DIFF
--- a/app/views/docs/kata.html.erb
+++ b/app/views/docs/kata.html.erb
@@ -953,10 +953,10 @@
 	    <blockquote style='border: 1px solid black; padding: .5em 1.5em; margin: 0em 0em 3em'>
 	      <p>
 		📝
-		CoderDojo では、ラズベリーパイ財団や CoderDojo 財団などが共同で運営している、<a href='https://codeclub.org/en/our-partners'>CoderDojo を含む世界中の非営利 Club コミュニティ</a> <span style='font-size: smaller'>(Code Club コミュニティ)</span> で新規クラブ登録・管理を行っています。
+		CoderDojo では、ラズベリーパイ財団や CoderDojo 財団などが共同で運営している、<a href='https://codeclub.org/en/our-partners#:~:text=CoderDojo%20Japan'>CoderDojo を含む世界中の非営利 Club コミュニティ</a> <span style='font-size: smaller'>(Code Club コミュニティ)</span> で新規クラブ登録・管理を行っています。
 
 		<!--<%= link_to lazy_image_tag('/kata/startup-coderdojo.webp', alt: 'クラブ登録サイトのスクショ (一部)', style: 'margin: 30px auto 20px'), 'https://codeclub.org/en/coderdojo-community' %>-->
-		<%= link_to lazy_image_tag('/kata/startup-partners.webp', alt: 'National Partners (一部)', style: 'margin: 10px auto 20px'), 'https://codeclub.org/en/our-partners' %>
+		<%= link_to lazy_image_tag('/kata/startup-partners.webp', alt: 'National Partners (一部)', style: 'margin: 10px auto 20px'), 'https://codeclub.org/en/our-partners#:~:text=CoderDojo%20Japan' %>
 	      </p>
 	    </blockquote>
 	    <br>
@@ -1056,8 +1056,8 @@
 	      Global Community Slack
 	      <small>(提供: <%= link_to 'Raspberry Pi & CoderDojo Foundation', raspi_url %>)</small>
 	    </h4>
-	    <p><%= link_to 'ラズベリーパイ財団や CoderDojo 財団', raspi_url %>などが共同で運営している、<a href='https://codeclub.org/en/our-partners'>CoderDojo を含む世界中の非営利 Club コミュニティ</a> <span style='font-size: smaller'>(Code Club コミュニティ)</span> 関係者が集まる連絡網「<b><a href='https://codeclub.org/en/slack'>Code Club Slack</a></b>」があります。英語でのコミュニケーションとなりますが世界中の運営者とも情報交換できる場ですので、よければ<b><a href='https://codeclub.org/en/slack'>コチラ</a></b>から申請してみてください。</p>
-	    <%= link_to lazy_image_tag('/kata/startup-partners.webp', alt: 'National Partners (一部)', style: 'margin: 5px auto 30px'), 'https://codeclub.org/en/our-partners' %>
+	    <p><%= link_to 'ラズベリーパイ財団や CoderDojo 財団', raspi_url %>などが共同で運営している、<a href='https://codeclub.org/en/our-partners#:~:text=CoderDojo%20Japan'>CoderDojo を含む世界中の非営利 Club コミュニティ</a> <span style='font-size: smaller'>(Code Club コミュニティ)</span> 関係者が集まる連絡網「<b><a href='https://codeclub.org/en/slack'>Code Club Slack</a></b>」があります。英語でのコミュニケーションとなりますが世界中の運営者とも情報交換できる場ですので、よければ<b><a href='https://codeclub.org/en/slack'>コチラ</a></b>から申請してみてください。</p>
+	    <%= link_to lazy_image_tag('/kata/startup-partners.webp', alt: 'National Partners (一部)', style: 'margin: 5px auto 30px'), 'https://codeclub.org/en/our-partners#:~:text=CoderDojo%20Japan' %>
 	    <br>
 	  </li>
 	  <li>
@@ -1508,7 +1508,8 @@
 	  <li>
 	    <h4 id='q-kata-abroad'>Q. 海外の CoderDojo に参加してみることはできますか?</h4>
 	    <p>CoderDojo コミュニティには地域ごとに <%= link_to 'CoderDojo Japan', doc_path('about') %> のような公式法人（National Partners）があります。公式法人がある地域は比較的活発な地域となっていますので、下記ページから興味ある地域の公式法人にコンタクトしてみると良いかもしれません。</p>
-	    <p><b><a href="https://codeclub.org/en/our-partners#:~:text=CoderDojo%20Japan">🌐 National Partners - Foundation</a></b></p>
+	    <p><b><a href="https://codeclub.org/en/our-partners#:~:text=National%20Partners">🌐 National Partners - Raspberry Pi Foundation</a></b></p>
+	    <%= link_to lazy_image_tag('/kata/startup-partners.webp', alt: 'National Partners (一部)', style: 'margin: 5px auto 30px'), 'https://codeclub.org/en/our-partners#:~:text=CoderDojo%20Japan' %>
 	    <br>
 	  </li>
 	  <li>


### PR DESCRIPTION

<img width="788" height="531" alt="image" src="https://github.com/user-attachments/assets/75e0ba4a-5b76-439d-a927-1267047b04e6" />

### 背景

リンク先の [codeclub.org/en/our-partners](https://codeclub.org/en/our-partners) は世界中の National Partners が並ぶ長いページで、遷移しても **CoderDojo Japan の記載を自分で探す手間**がありました。

### やったこと

**Text Fragment（`#:~:text=`）を付けて、該当箇所に直接スクロールする**ようにしました。

| 箇所 | 遷移先 |
|------|--------|
| 「CoderDojo を含む世界中の非営利 Club コミュニティ」のリンク（2箇所） | CoderDojo Japan の記載 |
| National Partners の画像リンク（2箇所） | CoderDojo Japan の記載 |

あわせて「Q. 海外の CoderDojo に参加してみることはできますか?」の FAQ を改善しました。

- リンク文言を **「National Partners - Raspberry Pi Foundation」** に修正
  （運営主体は Raspberry Pi 財団であり、単に "Foundation" では曖昧でした）
- 遷移先を **National Partners の見出し**に変更（この FAQ は一覧を見たい導線のため、Japan 単体ではなく一覧の先頭へ）
- 他の箇所と同様に **National Partners の画像**を添えて、視覚的な手がかりを追加

### 動作確認

- kata ページのリンク切れ検査を含む `spec/requests/docs_spec.rb` 通過（8 examples, 0 failures）
- 全テスト通過（220 examples, 0 failures）