### PR TITLE
fix(stats): 集計対象の道場数が連名道場を数え落としていた

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -68,17 +68,11 @@ class StatsController < ApplicationController
     end
 
     # 集計方法と集計対象
-    # TODO: 'DISTINCT dojo_id' cannot track joint-registrated dojos
-    #   cf. https://github.com/coderdojo-japan/coderdojo.jp/issues/682
-    # TODO: 集計対象となっている道場数の推移と合わせて調整すると良さそう
-    # joint_dojo_counter  = Dojo.where('counter > 1').map do |d|
-    #   d.dojo_event_services.any? ? (d.counter-1) : 0 # Remove itself from counting
-    # end.sum
-    # @aggregated_dojos   = DojoEventService.count('DISTINCT dojo_id') + joint_dojo_counter
     #
-    # MEMO: 色々不要!! 以下の *_table/whole の最新の値を出せば良いだけだった!!
-    # @dojos_aggregated        = DojoEventService.count('DISTINCT dojo_id')
-    # @dojos_included_inactive = stats.annual_sum_total_of_dojo_inactive_included
+    # 連名道場を数え落とす問題は Dojo.aggregatable_annual_count 側で解消済み。
+    # SUM(counter) で数えるようにしたため、下記の補正は不要になった。
+    # 経緯は Issue #862 を参照。
+    # https://github.com/coderdojo-japan/coderdojo.jp/issues/862
 
     # 「集計対象となっている道場数 / 非集計対象含む道場数」の推移
     @annual_dojos_table = stats.annual_sum_total_of_aggregatable_dojo

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -69,13 +69,18 @@ class Dojo < ApplicationRecord
       active.group_by_prefecture
     end
 
+    # 連名道場は 1 エントリが counter 個の道場を表すため、SUM(counter) で数える。
+    # 「非集計対象を含む道場数」（annual_count）と数え方を揃えるため。
+    #
+    # joins ではなくサブクエリを使う。joins だとイベントサービスを複数持つ Dojo が
+    # 行数分だけ重複し、SUM が過大になる（現在 21 件が該当）。
     def aggregatable_annual_count(period)
       Hash[
-        joins(:dojo_event_services)
+        where(id: DojoEventService.select(:dojo_id))
           .where(created_at: period)
           .group('year')
           .order('year ASC')
-          .pluck(Arel.sql("to_char(dojos.created_at, 'yyyy') AS year, COUNT(DISTINCT dojos.id)"))
+          .pluck(Arel.sql("to_char(created_at, 'yyyy') AS year, SUM(counter)"))
       ]
     end
 

--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -73,7 +73,7 @@ class Dojo < ApplicationRecord
     # 「非集計対象を含む道場数」（annual_count）と数え方を揃えるため。
     #
     # joins ではなくサブクエリを使う。joins だとイベントサービスを複数持つ Dojo が
-    # 行数分だけ重複し、SUM が過大になる（現在 21 件が該当）。
+    # 行数分だけ重複し、SUM が過大になる（2026-08 時点で 21 件が該当）。
     def aggregatable_annual_count(period)
       Hash[
         where(id: DojoEventService.select(:dojo_id))

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -329,4 +329,34 @@ RSpec.describe Dojo, :type => :model do
       end
     end
   end
+
+  # 連名道場（counter > 1）は 1 エントリが複数の道場を表す。
+  # 「集計対象の道場数」がこれを 1 と数えると、同じページの
+  # 「非集計対象を含む道場数」（SUM(counter)）と数え方が食い違う。
+  # 経緯は Issue #862 を参照。
+  # https://github.com/coderdojo-japan/coderdojo.jp/issues/862
+  describe '.aggregatable_annual_count' do
+    let(:period) { Time.zone.local(2020).all_year }
+
+    it 'counts a joint dojo as its counter' do
+      dojo = create(:dojo, name: '連名', counter: 3, created_at: Time.zone.local(2020, 5, 1))
+      create(:dojo_event_service, dojo_id: dojo.id)
+
+      expect(Dojo.aggregatable_annual_count(period)['2020'].to_i).to eq(3)
+    end
+
+    it 'counts a dojo once even when it has multiple event services' do
+      dojo = create(:dojo, name: '複数サービス', counter: 1, created_at: Time.zone.local(2020, 5, 1))
+      create(:dojo_event_service, dojo_id: dojo.id, name: :connpass,   group_id: '111')
+      create(:dojo_event_service, dojo_id: dojo.id, name: :doorkeeper, group_id: '222')
+
+      expect(Dojo.aggregatable_annual_count(period)['2020'].to_i).to eq(1)
+    end
+
+    it 'excludes a dojo without any event service' do
+      create(:dojo, name: '対象外', counter: 2, created_at: Time.zone.local(2020, 5, 1))
+
+      expect(Dojo.aggregatable_annual_count(period)['2020'].to_i).to eq(0)
+    end
+  end
 end

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Dojo, :type => :model do
       dojo = create(:dojo, name: '連名', counter: 3, created_at: Time.zone.local(2020, 5, 1))
       create(:dojo_event_service, dojo_id: dojo.id)
 
-      expect(Dojo.aggregatable_annual_count(period)['2020'].to_i).to eq(3)
+      expect(Dojo.aggregatable_annual_count(period)['2020']).to eq(3)
     end
 
     it 'counts a dojo once even when it has multiple event services' do
@@ -350,13 +350,25 @@ RSpec.describe Dojo, :type => :model do
       create(:dojo_event_service, dojo_id: dojo.id, name: :connpass,   group_id: '111')
       create(:dojo_event_service, dojo_id: dojo.id, name: :doorkeeper, group_id: '222')
 
-      expect(Dojo.aggregatable_annual_count(period)['2020'].to_i).to eq(1)
+      expect(Dojo.aggregatable_annual_count(period)['2020']).to eq(1)
     end
 
     it 'excludes a dojo without any event service' do
       create(:dojo, name: '対象外', counter: 2, created_at: Time.zone.local(2020, 5, 1))
 
-      expect(Dojo.aggregatable_annual_count(period)['2020'].to_i).to eq(0)
+      # キーが無いことを検証する。値を .to_i すると、メソッドが空を返しても
+      # nil.to_i == 0 で通ってしまい、テストが機能しなくなる。
+      expect(Dojo.aggregatable_annual_count(period)).not_to have_key('2020')
+    end
+
+    # 分母となる annual_count も inactive を含むため、こちらも含めるのが正しい。
+    # 将来 active スコープを足す「修正」で分子だけが減ると、比率が壊れる。
+    it 'includes an inactive dojo when it has an event service' do
+      dojo = create(:dojo, name: '休止中', counter: 1,
+                    created_at: Time.zone.local(2020, 5, 1), inactivated_at: Time.zone.local(2021, 1, 1))
+      create(:dojo_event_service, dojo_id: dojo.id)
+
+      expect(Dojo.aggregatable_annual_count(period)['2020']).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Fix #862

`/stats` の 2 つの指標で、連名道場の数え方が非対称でした。

| 指標 | 実装 | 連名道場（`counter: N`）の扱い |
|:---|:---|:---|
| 集計対象となっている道場数 | `COUNT(DISTINCT dojos.id)` | ❌ 1 と数える |
| 非集計対象を含む道場数 | `SUM(counter)` | ✅ N と数える |

分子だけ COUNT、分母は SUM という単位不一致で、比率も歪んでいました。

### 影響していた道場

| Dojo | `counter` | イベントサービス | 数え落とし |
|:---|---:|---:|---:|
| 西宮・梅田 (42) | 2 | 1 件 | 1 |
| 大田・邑南、他 (224) | 7 | 1 件 | 6 |
| 藤井寺・柏原 (272) | 2 | 0 件 | 0（対象外なので正しく除外） |

**`/stats` の表示値は 242 → 249 になります**（2014 年 9→10、2019 年 34→40）。ページは `@period_end = 2025` で区切られているため、全期間で数えると 245 → 252 です。

### 変更内容

```diff
     def aggregatable_annual_count(period)
       Hash[
-        joins(:dojo_event_services)
+        where(id: DojoEventService.select(:dojo_id))
           .where(created_at: period)
           .group('year')
           .order('year ASC')
-          .pluck(Arel.sql("to_char(dojos.created_at, 'yyyy') AS year, COUNT(DISTINCT dojos.id)"))
+          .pluck(Arel.sql("to_char(created_at, 'yyyy') AS year, SUM(counter)"))
       ]
     end
```

**`joins` をやめてサブクエリにしています。** `joins` のまま `SUM` にすると、イベントサービスを複数持つ Dojo が行数分だけ重複して過大になります（2026-08 時点で 21 件が該当）。

あわせて `stats_controller.rb` の TODO とコメントアウトされた旧実装を削除しました。参照先の Issue 番号が `#682` になっていましたが、正しくは `#862` です。

### 追加した spec（4 例）

| 検証 | 内容 |
|:---|:---|
| 連名道場 | `counter: 3` + サービス 1 件 → 3 と数える |
| 複数サービス | サービス 2 件を持つ Dojo → 1 と数える（重複しない） |
| 対象外 | サービスを持たない Dojo → キーが作られない |
| inactive | 休止中でもサービスがあれば数える |

最後の 1 例は、分母の `annual_count` も inactive を含むため整合を固定するものです。実際に `active` スコープを足すとこの spec が落ちることを確認しています。

### 連名道場の分割との関係

Issue #862 に[設計案](https://github.com/coderdojo-japan/coderdojo.jp/issues/862#issuecomment-5187711078)を書いたとおり、連名道場を個別エントリに分割すれば `counter` は全て 1 になり、**この修正は自然に無害化**します。分割は判断を要する作業なので、先に公開されている数値を正しくしています。

`bundle exec rspec spec` → 254 examples, 0 failures