### PR TITLE
fix(dojos): 実所在地と食い違っていた order を修正する

### DIFF
--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -231,7 +231,7 @@
   - Pepper
   - micro:bit
 - id: 277
-  order: '042129'
+  order: '042161'
   created_at: '2021-10-18'
   name: 富谷
   prefecture_id: 4
@@ -958,6 +958,18 @@
   description: 野田市で毎月開催
   tags:
   - Scratch
+- id: 158
+  order: '122114'
+  created_at: '2018-11-17'
+  note: 2024-09-21 https://x.com/KEITAROinNRT/status/1837328724599189598
+  name: 成田
+  prefecture_id: 12
+  url: https://coderdojo.narita-area.com/
+  logo: "/img/dojos/narita.webp"
+  description: 成田市で毎月開催
+  tags:
+  - Scratch
+  global_club_id: 0f582494-c6ad-4b88-ad8a-dc18567a825e
 - id: 23
   order: '122173'
   created_at: '2014-09-22'
@@ -1105,18 +1117,6 @@
   tags:
   - Scratch
   - 映像制作
-- id: 158
-  order: '122303'
-  created_at: '2018-11-17'
-  note: 2024-09-21 https://x.com/KEITAROinNRT/status/1837328724599189598
-  name: 成田
-  prefecture_id: 12
-  url: https://coderdojo.narita-area.com/
-  logo: "/img/dojos/narita.webp"
-  description: 成田市で毎月開催
-  tags:
-  - Scratch
-  global_club_id: 0f582494-c6ad-4b88-ad8a-dc18567a825e
 - id: 121
   order: '131016'
   created_at: '2017-11-28'
@@ -2105,20 +2105,6 @@
   - Python
   - JavaScript
   global_club_id: 3b543ede-20e5-4283-a0a6-c342fcb3ffc8
-- id: 293
-  order: '160008'
-  created_at: '2022-12-04'
-  name: 舟橋
-  prefecture_id: 16
-  url: https://sites.google.com/coderdojo.com/funahashi/
-  logo: "/img/dojos/funabashimura.webp"
-  description: 舟橋村で毎月2回開催
-  tags:
-  - Scratch
-  - 電子工作
-  - Minecraft
-  - App Inventor
-  global_club_id: 0b208aca-b939-4ad0-b2ef-286dacd9fc19
 - id: 267
   order: '162019'
   created_at: '2021-04-29'
@@ -2219,6 +2205,20 @@
   - LEGO
   - Viscuit
   global_club_id: f126911d-5a5e-4fbe-89ef-de2feb46a232
+- id: 293
+  order: '163210'
+  created_at: '2022-12-04'
+  name: 舟橋
+  prefecture_id: 16
+  url: https://sites.google.com/coderdojo.com/funahashi/
+  logo: "/img/dojos/funabashimura.webp"
+  description: 舟橋村で毎月2回開催
+  tags:
+  - Scratch
+  - 電子工作
+  - Minecraft
+  - App Inventor
+  global_club_id: 0b208aca-b939-4ad0-b2ef-286dacd9fc19
 - id: 298
   order: '163228'
   created_at: '2023-02-24'
@@ -2888,18 +2888,6 @@
   - Unity
   - Webサイト
   global_club_id: 14bf5604-1ca8-4d10-8187-b33fb5c2443f
-- id: 34
-  order: '261009'
-  created_at: '2014-10-14'
-  name: 長岡京
-  prefecture_id: 26
-  url: https://coderdojo-nagaokakyo.doorkeeper.jp/
-  logo: "/img/dojos/nagaokakyo.webp"
-  description: 長岡京市で毎月開催
-  tags:
-  - Scratch
-  - 8x9Craft
-  global_club_id: fa0ae0bf-b6b3-4d57-975b-6f095ab89c7a
 - id: 262
   order: '262048'
   created_at: '2021-01-12'
@@ -2911,6 +2899,18 @@
   tags:
   - Scratch
   global_club_id: 67cbaaab-e71e-4f98-aefc-6dc62d5ef197
+- id: 34
+  order: '262099'
+  created_at: '2014-10-14'
+  name: 長岡京
+  prefecture_id: 26
+  url: https://coderdojo-nagaokakyo.doorkeeper.jp/
+  logo: "/img/dojos/nagaokakyo.webp"
+  description: 長岡京市で毎月開催
+  tags:
+  - Scratch
+  - 8x9Craft
+  global_club_id: fa0ae0bf-b6b3-4d57-975b-6f095ab89c7a
 - id: 250
   order: '262129'
   created_at: '2020-06-27'
@@ -2969,20 +2969,6 @@
   - PHP
   - Ruby
   - Java
-- id: 44
-  order: '271004'
-  created_at: '2016-08-15'
-  name: 大阪狭山
-  prefecture_id: 27
-  url: https://coderdojo-osakasayama.doorkeeper.jp/
-  logo: "/img/dojos/osakasayama.webp"
-  description: 大阪狭山で毎月開催
-  tags:
-  - Scratch
-  - Ruby
-  - mruby
-  - 電子工作
-  global_club_id: 71008d87-7849-4be0-8868-578642d24718
 - id: 116
   order: '271004'
   created_at: '2017-11-02'
@@ -3336,6 +3322,20 @@
   tags:
   - Scratch
   global_club_id: 55f5d988-38b6-4ede-97d6-5da2a1d87ebb
+- id: 44
+  order: '272311'
+  created_at: '2016-08-15'
+  name: 大阪狭山
+  prefecture_id: 27
+  url: https://coderdojo-osakasayama.doorkeeper.jp/
+  logo: "/img/dojos/osakasayama.webp"
+  description: 大阪狭山で毎月開催
+  tags:
+  - Scratch
+  - Ruby
+  - mruby
+  - 電子工作
+  global_club_id: 71008d87-7849-4be0-8868-578642d24718
 - id: 124
   order: '281018'
   created_at: '2018-01-26'
@@ -4469,7 +4469,7 @@
   - Python
   global_club_id: e03205bc-4467-4431-9fa7-5b12b6cf3b7e
 - id: 55
-  order: '454419'
+  order: '452017'
   created_at: '2016-09-15'
   note: Active for years - 2025-04-13 https://x.com/YoseiIto/status/1889435600337641670
   name: 宮崎


### PR DESCRIPTION
> **#1868 の上に積んでいます。** 先に #1868 をマージしてください。

`global_club_id` を全件検証する過程で見つかった、`order`（全国地方公共団体コード）の誤り 6 件を直します。

### 見つけ方

提携先のクラブ情報から緯度経度を取得し、[国土地理院の逆ジオコーディング](https://mreversegeocoder.gsi.go.jp/reverse-geocoder/LonLatToAddress)で市区町村コードに変換して、`db/dojos.yml` の `order` と突き合わせました。261 件のうち 6 件が別の自治体を指していました。

### 修正内容

| id | Dojo | 現在の `order` | クラブの実所在地 | 修正後 |
|:---|:---|:---|:---|:---|
| 34 | 長岡京 | `261009`（京都市） | 京都府長岡京市 開田四丁目 | `262099` |
| 44 | 大阪狭山 | `271004`（大阪市） | 大阪府大阪狭山市 狭山四丁目 | `272311` |
| 55 | 宮崎 | `454419`（高千穂町） | 宮崎県宮崎市 橘通東四丁目 | `452017` |
| 158 | 成田 | `122303`（**該当コードなし**） | 千葉県成田市 公津の杜四丁目 | `122114` |
| 277 | 富谷 | `042129`（登米市） | 宮城県富谷市 成田一丁目 | `042161` |
| 293 | 舟橋 | `160008`（**市町村名が空**） | 富山県舟橋村 佛生寺 | `163210` |

`122303` は `db/city_code.csv` に存在しないコード、`160008` は市町村名が空の都道府県コードで、いずれも本来あってはいけない値でした。クラブ名も `Nagaokakyo, Kyoto` / `Osakasayama, Osaka` / `Miyazaki` / `Narita` / `富谷` / `舟橋` と、すべて実所在地と一致しています。

### 影響

`prefecture_id` はいずれも正しいため、影響は **`/dojos` 一覧内の並び順**に限られます。地図や統計には影響しません。

手順書が「order 昇順に追加する」としているので、エントリの位置も移動しました。

### 確認したこと

- エントリ数は 339 件のまま。内容が変わったのは上記 6 件の `order` のみ
- 移動した 4 件は、いずれも前後のエントリとの `order` 昇順が成立する位置に収まっている
- ファイル全体の `order` 逆行箇所は **18 件で修正前後とも変わらず**。既存の乱れを増やしていない
- `bundle exec rspec spec` → 247 examples, 0 failures

### 直していないもの

`id 106 宜野湾` と `id 204 武蔵村山` は、クラブの登録座標が隣接する市（それぞれ浦添市・東大和市）にあります。ただしクラブ名は `Ginowan, Okinawa` / `Musashimurayama City` で `order` と一致しており、会場が市境付近にあるか座標が粗いだけと見られるため、`order` は変更していません。
