### PR TITLE
docs: 突合先は名前ではなく承認確認 URL の UUID で特定する

### DIFF
--- a/doc/how_to_add_dojo.md
+++ b/doc/how_to_add_dojo.md
@@ -134,6 +134,10 @@ Pull Request 例: https://github.com/coderdojo-japan/coderdojo.jp/pull/274
 - 右列: [Clubs API](https://clubs-api.raspberrypi.org/) 上のクラブ名と完全一致（`_data/dojos_earth.json` で確認できます）
 - 区切りは**タブ 1 個**。スペースに変換されると日次ビルドが落ちます
 
+右列は Dojo 名と大きく異なることがあります（例: `三木` に対して `三木市 ・西神@ 三木山総合体育館　ふくいく`）。
+名前で探さず、**掲載申請の「承認確認」URL の UUID** と一致する `id` のクラブを選んでください。
+同じ市に別の Dojo がある場合の取り違えを防げます。
+
 この 1 行を追加して push すれば、あとは DojoMap の日次 Actions が GeoJSON を再生成してデプロイします。
 すぐ反映したい場合は [Daily Update](https://github.com/coderdojo-japan/map.coderdojo.jp/actions/workflows/scheduler_daily.yml) を手動実行してください。
 


### PR DESCRIPTION
#1864 で追加した「DojoMap への反映（暫定手順）」に、突合先クラブの特定方法を 3 行足します。

### きっかけ

CoderDojo 三木（#1862）を DojoMap に追加した際、Clubs API 側の登録名が Dojo 名と大きく異なっていました。

| | 名前 |
|:---|:---|
| `db/dojos.yml` | `三木` |
| Clubs API | `三木市 ・西神@ 三木山総合体育館　ふくいく` |

さらに同じ三木市には `order` も同一（`282154`）の「みき」（`id: 230`、2023-02-02 に活動終了）があり、名前で探すと取り違えます。

### 確実な特定方法

掲載申請の「承認確認」URL の UUID が、Clubs API の `id` と一致します。三木の場合は `69f7acfe-7d93-4671-a9a6-bee112e2919e` で確定できました。

なお、この UUID こそ #1747 が `global_club_id` として Dojo モデルに持たせようとしているものです。#1747 が完成すれば、この節ごと不要になります。

### 反映済みのマッピング

- CoderDojo 南城: coderdojo-japan/map.coderdojo.jp@b4f08ea
- CoderDojo 三木: coderdojo-japan/map.coderdojo.jp@ee28a3d