### PR TITLE
docs: 検証していない仮説を手順書から削除する

### DIFF
--- a/doc/how_to_add_dojo.md
+++ b/doc/how_to_add_dojo.md
@@ -136,7 +136,6 @@ Pull Request 例: https://github.com/coderdojo-japan/coderdojo.jp/pull/274
 
 右列は Dojo 名と大きく異なることがあります（例: `三木` に対して `三木市 ・西神@ 三木山総合体育館　ふくいく`）。
 名前で探さず、**掲載申請の「承認確認」URL の UUID** と一致する `id` のクラブを選んでください。
-同じ市に別の Dojo がある場合の取り違えを防げます。
 
 この 1 行を追加して push すれば、あとは DojoMap の日次 Actions が GeoJSON を再生成してデプロイします。
 すぐ反映したい場合は [Daily Update](https://github.com/coderdojo-japan/map.coderdojo.jp/actions/workflows/scheduler_daily.yml) を手動実行してください。


### PR DESCRIPTION
#1865 で追加した 3 行のうち、最後の 1 行を削除します。

```diff
 右列は Dojo 名と大きく異なることがあります（例: `三木` に対して `三木市 ・西神@ 三木山総合体育館　ふくいく`）。
 名前で探さず、**掲載申請の「承認確認」URL の UUID** と一致する `id` のクラブを選んでください。
-同じ市に別の Dojo がある場合の取り違えを防げます。
```

### 理由

UUID 照合が防ぐのは **Clubs API 側（右列）のクラブの取り違え**です。削除する文は「同じ市に別の Dojo がある場合」と coderdojo.jp 側（左列）に紛らわしい Dojo がある状況を危険として提示しており、読者の注意を逆側に向けます。

三木の実例とも合いません。

| | 名前 | コードポイント |
|:---|:---|:---|
| `id: 230`（2023-02-02 に活動終了） | `みき` | `307f 304d` |
| `id: 357`（今回追加） | `三木` | `4e09 6728` |

別文字列なので `dojo2dojo.csv` の左列としては衝突せず、さらに Clubs API に `みき` は存在しません（JP 323 クラブ中、三木/みき に該当するのは 1 件のみ）。曖昧だったのは Clubs API 側の名前がどちらの Dojo のものかという点だけでした。

つまりこの文は、実際には起きていない状況を根拠にしています。検証していない仮説を手順書に残さないため削除します。直前の 2 行だけで「なぜ名前検索が危ないか」と「どうするか」は完結しています。