### PR TITLE
fix(dojos): 検査数字が合わない order 4 件を直す

### DIFF
--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -842,7 +842,7 @@
   - Scratch
   global_club_id: 831a556f-4f1a-49d4-bd2d-240e3378af1b
 - id: 159
-  order: '121003'
+  order: '121002'
   created_at: '2018-12-02'
   inactivated_at: '2025-04-20'
   note: 2024-04-20 https://www.facebook.com/CoderDojoTOKE/posts/pfbid02jsCuPajVr3u88nqS8ebcxxBh3v96C21NJwTdPFc2vy1q9UrJo3UsXeHxQWcjVmLcl
@@ -856,7 +856,7 @@
   - Viscuit
   global_club_id: 542b0936-d7f7-49ef-9675-e352c3e5281c
 - id: 312
-  order: '121003'
+  order: '121002'
   created_at: '2023-11-01'
   name: 稲毛海岸
   prefecture_id: 12
@@ -1106,7 +1106,7 @@
   - Unity
   - Minecraft
 - id: 157
-  order: '122302'
+  order: '123226'
   created_at: '2018-11-25'
   inactivated_at: '2021-06-16'
   name: 酒々井
@@ -3802,7 +3802,7 @@
   - AR/AI
   - ラズベリーパイ
 - id: 225
-  order: '320225'
+  order: '322024'
   created_at: '2019-09-06'
   inactivated_at: '2023-01-08'
   name: 浜田

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -206,13 +206,9 @@ RSpec.describe Dojo, :type => :model do
     # 適用できないため、こちらは形式面から守る。
     # https://github.com/coderdojo-japan/coderdojo.jp/pull/1869
     #
-    # 下記は現時点で検査数字が合っていないもの。直したらこの一覧から消すこと。
-    invalid_check_digit = {
-      157 => '酒々井（122302。酒々井町は 123226）',
-      159 => '土気（121003。千葉市は 121002）',
-      225 => '浜田（320225。浜田市は 322024）',
-      312 => '稲毛海岸（121003。千葉市は 121002）',
-    }.freeze
+    # 検査数字が合っていないものがあれば、直すまでの間ここに退避させる。
+    # 現在は空。PR #1874 で 4 件を db/city_code.csv の値に直した。
+    invalid_check_digit = {}.freeze
 
     # 上 5 桁に 6,5,4,3,2 を掛けた和を 11 で割った余りを 11 から引く。10 以上なら 1 の位。
     def check_digit_of(code)


### PR DESCRIPTION
PR #1870 で検査数字の spec を入れた時点で見つかっていた 4 件です。除外リストに退避させたまま残っていたので直します。

いずれも `db/city_code.csv` で裏を取りました。

| Dojo | 修正前 | 修正後 | 自治体 |
|:--|:--|:--|:--|
| 土気 (159) | `121003` | `121002` | 千葉市 |
| 稲毛海岸 (312) | `121003` | `121002` | 千葉市 |
| 酒々井 (157) | `122302` | `123226` | 酒々井町 |
| 浜田 (225) | `320225` | `322024` | 浜田市 |

### 千葉市の 2 件を区コードにしなかった理由

土気は緑区 (`121053`)、稲毛海岸は美浜区 (`121061`) なので、区コードを使う手もあります。ただ同じ千葉市の千葉 (22)・若葉若松 (151)・若葉みつわ台 (25) がいずれも市コード `121002` を使っているため、揃えました。

### 影響範囲

`order` は `default_order` スコープ（`prefecture_id` 昇順 → `order` 昇順）でしか使われません。表示上の変化は都道府県内の並び順のみです。

### 進め方

spec の除外リストを先に空にして **RED で 4 件ちょうどが出ることを確認**してから YAML を直しました。

除外リスト自体は空のまま残しています。次に同じことが起きた時の退避先として使えるためです。

`bundle exec rspec spec` → 257 examples, 0 failures
`dojos:update_db_by_yaml` → `dojos:migrate_adding_id_to_yaml` を往復させても、差分は order の 4 行だけでした。