### PR TITLE
fix(ci): heroku-deploy を v3 に戻し、デプロイの停止を解消する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,10 @@ updates:
       interval: weekly
     commit-message:
       prefix: "Bump"
+    ignore:
+      # heroku-deploy v4 は push 先を refs/head/main と組み立てるバグがあり
+      # (正しくは refs/heads/main)、Heroku がビルドをスキップしてデプロイが
+      # 黙って行われなくなる。修正が入るまでメジャー更新を見送る。
+      # 経緯は PR #1848 を参照。
+      - dependency-name: akhileshns/heroku-deploy
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,13 +56,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7
-      - uses: akhileshns/heroku-deploy@v4
+      # heroku-deploy は v3 に固定する。v4 は push 先を refs/head/main と組み立てており
+      # (正しくは refs/heads/main)、Heroku 側が main への push と認識できずに
+      # `Pushed to branch other than [main, master], skipping build.` としてビルドを
+      # スキップする。push 自体は成功するため Actions は success と表示され、
+      # デプロイされていないことに気付けない。branch 入力を指定しても解消しない。
+      # 詳細は PR #1847 / #1848 を参照。
+      - uses: akhileshns/heroku-deploy@v3.15.15
         with:
           heroku_api_key:  ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
           heroku_email:    ${{ secrets.HEROKU_EMAIL }}
-          # branch の既定値 "HEAD" のままだと、Heroku 側が main/master への push と
-          # 認識できず `Pushed to branch other than [main, master], skipping build.`
-          # としてビルドをスキップする。Actions は push 自体に成功するため success と
-          # 表示され、デプロイされていないことに気付けない。明示的に main を指定する。
-          branch: main


### PR DESCRIPTION
PR #1847（`branch: main` の明示）では解消しませんでした。deploy ジョブのログを読み直したところ、**v4 が push 先を間違えている**ことが分かりました。

```
336b313e..8a40364e  main -> refs/head/main
remote: Pushed to branch other than [main, master], skipping build.
```

`refs/head/main` になっています（正しくは `refs/heads/main`）。そのため Heroku は main への push と認識できず、ビルドをスキップします。`branch` 入力を指定しても、アクション側が `refs/head/${branch}` を組み立てるため直りません。

**push 自体は成功する**ので Actions は deploy ジョブを success と表示します。この「静かな失敗」により、7月13日以降のデプロイが行われていないことに気付けませんでした。

## 修正

確実に動作していた **v3.15.15 に固定**します。あわせて、Dependabot が再び v4 へ上げないよう、このアクションのメジャー更新を無視する設定を `.github/dependabot.yml` に追加しました。

## マージ後の確認（success 表示では判断しない）

```bash
heroku releases --app coderdojo-japan | head -5              # v3987 以降が作られたか
heroku run rails runner "puts RUBY_VERSION" --app coderdojo-japan  # 4.0.5 になったか
```

このマージで、滞留している次の変更がまとめて本番へ反映されます。

- PR #1843 — Ruby 3.4.4 → 4.0.5
- PR #1845 — connpass のイベント履歴欠損の修正
- PR #1847 — （効果はなかった `branch: main` の指定。本 PR で削除）