### PR TITLE
📊 Publish CoderDojo Stats in 2025 ☯️✨

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -4,10 +4,10 @@ class StatsController < ApplicationController
   def show
     # 言語設定
     @lang = params[:lang] || 'ja'
-    
-    # 2012年1月1日〜2024年12月31日までの集計結果
+
+    # 2012年1月1日〜2025年12月31日までの集計結果
     @period_start = 2012
-    @period_end   = 2024
+    @period_end   = 2025
     period        = Time.zone.local(@period_start).beginning_of_year..Time.zone.local(@period_end).end_of_year
     stats         = Stat.new(period)
 
@@ -118,7 +118,7 @@ class StatsController < ApplicationController
       else
         region
       end
-      
+
       @data_by_region << {
         code:        index+1,
         name:        "#{region_name} (#{dojos.pluck(:counter).sum})",

--- a/app/models/high_charts_builder.rb
+++ b/app/models/high_charts_builder.rb
@@ -37,7 +37,7 @@ class HighChartsBuilder
         f.series(type: 'line',   name: lang == 'en' ? 'Total' : '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
           { title: { text: lang == 'en' ? 'Events' : '開催回数' }, tickInterval:  500, max: 2000 },
-          { title: { text: lang == 'en' ? 'Total' : '累積合計' }, tickInterval: 3000, max: 12000, opposite: true }
+          { title: { text: lang == 'en' ? 'Total' : '累積合計' }, tickInterval: 3500, max: 14000, opposite: true }
         ]
         f.chart(width: HIGH_CHARTS_WIDTH, alignTicks: false)
         f.colors(["#F4C34F", "#BD2561"])
@@ -55,7 +55,7 @@ class HighChartsBuilder
         f.series(type: 'line',   name: lang == 'en' ? 'Total' : '累積合計', yAxis: 1, data: data[:cumulative_sums])
         f.yAxis [
           { title: { text: lang == 'en' ? 'Participants' : '参加者数' }, tickInterval: 2500,  max: 12500 },
-          { title: { text: lang == 'en' ? 'Total' : '累積合計' }, tickInterval: 14000, max: 64000, opposite: true }
+          { title: { text: lang == 'en' ? 'Total' : '累積合計' }, tickInterval: 15000, max: 75000, opposite: true }
         ]
         f.chart(width: HIGH_CHARTS_WIDTH, alignTicks: false)
         f.colors(["#EF685E", "#35637D"])
@@ -67,13 +67,13 @@ class HighChartsBuilder
     def annual_chart_data_from(source)
       # sourceがハッシュの場合は配列に変換
       source_array = source.is_a?(Hash) ? source.to_a : source
-      
+
       years           = source_array.map(&:first)
       counts          = source_array.map(&:last)
-      
+
       # 年間の値として扱う（イベント回数や参加者数用）
       increase_nums = counts
-      
+
       # 累積合計を計算
       cumulative_sums = counts.size.times.map {|i| counts[0..i].sum }
 
@@ -83,7 +83,7 @@ class HighChartsBuilder
         cumulative_sums: cumulative_sums
       }
     end
-    
+
     # 道場数の推移用の特別なデータ処理
     # 新規開設数と累積数を表示
     def annual_dojos_chart_data_from(source)
@@ -91,22 +91,22 @@ class HighChartsBuilder
       if source.is_a?(Hash) && source.key?(:active_dojos) && source.key?(:new_dojos)
         active_array = source[:active_dojos].to_a
         new_array = source[:new_dojos].to_a
-        
+
         years = active_array.map(&:first)
         cumulative_sums = active_array.map(&:last)
         increase_nums = new_array.map(&:last)  # 新規開設数を使用
       else
         # 後方互換性のため、古い形式もサポート
         source_array = source.is_a?(Hash) ? source.to_a : source
-        
+
         years = source_array.map(&:first)
         counts = source_array.map(&:last)
-        
+
         # 増減数を計算（前年との差分）- 後方互換性のため
         increase_nums = counts.each_with_index.map do |count, i|
           i == 0 ? count : count - counts[i - 1]
         end
-        
+
         cumulative_sums = counts
       end
 

--- a/db/static_event_histories.yml
+++ b/db/static_event_histories.yml
@@ -4,9 +4,9 @@
 #
 # [Template]
 # - dojo_id:
-#   event_url: 
-#   evented_at: 
-#   participants: 
+#   event_url:
+#   evented_at:
+#   participants:
 #
 # TODO: There are many dojos that manage their event other than Connpass/Doorkeeper. (It's of course fine!)
 # If you want to aggregate them, visit the following URL and add their data to this YAML file like below.
@@ -23,12 +23,40 @@
 #       「興味あり」はカウントせず、「参加者」のみをカウントしています。
 #
 
-# 2025
+# 2026
 # ...
 # - dojo_id:
-#   event_url: 
-#   evented_at: 
-#   participants: 
+#   event_url:
+#   evented_at:
+#   participants:
+
+# 2025
+# ID 54: CoderDojo 久留米 as DojoCon Japan 2025
+# ［入場チケット］［18歳以上専用］DojoCon Japan 2025
+- dojo_id: 54
+  event_url: https://dojocon-japan.doorkeeper.jp/events/187904
+  evented_at: 2025-10-25 10:00
+  participants: 143
+# ［入場チケット］［18歳未満同伴者 1］DojoCon Japan 2025
+- dojo_id: 54
+  event_url: https://dojocon-japan.doorkeeper.jp/events/187906
+  evented_at: 2025-10-25 10:00
+  participants: 36
+# ［入場チケット］［18歳未満同伴者 2］DojoCon Japan 2025
+- dojo_id: 54
+  event_url: https://dojocon-japan.doorkeeper.jp/events/187907
+  evented_at: 2025-10-25 10:00
+  participants: 12
+# ［入場チケット］［18歳未満同伴者 3］DojoCon Japan 2025
+- dojo_id: 54
+  event_url: https://dojocon-japan.doorkeeper.jp/events/187908
+  evented_at: 2025-10-25 10:00
+  participants: 3
+# ［入場チケット］［18歳未満同伴者 4］DojoCon Japan 2025
+- dojo_id: 54
+  event_url: https://dojocon-japan.doorkeeper.jp/events/187909
+  evented_at: 2025-10-25 10:00
+  participants: 1
 
 # 平野 @ YOZORA LABO (LINE による参加申込にも対応。LINE 中心で対応してそう?) in 2025
 - dojo_id: 329


### PR DESCRIPTION
/stats の集計期間を 2012〜2024 から **2012〜2025** に広げ、2025年のデータを公開します。過去の年次更新（#1651, #1585, #1486, #1405, #1142）と同じ手順です。

## 2025年の実績

| 項目 | 2024年 | 2025年 |
|---|---|---|
| 開催回数 | 1,208 | **1,274** |
| 参加者数 | 7,562 | **7,706** |
| 年末時点の道場数 | 197 | **204** |

累積では、開催回数 **11,544回** / 参加者数 **69,755人** になります。

## 問題修正後の2025年データ (予測値)

<img width="612" height="403" alt="image" src="https://github.com/user-attachments/assets/889a574e-a813-4329-8fd1-a59a8929aece" />

<img width="623" height="417" alt="image" src="https://github.com/user-attachments/assets/e8fc18cb-3ba1-42bc-8f45-e9e47c2a7404" />

<img width="645" height="423" alt="image" src="https://github.com/user-attachments/assets/ebe17cd9-6f19-476f-a1c6-cdc759163b3d" />

## 変更内容

**1. 集計期間の更新** — `@period_end` を 2025 に。推移グラフと年次テーブルは `@period_range` から動的に生成されるため、この1箇所の更新で2025年が加わります。

**2. グラフの軸** — 2025年のデータが収まるように引き上げました。

| グラフ | 変更 | 2025年末の実績 |
|---|---|---|
| 開催回数の累積合計 | 12,000 → 14,000 | 11,544 |
| 参加者数の累積合計 | 64,000 → 75,000 | 69,755 |

道場数のグラフは、年末アクティブ道場数の最大が 235（2021年）で上限 250 に収まるため変更していません。

**3. DojoCon Japan 2025 を静的データに追加** — connpass / Doorkeeper のグループに紐づかないイベントは `db/static_event_histories.yml` から集計しています。DojoCon Japan 2025（2025-10-25）の入場チケットと同伴者チケット計5件・参加者195人を、CoderDojo 久留米（ID: 54）のイベントとして追加しました。参加者数と開始時刻は Doorkeeper API の値と照合済みです。

- https://dojocon2025.coderdojo.jp/
- https://dojocon-japan.doorkeeper.jp/events/187904

`evented_at` に時刻を含めているのは、日付のみだと YAML が Date として読み込まれ、`YAML.load_file` の許可クラスに含まれず集計が失敗するためです（既存データも時刻付きです）。

## ⚠️ マージ前に必要な作業

**このPRは #1845 のマージと、本番データのバックフィル完了後にマージしてください。**

現在の本番 DB は connpass のイベント履歴が 2025-04-30 以降欠損しており、このまま2025年を公開すると開催回数が 616 回（実際の約半分）と表示されます。#1845 で原因を修正し、バックフィルを実行すると、上記の正しい数字になります。

## 検証

本番 DB のコピーをローカルに取り込み、#1845 の修正を適用してバックフィルした状態で確認しました。

- 3つの推移グラフに2025年が追加され、いずれも軸の上限に収まっている（描画も目視確認）
- 年次テーブルにも2025年の列が追加されている
- 全テスト 220 examples, 0 failures