### PR TITLE
docs: 暫定節の削除条件を Issue #1616 へ付け替える

### DIFF
--- a/doc/how_to_add_dojo.md
+++ b/doc/how_to_add_dojo.md
@@ -120,7 +120,7 @@ Pull Request 例: https://github.com/coderdojo-japan/coderdojo.jp/pull/274
 
 ## DojoMap への反映（暫定手順）
 
-> ⚠️ Dojo が `global_club_id` を持つようになったら（[PR #1747](https://github.com/coderdojo-japan/coderdojo.jp/pull/1747)）、この節は丸ごと削除してください。
+> ⚠️ DojoMap が `global_club_id` で突合するようになったら（[Issue #1616](https://github.com/coderdojo-japan/coderdojo.jp/issues/1616)）、この節は丸ごと削除してください。
 
 [DojoMap](https://map.coderdojo.jp) は Clubs API 側のクラブ名と `db/dojos.yml` の `name` を、
 [`dojo2dojo.csv`](https://github.com/coderdojo-japan/map.coderdojo.jp/blob/main/dojo2dojo.csv) で突合しています。


### PR DESCRIPTION
`doc/how_to_add_dojo.md` の「DojoMap への反映（暫定手順）」は、削除条件として PR #1747 を参照していました。同 PR をクローズするため、Issue #1616 に付け替えます。

```diff
-> ⚠️ Dojo が `global_club_id` を持つようになったら（[PR #1747](...)）、この節は丸ごと削除してください。
+> ⚠️ DojoMap が `global_club_id` で突合するようになったら（[Issue #1616](...)）、この節は丸ごと削除してください。
```

条件の文言も「Dojo が持つ」から「DojoMap が突合する」に変えました。値の投入（#1868）は済んでおり、この節が不要になるのは**地図側が UUID で突合するようになった時点**だからです。

### なぜ #1747 をクローズするか

- 唯一の成果物である設計文書が `null: false` を指定しているが、**実データでは成立しない**（閉鎖済みの Dojo は Clubs API から見えず値を持てないため 78 件が値なし）。開いたままだと誤った設計で実装される
- 生き残った設計判断は、すでにマージ済みの成果物に記録されている（#1868 の本文、`spec/models/dojo_spec.rb` のコメント、この手順書）
- 残作業の追跡は Issue #1616 が適している

`bundle exec rspec spec` → 250 examples, 0 failures