### PR TITLE
fix(ci): Heroku へのデプロイが黙ってスキップされていた問題を修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,8 @@ jobs:
           heroku_api_key:  ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
           heroku_email:    ${{ secrets.HEROKU_EMAIL }}
+          # branch の既定値 "HEAD" のままだと、Heroku 側が main/master への push と
+          # 認識できず `Pushed to branch other than [main, master], skipping build.`
+          # としてビルドをスキップする。Actions は push 自体に成功するため success と
+          # 表示され、デプロイされていないことに気付けない。明示的に main を指定する。
+          branch: main


### PR DESCRIPTION
**本番へのデプロイが 2026-07-13 以降、行われていませんでした。** GitHub Actions の deploy ジョブは success と表示されますが、Heroku 側でビルドがスキップされています。

## 症状

本番の最新リリースは **v3986（Deploy 62410e62 / 2026-07-13 22:32）** のままで、その後マージされた次の変更が反映されていません。

- PR #1843 — Ruby 3.4.4 → 4.0.5（本番はまだ Ruby 3.4.4 で稼働中）
- PR #1845 — connpass のイベント履歴欠損の修正

## 原因

deploy ジョブのログに、次の 1 行が出ています。

```
remote: Pushed to branch other than [main, master], skipping build.
```

`akhileshns/heroku-deploy` を v3.15.15 から v4 に更新した PR #1842 以降の挙動です。v4 の `branch` 入力の既定値は `"HEAD"` で、GitHub Actions のチェックアウトは detached HEAD になるため、Heroku 側が main への push と認識できず、ビルドをスキップしていました。

**push 自体は成功する**ため、Actions は deploy ジョブを success と表示します。そのため、デプロイされていないことに気付けない状態でした。

## 修正

`branch: main` を明示します。

```yaml
      - uses: akhileshns/heroku-deploy@v4
        with:
          heroku_api_key:  ${{ secrets.HEROKU_API_KEY }}
          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
          heroku_email:    ${{ secrets.HEROKU_EMAIL }}
          branch: main
```

## マージ後の確認方法

deploy ジョブの success 表示だけでは判断できません。**Heroku に新しいリリースが作られたかを確認してください。**

```bash
heroku releases --app coderdojo-japan | head -5   # 新しい v3987 以降が出ているか
heroku run rails runner "puts RUBY_VERSION" --app coderdojo-japan   # 4.0.5 になっているか
```

このマージにより、滞留していた #1843（Ruby 4.0.5）と #1845（connpass 修正）も同時に本番へ反映されます。

もし `branch: main` を指定しても解消しない場合は、確実に動いていた v3.15.15 へ戻す選択肢があります。