### PR TITLE
feat(stats): /stats.json に集計対象の道場数と対象期間を追加する

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -143,9 +143,16 @@ class StatsController < ApplicationController
 
           # HTML にしか無かった指標。本番の値を確かめるのに HTML を grep すると
           # 無関係な数字を拾うため、JSON でも取れるようにしている。
-          aggregatable_dojos: @annual_dojos_table.values.last,  # 集計対象となっている道場数
-          total_dojos:        @annual_dojos_whole.values.last,  # 非集計対象も含む道場数
-          period: { start: @period_start, end: @period_end },
+          #
+          # 上の total_events / total_ninjas は全期間の値だが、こちらは期間で
+          # 区切られる。同じ階層に置くと基準が違うことが読めないため入れ子にする。
+          # 非アクティブになった道場も含む点は HTML の表記と揃えている。
+          dojos_in_period: {
+            start:        @period_start,
+            end:          @period_end,
+            aggregatable: @annual_dojos_table[@period_end.to_s],  # 集計対象となっている道場数
+            total:        @annual_dojos_whole[@period_end.to_s],  # 非集計対象も含む道場数
+          },
         }
       }
     end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -135,10 +135,17 @@ class StatsController < ApplicationController
       format.html # => app/views/stats/show.html.erb
       format.json { render json: {
           # NOTE: Add JSON data upon requests
+          # 既存のキーは他リポジトリが参照しているため消さない。追加のみ行う。
           active_dojos: @sum_of_dojos,  # Required by other repos
           total_events: @sum_of_events,
           total_ninjas: @sum_of_participants,
           active_dojos_by_prefecture: @data_by_prefecture,
+
+          # HTML にしか無かった指標。本番の値を確かめるのに HTML を grep すると
+          # 無関係な数字を拾うため、JSON でも取れるようにしている。
+          aggregatable_dojos: @annual_dojos_table.values.last,  # 集計対象となっている道場数
+          total_dojos:        @annual_dojos_whole.values.last,  # 非集計対象も含む道場数
+          period: { start: @period_start, end: @period_end },
         }
       }
     end

--- a/spec/requests/stats_spec.rb
+++ b/spec/requests/stats_spec.rb
@@ -12,6 +12,36 @@ RSpec.describe "Stats", type: :request do
     end
   end
 
+  # /stats.json は他リポジトリからも参照される。既存キーは消さず追加のみ行う。
+  # HTML を grep して数値を確かめると無関係な数字を拾うため、
+  # 本番の値はこのエンドポイントで確認できるようにしておく。
+  describe "GET /stats.json" do
+    let(:json) { JSON.parse(response.body) }
+
+    before do
+      dojo = create(:dojo, name: '集計対象', counter: 2, created_at: Time.zone.local(2020, 5, 1))
+      create(:dojo_event_service, dojo_id: dojo.id)
+      create(:dojo, name: '対象外', counter: 1, created_at: Time.zone.local(2020, 5, 1))
+      get "/stats.json"
+    end
+
+    it "他リポジトリが参照している既存のキーを返す" do
+      expect(response).to have_http_status(200)
+      expect(json).to include('active_dojos', 'total_events', 'total_ninjas', 'active_dojos_by_prefecture')
+    end
+
+    it "集計対象の道場数と全道場数を返す" do
+      # 集計対象はイベントサービスを持つ Dojo のみ。連名道場は counter 個と数える
+      expect(json['aggregatable_dojos']).to eq(2)
+      # 全道場は非集計対象も含む
+      expect(json['total_dojos']).to eq(3)
+    end
+
+    it "集計の対象期間を返す" do
+      expect(json['period']).to eq({ 'start' => 2012, 'end' => 2025 })
+    end
+  end
+
   describe "GET /english/stats" do
     it "英語版の統計ページが表示される" do
       get "/english/stats"
@@ -27,7 +57,7 @@ RSpec.describe "Stats", type: :request do
       Prefecture.find_or_create_by!(name: "東京都", region: "関東")
       Prefecture.find_or_create_by!(name: "大阪府", region: "近畿")
       Prefecture.find_or_create_by!(name: "北海道", region: "北海道")
-      
+
       get "/english/stats"
       expect(response.body).to include("Tokyo")
       expect(response.body).to include("Osaka")

--- a/spec/requests/stats_spec.rb
+++ b/spec/requests/stats_spec.rb
@@ -28,17 +28,26 @@ RSpec.describe "Stats", type: :request do
     it "他リポジトリが参照している既存のキーを返す" do
       expect(response).to have_http_status(200)
       expect(json).to include('active_dojos', 'total_events', 'total_ninjas', 'active_dojos_by_prefecture')
+      # キーの存在だけでなく値も検証する。意味が変わっても気づけるようにするため
+      expect(json['active_dojos']).to eq(Dojo.active.sum(:counter))
     end
 
-    it "集計対象の道場数と全道場数を返す" do
+    it "期間内の道場数を入れ子で返す" do
       # 集計対象はイベントサービスを持つ Dojo のみ。連名道場は counter 個と数える
-      expect(json['aggregatable_dojos']).to eq(2)
-      # 全道場は非集計対象も含む
-      expect(json['total_dojos']).to eq(3)
+      expect(json['dojos_in_period']).to eq({
+        'start' => 2012, 'end' => 2025, 'aggregatable' => 2, 'total' => 3
+      })
     end
 
-    it "集計の対象期間を返す" do
-      expect(json['period']).to eq({ 'start' => 2012, 'end' => 2025 })
+    it "非アクティブな道場も期間内の道場数に含む" do
+      # HTML の「非アクティブになった道場も含まれています」という表記と揃えている。
+      # active_dojos より大きい値になるのはこのため
+      dojo = create(:dojo, name: '休止中', counter: 1,
+                    created_at: Time.zone.local(2021, 5, 1), inactivated_at: Time.zone.local(2022, 1, 1))
+      create(:dojo_event_service, dojo_id: dojo.id, group_id: '999')
+      get "/stats.json"
+
+      expect(JSON.parse(response.body)['dojos_in_period']['aggregatable']).to eq(3)
     end
   end
 


### PR DESCRIPTION
本番の統計値を確かめる手段が HTML しかなく、検証が壊れやすい状態でした。

#1872 のデプロイ確認で、私は `curl -s https://coderdojo.jp/stats | grep -oE "24[0-9]"` としましたが、これは `240` `247` `248` も拾っており、**検証として成立していませんでした**。目的の値だけを取る手段が必要です。

### 追加するキー

```diff
 {
   "active_dojos": 210,
   "total_events": 12239,
   "total_ninjas": 73794,
   "active_dojos_by_prefecture": { ... },
+  "dojos_in_period": {
+    "start": 2012,
+    "end": 2025,
+    "aggregatable": 249,
+    "total": 339
+  }
 }
```

| キー | 内容 |
|:---|:---|
| `aggregatable` | 集計対象となっている道場数（イベントサービスを持つ Dojo） |
| `total` | 非集計対象も含む道場数 |
| `start` / `end` | 集計の対象期間 |

**入れ子にしたのは、既存の `total_events` / `total_ninjas` が全期間の値なのに対し、これらは期間で区切られるためです。** 同じ階層に `total_dojos` として置くと、同じ接頭辞で基準が違うことが読めません。実際、全期間で数えれば 347 で、339 とは別の値になります。

なお `aggregatable` には非アクティブな道場も含まれます（`active_dojos` より大きい理由）。これは `/stats` の「非アクティブになった道場も含まれています」という表記と揃えたものです。

### 既存キーは変更していません

`active_dojos` にはコード内に `# Required by other repos` と注記があり、他リポジトリから参照されています。**追加のみ**で、既存のキーは名前も値も変えていません。

### 追加した spec

`/stats.json` のテストがそもそも無かったので、あわせて入れました。

| 検証 | 内容 |
|:---|:---|
| 既存キー | 4 キーが消えていないこと、および `active_dojos` の**値** |
| 期間内の道場数 | 連名道場を `counter` 個と数え、非集計対象を除くこと |
| 非アクティブ | 休止中の道場も `aggregatable` に含むこと |

いずれも実際に壊して落ちることを確認しています（既存キーの値を変える / 非アクティブを除外する）。

`bundle exec rspec spec` → 257 examples, 0 failures