### PR TITLE
fix(statistics): connpass のイベント履歴が 2025年5月から欠損していた問題を修正

### DIFF
--- a/db/static_event_histories.yml
+++ b/db/static_event_histories.yml
@@ -4,9 +4,9 @@
 #
 # [Template]
 # - dojo_id:
-#   event_url: 
-#   evented_at: 
-#   participants: 
+#   event_url:
+#   evented_at:
+#   participants:
 #
 # TODO: There are many dojos that manage their event other than Connpass/Doorkeeper. (It's of course fine!)
 # If you want to aggregate them, visit the following URL and add their data to this YAML file like below.
@@ -26,15 +26,13 @@
 # 2025
 # ...
 # - dojo_id:
-#   event_url: 
-#   evented_at: 
-#   participants: 
+#   event_url:
+#   evented_at:
+#   participants:
 
-# 平野 @ YOZORA LABO (LINE による参加申込にも対応。LINE 中心で対応してそう?) in 2025
-- dojo_id: 329
-  event_url: https://yozoralabo.connpass.com/event/363235/
-  evented_at: 2025-08-09 13:00
-  participants: 2
+# NOTE: 平野 @ YOZORA LABO の 2025-08-09 の回は、connpass 集計が止まっていた間に
+#       ここへ手動で追加されていた。集計の復旧により connpass から取得できるようになり
+#       (参加者数も API と同じ 2 人)、event_url が重複するため、この項目は削除した。
 
 # 2023/01..2025/04 CoderDojo佐賀 https://www.facebook.com/CoderDojoSAGA
 - dojo_id:  269

--- a/lib/event_service/providers/connpass.rb
+++ b/lib/event_service/providers/connpass.rb
@@ -36,6 +36,10 @@ module EventService
           events = []
 
           param_period_patern.each do |param_period|
+            # ページ送りの位置は期間バッチごとに独立している。
+            # 前のバッチの位置を引き継ぐと、このバッチの先頭のイベントを取りこぼす。
+            params[:start] = 1
+
             loop do
               begin
                 args = params.merge(param_period).compact

--- a/lib/statistics/tasks/connpass.rb
+++ b/lib/statistics/tasks/connpass.rb
@@ -21,7 +21,9 @@ module Statistics
         end
 
         @client.fetch_events(**@params.merge(group_id: group_ids)).each do |e|
-          dojo_event_service = DojoEventService.find_by(group_id: e.dig('series', 'id').to_s)
+          # API v1 -> v2 でイベントの所属グループを表すキーが series -> group に変わった
+          # cf. https://connpass.com/about/api/v2/
+          dojo_event_service = DojoEventService.find_by(group_id: e.dig('group', 'id').to_s)
           next unless dojo_event_service
 
           EventHistory.create!(dojo_id:          dojo_event_service.dojo_id,

--- a/spec/lib/event_service/providers/connpass_spec.rb
+++ b/spec/lib/event_service/providers/connpass_spec.rb
@@ -32,5 +32,33 @@ RSpec.describe EventService::Providers::Connpass do
         expect(subject.size).to eq 5
       end
     end
+
+    # 期間が 12 か月を超えると ym は複数のバッチに分割される。
+    # バッチごとに start を 1 に戻さないと、2 つ目以降のバッチが
+    # 前のバッチのページ送り位置から始まり、イベントを丸ごと取りこぼす。
+    context 'when the period is split into multiple batches' do
+      let(:full_page) do
+        events = Array.new(100) do |i|
+          { 'url' => "https://example.com/event/#{i}/", 'id' => i, 'accepted' => 1,
+            'started_at' => '2025-05-07T10:00:00+09:00', 'group' => { 'id' => 9876 } }
+        end
+        { 'results_returned' => 100, 'results_available' => 150, 'results_start' => 1, 'events' => events }
+      end
+
+      it 'restarts pagination from the beginning for each batch' do
+        requested_starts = []
+        allow_any_instance_of(ConnpassApiV2::Client).to receive(:get_events) do |_client, **args|
+          requested_starts << args[:start]
+          ConnpassApiV2::Response.new(full_page)
+        end
+
+        yyyymm = (0..13).map { |i| (Time.zone.local(2025, 1, 1) + i.months).strftime('%Y%m') }
+        described_class.new.fetch_events(group_id: 9876, yyyymm: yyyymm)
+
+        # ym は 12 か月 + 2 か月の 2 バッチに分かれるので、start=1 の要求が 2 回あるはず
+        expect(requested_starts.count(1)).to eq(2),
+          "各バッチの先頭で start=1 になるべきですが、実際の start は #{requested_starts.inspect} でした"
+      end
+    end
   end
 end

--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -31,8 +31,21 @@ RSpec.describe Statistics::Aggregation do
 
     subject { Statistics::Aggregation.new(from: Time.zone.today.prev_month.strftime('%Y%m')).run }
 
+    # connpass 1 件 + doorkeeper 1 件 + static_yaml 1 件
+    # （connpass が 0 件だった頃は 2 件で通っていた。上記キー変更のバグを追認していたため）
     it do
-      expect{ subject }.to change{ EventHistory.count }.from(0).to(2)
+      expect{ subject }.to change{ EventHistory.count }.from(0).to(3)
+    end
+
+    # connpass API v2 でイベントの所属グループを表すキーが series -> group に変わった。
+    # 集計側が古いキーを見ていると、DojoEventService が引けず全イベントが黙って捨てられる。
+    # 2025年5月以降の connpass のイベント履歴が丸ごと欠損した原因なので、明示的に固定する。
+    it 'connpass のイベント履歴が記録される' do
+      expect{ subject }.to change{ EventHistory.for(:connpass).count }.from(0)
+
+      event = EventHistory.for(:connpass).first
+      expect(event.service_group_id).to eq('9876')
+      expect(event.participants).to eq(10)
     end
   end
 


### PR DESCRIPTION
本番 DB を調べたところ、**connpass のイベント履歴が 2025-04-30 を最後に記録されていません**（Doorkeeper は正常に記録され続けています）。そのため /stats の開催数・参加数が実態より大幅に少なくなっています。

| 年 | 開催数（現状） | 開催数（修正後） | 参加数（現状） | 参加数（修正後） |
|---|---|---|---|---|
| 2024 | 1,208 | 1,208 | 7,562 | 7,562 |
| **2025** | **616** | **1,269** | **3,754** | **7,511** |


## 問題修正後の2025年データ (予測値)

<img width="612" height="403" alt="image" src="https://github.com/user-attachments/assets/889a574e-a813-4329-8fd1-a59a8929aece" />

<img width="623" height="417" alt="image" src="https://github.com/user-attachments/assets/e8fc18cb-3ba1-42bc-8f45-e9e47c2a7404" />

<img width="645" height="423" alt="image" src="https://github.com/user-attachments/assets/ebe17cd9-6f19-476f-a1c6-cdc759163b3d" />


## 原因 1: connpass API v2 のキー変更に、統計側だけが追随していなかった

API v1 → v2 で、イベントの所属グループを表すキーが `series` から `group` に変わっています。近日開催イベント側（`lib/upcoming_events/tasks/connpass.rb`）は追随済みでしたが、統計側が `series` のままでした。

```ruby
dojo_event_service = DojoEventService.find_by(group_id: e.dig('series', 'id').to_s)
next unless dojo_event_service   # ← 全イベントがここで静かに捨てられていた
```

`find_by` が常に nil を返すため、取得したイベントが1件も記録されず、しかもエラーにならないため気付けませんでした。

既存テストは `EventHistory.count` が 2 件（doorkeeper 1 + static_yaml 1）になることを期待しており、**connpass が 0 件である状態を追認**していました。connpass のイベント履歴が記録されることを明示するテストを追加し、期待値を 3 件に改めています。

## 原因 2: 期間バッチをまたぐとページ送りの位置を引き継いでしまう

`fetch_events` は期間を 12 か月（`ym`）/ 10 日（`ymd`）ごとのバッチに分けてリクエストしますが、ページ送りの位置 `params[:start]` をバッチ間で引き継いでいました。そのため2つ目以降のバッチが前のバッチの続きから始まり、先頭のイベントを取りこぼします。

実測では、2025年5月〜2026年7月（14か月）を集計すると、1バッチ目に収まる **2026年4月までしか取得できません**でした。週次の定期実行は「前週の7日間」だけを対象とし単一バッチで完結するため影響を受けませんが、今回のような再集計（バックフィル）では確実に取りこぼします。

## 静的データの重複を1件削除

connpass 集計が止まっていた間に、平野 @ YOZORA LABO の 2025-08-09 の回が `db/static_event_histories.yml` へ手動で追加されていました。集計が復旧すると同じイベントを connpass API からも取得するため、`event_url` の一意制約に衝突して再集計が失敗します。connpass API の `accepted` も 2 人で YAML の値と一致するため、静的定義側を削除しても情報は失われません。

## 検証

本番 DB のコピーをローカルに取り込んで確認しました。

- 修正後にバックフィル（`rails statistics:aggregation[202505,20260713,connpass]`）を実行し、エラーなく完了
- connpass の月別件数が 2025年5月〜2026年7月まで連続して埋まった（月 73〜89 件）。重複 URL は 0 件
- 全テスト 222 examples, 0 failures

## マージ後に必要な作業（本番データのバックフィル）

このマージだけでは過去のデータは戻りません。デプロイ後、次の順序で実行する必要があります。**順序が重要**です（静的データの重複を先に解消しないと、バックフィルが失敗します）。

```bash
# 0) 保険
heroku pg:backups:capture --app <APP>

# 1) 静的データを先に再構築（YAML から重複エントリが消えた状態を反映）
heroku run -- rails "statistics:aggregation[-,-,static_yaml]" --app <APP>

# 2) connpass のバックフィル
heroku run -- rails "statistics:aggregation[20250501,20260713,connpass]" --app <APP>
```

なお、この rake タスクは例外を握り潰して部分的な状態のまま COMMIT し、終了コード 0 で終わります。**exit code ではなく、出力の「集計を行いました」と件数で成否を判断してください。**