### PR TITLE
feat(statistics): 集計が静かに壊れていないかを週次で検知する

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -23,3 +23,13 @@ jobs:
       env:
         HEROKU_API_KEY:  ${{ secrets.HEROKU_API_KEY  }}
         HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+
+    # 集計は失敗しても例外を握り潰して exit 0 で終わることがある。
+    # 「直近 30 日で 1 件も記録されていないプロバイダ」を検知して、
+    # 静かなデータ欠損に気付けるようにする（PR #1845 の再発防止）。
+    - name: 🔍 Check if the aggregation is silently broken
+      run: |
+        heroku run rails statistics:sanity_check --app $HEROKU_APP_NAME
+      env:
+        HEROKU_API_KEY:  ${{ secrets.HEROKU_API_KEY  }}
+        HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}

--- a/lib/statistics.rb
+++ b/lib/statistics.rb
@@ -2,4 +2,5 @@ module Statistics; end
 
 require_relative 'statistics/tasks'
 require_relative 'statistics/aggregation'
+require_relative 'statistics/sanity_check'
 require_relative 'event_service'

--- a/lib/statistics/sanity_check.rb
+++ b/lib/statistics/sanity_check.rb
@@ -1,0 +1,57 @@
+module Statistics
+  # イベント履歴の集計が「静かに壊れていないか」を確認する。
+  #
+  # connpass API v1 -> v2 でレスポンスのキーが変わった際、集計側の追随が漏れ、
+  # 例外もエラーも出ないまま 14 か月ぶんのイベント履歴が欠損していた（PR #1845）。
+  # テストは緑のままで、人間が /stats の数字を見て初めて気づいた。
+  #
+  # 「以前は取得できていたのに、直近はまったく取得できていない」プロバイダは、
+  # 実態としてあり得ない。集計が壊れているサインとして扱い、定期実行を失敗させる。
+  class SanityCheck
+    class StaleDataError < StandardError; end
+
+    # 既定の 30 日は、実データから決めた。connpass は 30 日あたり約 90 件、
+    # doorkeeper は約 25 件を記録しており、30 日間 0 件は実態としてあり得ない。
+    def initialize(days: 30)
+      @days = days
+    end
+
+    def run
+      stale = stale_providers
+
+      if stale.empty?
+        puts "直近 #{@days} 日のイベント履歴を確認しました（問題なし）"
+        return
+      end
+
+      raise StaleDataError,
+            "#{stale.join(', ')} のイベント履歴が、直近 #{@days} 日で 1 件も記録されていません。" \
+            '集計が壊れている可能性があります（過去には記録されています）。'
+    end
+
+    # 直前の @days 日には記録があったのに、直近の @days 日は 0 件のプロバイダ。
+    #
+    # 「過去に 1 件でもあれば対象」としてはいけない。廃止済みの facebook（2024年以降 0 件）や、
+    # 手動でしか追加されない static_yaml（間隔が空く）を毎回フラグしてしまい、
+    # 警告が無視されるようになる。「直前まで動いていたものが、急に止まった」だけを見る。
+    def stale_providers
+      DojoEventService.distinct.pluck(:name).select do |provider|
+        recorded_in?(provider, previous_period) && !recorded_in?(provider, recent_period)
+      end
+    end
+
+    private
+
+    def recent_period
+      @days.days.ago..
+    end
+
+    def previous_period
+      (@days * 2).days.ago...@days.days.ago
+    end
+
+    def recorded_in?(provider, period)
+      EventHistory.for(provider).where(evented_at: period).exists?
+    end
+  end
+end

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -8,6 +8,12 @@ namespace :statistics do
     end
   end
 
+  desc '集計が静かに壊れていないかを確認します（直近 N 日で 0 件のプロバイダを検知）'
+  task :sanity_check, [:days] => :environment do |tasks, args|
+    days = args[:days].presence&.to_i || 30
+    Statistics::SanityCheck.new(days: days).run
+  end
+
   desc 'キーワードからイベント情報を検索します'
   task :search, [:keyword] => :environment do |tasks, args|
     raise ArgumentError, 'Require the keyword' if args[:keyword].nil?

--- a/spec/lib/statistics/sanity_check_spec.rb
+++ b/spec/lib/statistics/sanity_check_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+require 'statistics'
+
+# connpass の集計が API v2 のキー変更で壊れた時、例外もエラーも出ないまま
+# 14 か月ぶんのイベント履歴が欠損していた（PR #1845）。テストは緑のままで、
+# 人間が統計の数字を見て初めて気づいた。
+#
+# 同じ「静かな欠損」を機械的に検知するため、「以前は取得できていたのに、
+# 直近はまったく取得できていないプロバイダ」を洗い出す。
+RSpec.describe Statistics::SanityCheck do
+  let(:dojo) { create(:dojo, name: 'Dojo1', prefecture_id: 13) }
+
+  before do
+    create(:dojo_event_service, dojo_id: dojo.id, name: :connpass, group_id: 9876)
+  end
+
+  def create_event(service_name, evented_at, event_id)
+    EventHistory.create!(
+      dojo_id:          dojo.id,
+      dojo_name:        dojo.name,
+      service_name:     service_name,
+      service_group_id: '9876',
+      event_id:         event_id,
+      event_url:        "https://example.com/events/#{event_id}",
+      participants:     1,
+      evented_at:       evented_at
+    )
+  end
+
+  describe '#stale_providers' do
+    it '直前の期間には取得できていたのに、直近が 0 件のプロバイダを検知する' do
+      create_event('connpass', 100.days.ago, '1')
+
+      expect(described_class.new(days: 60).stale_providers).to eq(['connpass'])
+    end
+
+    it '直近も取得できていれば検知しない' do
+      create_event('connpass', 100.days.ago, '1')
+      create_event('connpass',  10.days.ago, '2')
+
+      expect(described_class.new(days: 60).stale_providers).to be_empty
+    end
+
+    it 'イベントが 1 件も無いプロバイダは検知しない' do
+      create(:dojo_event_service, dojo_id: dojo.id, name: :facebook, group_id: 10_000)
+
+      expect(described_class.new(days: 60).stale_providers).to be_empty
+    end
+
+    # 廃止済みの facebook（2024年以降 0 件）や、手動でしか追加されない static_yaml を
+    # 毎回フラグすると、警告が無視されるようになる。実データで誤検知したケース。
+    it 'ずっと前に止まったプロバイダは検知しない（直前の期間も 0 件のため）' do
+      create(:dojo_event_service, dojo_id: dojo.id, name: :facebook, group_id: 10_000)
+      create_event('facebook', 2.years.ago, 'fb1')
+
+      expect(described_class.new(days: 60).stale_providers).to be_empty
+    end
+  end
+
+  describe '#run' do
+    it '検知したら例外を投げて、定期実行のジョブを失敗させる' do
+      create_event('connpass', 100.days.ago, '1')
+
+      expect { described_class.new(days: 60).run }
+        .to raise_error(Statistics::SanityCheck::StaleDataError, /connpass/)
+    end
+
+    it '問題がなければ例外を投げない' do
+      create_event('connpass', 10.days.ago, '1')
+
+      expect { described_class.new(days: 60).run }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
connpass API v1 → v2 のキー変更で集計が壊れた際、**例外もエラーも出ないまま 14 か月ぶんのイベント履歴が欠損**していました（PR #1845）。テストは緑のままで、人間が /stats の数字を見て初めて気づきました。同じ欠損を機械的に検知します。

## 検知のルール

`statistics:sanity_check` は「**直前の 30 日には記録があったのに、直近の 30 日は 1 件も記録されていない**」プロバイダを検知し、例外を投げて週次ジョブを失敗させます。週次の統計集計の直後に実行します。

```bash
bundle exec rails statistics:sanity_check      # 既定 30 日
bundle exec rails statistics:sanity_check[60]  # 窓幅を指定
```

## 誤検知を防ぐための設計（実データで判明）

最初は「過去に 1 件でも記録があるのに、直近が 0 件」というルールで実装しました。ユニットテストは全て通りましたが、**本番データで動かすと誤検知しました**。

```
facebook     直近30日: 0 件 / それ以前: 1,216 件   ← 廃止済み（2024年以降 0 件）
static_yaml  直近30日: 0 件 / それ以前:   143 件   ← 手動追加なので間隔が空く
```

警告が誤検知だらけになると、誰も見なくなります。そこで「**直前まで動いていたものが、急に止まった**」だけを見る形に変更しました。本番データで再確認し、窓幅 30 / 60 / 90 日のいずれでも誤検知はゼロです。

| プロバイダ | 直近30日 | 直前30日 |
|---|---|---|
| connpass | 90 件 | 89 件 |
| doorkeeper | 25 件 | 28 件 |
| facebook | 0 件 | 0 件（廃止済み・検知しない） |
| static_yaml | 0 件 | 0 件（手動追加・検知しない） |

既定の 30 日も実データから決めました。connpass は 30 日あたり約 90 件を記録しており、**30 日間 0 件は実態としてあり得ません**。

## この検知の限界（正直に）

壊れてから `2 × 窓幅`（既定 60 日）を過ぎると、「直前の期間」も 0 件になり、廃止済みプロバイダと区別できなくなります。**早期発見のための仕組み**であり、長期間放置された欠損は検知できません。今回の connpass の欠損（2025年5月〜）であれば、2025年6月〜7月の週次実行で検知できていたはずです。

## テスト

6 examples を追加（検知する / しない、誤検知しないこと、例外を投げること）。全テスト **238 examples, 0 failures**。