### PR TITLE
docs: DojoMap への反映手順を暫定で追加

### DIFF
--- a/doc/how_to_add_dojo.md
+++ b/doc/how_to_add_dojo.md
@@ -118,6 +118,28 @@ Pull Request 例: https://github.com/coderdojo-japan/coderdojo.jp/pull/274
 
 <br>
 
+## DojoMap への反映（暫定手順）
+
+> ⚠️ Dojo が `global_club_id` を持つようになったら（[PR #1747](https://github.com/coderdojo-japan/coderdojo.jp/pull/1747)）、この節は丸ごと削除してください。
+
+[DojoMap](https://map.coderdojo.jp) は Clubs API 側のクラブ名と `db/dojos.yml` の `name` を、
+[`dojo2dojo.csv`](https://github.com/coderdojo-japan/map.coderdojo.jp/blob/main/dojo2dojo.csv) で突合しています。
+**この表に無い Dojo は地図に出ません。**
+
+```
+南城	CoderDojo南城
+```
+
+- 左列: `db/dojos.yml` の `name` と完全一致
+- 右列: [Clubs API](https://clubs-api.raspberrypi.org/) 上のクラブ名と完全一致（`_data/dojos_earth.json` で確認できます）
+- 区切りは**タブ 1 個**。スペースに変換されると日次ビルドが落ちます
+
+この 1 行を追加して push すれば、あとは DojoMap の日次 Actions が GeoJSON を再生成してデプロイします。
+すぐ反映したい場合は [Daily Update](https://github.com/coderdojo-japan/map.coderdojo.jp/actions/workflows/scheduler_daily.yml) を手動実行し、
+地図に表示されたことを確認してください。
+
+<br>
+
 ## 統計システムへの追加
 
 coderdojo.jp では開催日、及び参加人数などを集計し、統計ページから公開しています。

--- a/doc/how_to_add_dojo.md
+++ b/doc/how_to_add_dojo.md
@@ -135,8 +135,15 @@ Pull Request 例: https://github.com/coderdojo-japan/coderdojo.jp/pull/274
 - 区切りは**タブ 1 個**。スペースに変換されると日次ビルドが落ちます
 
 この 1 行を追加して push すれば、あとは DojoMap の日次 Actions が GeoJSON を再生成してデプロイします。
-すぐ反映したい場合は [Daily Update](https://github.com/coderdojo-japan/map.coderdojo.jp/actions/workflows/scheduler_daily.yml) を手動実行し、
-地図に表示されたことを確認してください。
+すぐ反映したい場合は [Daily Update](https://github.com/coderdojo-japan/map.coderdojo.jp/actions/workflows/scheduler_daily.yml) を手動実行してください。
+
+突合の結果は https://map.coderdojo.jp/dojo2dojo.json で確認できます
+（配信されるまで数十秒かかることがあります）。
+
+```bash
+curl -s https://map.coderdojo.jp/dojo2dojo.json | ruby -rjson -e 'pp JSON.parse(STDIN.read).find { |x| x["name_japan"] == "南城" }'
+#=> {"global_club_id" => "b115e722-...", "name_japan" => "南城", "name_earth" => "CoderDojo南城", ...}
+```
 
 <br>
 


### PR DESCRIPTION
新規 Dojo を coderdojo.jp に追加しても、[DojoMap](https://map.coderdojo.jp) の [`dojo2dojo.csv`](https://github.com/coderdojo-japan/map.coderdojo.jp/blob/main/dojo2dojo.csv) に行を足さないと地図に出ません。手順書に書かれていなかったため、CoderDojo 南城が実際に地図から漏れていました。

### なぜ出ないのか

DojoMap は Clubs API 側のクラブ名と `db/dojos.yml` の `name` を `dojo2dojo.csv` で突合しています。表に無いクラブは `_tasks/upsert_dojos_geojson.rb` で除外されます。

```ruby
next if zen2japan[dojo[:name]].nil?   # dojo2dojo.csv に無かったらスキップ
```

同ファイルには `TODO: Japan DB にも Clubs DB と同じ UUID を持たせると突合でき、名前突合が不要になる` というコメントがあります。

### 手動作業は 1 行だけ

日次 Actions が「Clubs API 取得 → coderdojo.jp 取得 → GeoJSON 生成 → 自動コミット → Pages デプロイ」まで行うため、手で足すのは CSV の 1 行だけです。CoderDojo 南城で検証しました。

| 項目 | 確認結果 |
|:---|:---|
| Clubs API 側の名前 | `CoderDojo南城`（スペースなし）、`RUNNING_SESSIONS`、緯度経度あり |
| coderdojo.jp 側の名前 | `南城`、`is_active: true`、ロゴあり |
| 追加前の `dojos.geojson` | 南城は 0 件 |
| 追加後（`rake upsert_dojos_geojson` をローカル実行） | 座標 `[127.7706815, 26.1631734]` で追加、ロゴと説明文も反映 |
| ロゴの手動配置 | 不要（`jekyll build` 内で `cache_dojo_logos` が自動取得） |

南城のマッピングは DojoMap 側に反映済みです: coderdojo-japan/map.coderdojo.jp@b4f08ea

### 暫定手順であることの明示

Dojo が `global_club_id` を持てば名前での突合自体が不要になります。#1747 の完成時に節ごと削除できるよう、削除条件と PR へのリンクを節の 1 行目に置き、他の節からは参照していません。

### タブについて

区切りはタブ 1 個です。空行やタブのみの行は `japan_name.empty?` の短絡評価で安全に読み飛ばされますが（実際ファイル末尾がその形）、**タブが無い非空行は `nil.empty?` で日次ビルドが落ちます**。エディタがタブをスペースに変換した場合が該当するため、手順書に注意として書きました。
