### PR TITLE
refactor(dojos): index の死んだ条件式を取り除き、名前のある述語に寄せる

### DIFF
--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -2,51 +2,32 @@ class DojosController < ApplicationController
 
   # GET /dojos[.html|.json|.csv]
   def index
-    # yearパラメータがある場合の処理
+    # yearパラメータがある場合は、その年末時点でアクティブだった道場に絞り込む
     if params[:year].present?
-      begin
-        year = params[:year].to_i
-        # 有効な年の範囲をチェック
-        unless year.between?(2012, Date.current.year)
-          flash[:inline_alert] = "指定された年は無効です。2012年から#{Date.current.year}年の間で指定してください。"
-          return redirect_to dojos_path(anchor: 'table')
-        end
-
-        @selected_year = year
-        year_end = Time.zone.local(@selected_year).end_of_year
-
-        # その年末時点でアクティブだった道場を取得
-        dojos_scope = Dojo.active_at(year_end)
-        @page_title = "#{@selected_year}年末時点のCoderDojo一覧"
-      rescue ArgumentError
-        flash[:inline_alert] = "無効な年が指定されました"
+      year = params[:year].to_i  # 数値でない文字列は 0 になり、下の範囲チェックで弾かれる
+      unless year.between?(2012, Date.current.year)
+        flash[:inline_alert] = "指定された年は無効です。2012年から#{Date.current.year}年の間で指定してください。"
         return redirect_to dojos_path(anchor: 'table')
       end
+
+      @selected_year = year
+      dojos_scope    = Dojo.active_at(Time.zone.local(@selected_year).end_of_year)
+      @page_title    = "#{@selected_year}年末時点のCoderDojo一覧"
     else
-      # yearパラメータなしの場合（既存の実装そのまま）
       dojos_scope = Dojo.all
     end
 
-    @dojos = []
-    dojos_scope.includes(:prefecture).order_by_active_status.order(order: :asc).each do |dojo|
-      # 年が選択されている場合は、その年末時点でのアクティブ状態を判定
-      # 選択されていない場合は、現在の is_active を使用
-      is_active_at_selected_time = if @selected_year
-        # その年末時点でアクティブだったかを判定
-        # inactivated_at が nil（まだアクティブ）または選択年より後に非アクティブ化
-        dojo.inactivated_at.nil? || dojo.inactivated_at > Time.zone.local(@selected_year).end_of_year
-      else
-        dojo.active?
-      end
-
-      @dojos << {
+    @dojos = dojos_scope.includes(:prefecture).order_by_active_status.order(order: :asc).map do |dojo|
+      {
         id:          dojo.id,
         url:         dojo.url,
         name:        dojo.name,
         logo:        root_url + dojo.logo[1..],
         order:       dojo.order,
         counter:     dojo.counter,
-        is_active:   is_active_at_selected_time,
+        # 年を指定した場合、一覧は Dojo.active_at(年末) で絞り込み済みなので、
+        # 残っている道場はすべてその時点でアクティブ。ここで再判定はしない。
+        is_active:   @selected_year ? true : dojo.active?,
         prefecture:  dojo.prefecture.name,
         created_at:  dojo.created_at,
         description: dojo.description,

--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -4,7 +4,9 @@ class DojosController < ApplicationController
   def index
     # yearパラメータがある場合は、その年末時点でアクティブだった道場に絞り込む
     if params[:year].present?
-      year = params[:year].to_i  # 数値でない文字列は 0 になり、下の範囲チェックで弾かれる
+      # 数値でない文字列や、配列・ハッシュ形式の year（?year[]=2020）は 0 になり、
+      # 下の範囲チェックで無効な年として弾かれる
+      year = params[:year].to_s.to_i
       unless year.between?(2012, Date.current.year)
         flash[:inline_alert] = "指定された年は無効です。2012年から#{Date.current.year}年の間で指定してください。"
         return redirect_to dojos_path(anchor: 'table')

--- a/spec/requests/dojos_spec.rb
+++ b/spec/requests/dojos_spec.rb
@@ -68,6 +68,13 @@ RSpec.describe "Dojos", type: :request do
         expect(response).to redirect_to(dojos_path(anchor: 'table'))
         expect(flash[:inline_alert]).to include("無効")
       end
+
+      # 文字列以外の year（配列やハッシュ）でも 500 にせず、無効な年として扱う
+      it "handles non-string year parameters" do
+        get "/dojos.json?year[]=2020"
+        expect(response).to redirect_to(dojos_path(anchor: 'table'))
+        expect(flash[:inline_alert]).to include("無効")
+      end
     end
 
     describe "year filtering functionality" do

--- a/spec/requests/dojos_spec.rb
+++ b/spec/requests/dojos_spec.rb
@@ -70,8 +70,14 @@ RSpec.describe "Dojos", type: :request do
       end
 
       # 文字列以外の year（配列やハッシュ）でも 500 にせず、無効な年として扱う
-      it "handles non-string year parameters" do
+      it "handles array-formatted year parameters" do
         get "/dojos.json?year[]=2020"
+        expect(response).to redirect_to(dojos_path(anchor: 'table'))
+        expect(flash[:inline_alert]).to include("無効")
+      end
+
+      it "handles hash-formatted year parameters" do
+        get "/dojos.json?year[a]=2020"
         expect(response).to redirect_to(dojos_path(anchor: 'table'))
         expect(flash[:inline_alert]).to include("無効")
       end

--- a/spec/requests/dojos_spec.rb
+++ b/spec/requests/dojos_spec.rb
@@ -163,6 +163,58 @@ RSpec.describe "Dojos", type: :request do
         end
       end
 
+      # 年を指定した一覧は Dojo.active_at(年末) で絞り込んでいるため、
+      # 残った道場はすべてその年末時点でアクティブ、という不変条件が成り立つ。
+      # コントローラ側で is_active を再判定しないための根拠となるテスト。
+      context "when a year is specified" do
+        it "marks every listed dojo as active at that year end" do
+          get dojos_path(year: 2020, format: :json)
+          json_response = JSON.parse(response.body)
+
+          expect(json_response).not_to be_empty
+          expect(json_response.map { |d| d["is_active"] }).to all(be true)
+        end
+
+        # 「現在は非アクティブだが、その年末時点ではアクティブだった」道場が
+        # アクティブ扱いになることを名指しで固定する（上の不変条件だけでは、
+        # そもそも現在アクティブな道場しか返さない実装でも通ってしまうため）
+        it "marks a dojo inactivated in a later year as active at that year end" do
+          get dojos_path(year: 2020, format: :json)
+
+          dojo = JSON.parse(response.body).find { |d| d["id"] == @dojo_2020_inactive.id }
+          expect(dojo["is_active"]).to be true
+        end
+
+        # 年末の境界値: 元日 0:00 JST ちょうどに非アクティブ化された道場は、
+        # 前年末の時点ではまだアクティブ（> と >= の取り違えを検出する）
+        it "includes a dojo inactivated exactly at the beginning of the next year" do
+          boundary_dojo = create(:dojo,
+            name: "Boundary Dojo",
+            created_at: "2020-01-01",
+            inactivated_at: Time.zone.local(2021, 1, 1)
+          )
+
+          get dojos_path(year: 2020, format: :json)
+          expect(JSON.parse(response.body).map { |d| d["id"] }).to include(boundary_dojo.id)
+
+          get dojos_path(year: 2021, format: :json)
+          expect(JSON.parse(response.body).map { |d| d["id"] }).not_to include(boundary_dojo.id)
+        end
+
+        # タイムゾーン境界: UTC では前年末でも、JST では年明けに非アクティブ化された道場。
+        # 年末の判定が JST（Asia/Tokyo）で行われることを固定する
+        it "treats the year end in JST, not UTC" do
+          jst_new_year_dojo = create(:dojo,
+            name: "JST New Year Dojo",
+            created_at: "2020-01-01",
+            inactivated_at: Time.utc(2020, 12, 31, 20)  # = 2021-01-01 05:00 JST
+          )
+
+          get dojos_path(year: 2020, format: :json)
+          expect(JSON.parse(response.body).map { |d| d["id"] }).to include(jst_new_year_dojo.id)
+        end
+      end
+
       context "when year=2021 is specified" do
         it "returns dojos active at the end of 2021" do
           get dojos_path(year: 2021, format: :json)


### PR DESCRIPTION
`DojosController#index` に、実行されても結果が変わらない条件式が残っていたため、取り除きます。

## 1. 死んだ条件式の除去

`app/models/dojo.rb` の `Dojo.active_at(date)` は、次の条件で「その日時点でアクティブだった道場」を絞り込みます。

```ruby
scope :active_at, ->(date) {
  where('created_at <= ?', date)
    .where('inactivated_at IS NULL OR inactivated_at > ?', date)
}
```

`index` は年が指定されると `Dojo.active_at(年末)` で絞り込んでいるにもかかわらず、ループの中で**同じ条件をもう一度 Ruby で評価**していました。

```ruby
is_active_at_selected_time = if @selected_year
  dojo.inactivated_at.nil? || dojo.inactivated_at > Time.zone.local(@selected_year).end_of_year
else
  dojo.active?
end
```

スコープを通過した道場は必ずこの条件を満たすため、この判定は**常に true** です。モデルには `active_at?(date)` という名前付きの述語が既にありましたが、コントローラで条件式を直接書き直していたために、この重複に気づきにくくなっていました。

```ruby
is_active: @selected_year ? true : dojo.active?,
```

## 2. 到達しない `rescue ArgumentError` の除去

`String#to_i` は例外を投げず、`year` は範囲チェックで 2012..現在年 の Integer に限定されるため、`Time.zone.local(year)` も `ArgumentError` を投げません。これに伴い `begin`/`end` が不要になり、ネストが1段浅くなっています。

結果としてメソッドは 53行 → 32行になりました。

## 3. 併せて、既存のバグを1件修正

`/dojos?year[]=2020` のように year を配列で渡すと `params[:year]` が `Array` になり、`Array#to_i` が存在しないため **NoMethodError で 500** になっていました。リファクタ前から存在する問題で、回帰ではありません。`to_s` を挟み、数値でない文字列と同様に「無効な年」として弾くようにしています。

## テスト

振る舞いを変えていないことを担保するため、リファクタ前に characterization test を追加し、変更前後で green であることを確認しています（220 → 225 examples, 0 failures）。

- 年指定時、一覧のすべての道場の `is_active` が true であること
- **2021年に非アクティブ化された道場が、2020年末時点では `is_active == true`** であること（この1件が、旧インライン判定が担っていた仕事をピンポイントで固定します）
- 年末の境界値（元日 0:00 JST ちょうどに非アクティブ化）で、前年に含まれ・当年に含まれないこと
- 年末の判定が UTC ではなく JST で行われること
- 配列形式の year で 500 にならないこと

タイムゾーン・境界値・型・DB の値域の観点で反例を探し、上記3点の変更で振る舞いが変わるケースが無いことを確認しています。