### PR TITLE
feat(dojos): global_club_id をカラム化し /dojos.json に出す

### DIFF
--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -34,6 +34,9 @@ class DojosController < ApplicationController
         created_at:  dojo.created_at,
         description: dojo.description,
         inactivated_at: dojo.inactivated_at,  # CSV用に追加
+        # DojoMap が提携先のクラブと突き合わせるための ID。値を持たない道場もあるので
+        # null が返る。詳細は Issue #1616
+        global_club_id: dojo.global_club_id,
       }
     end
 

--- a/db/migrate/20260805073407_add_global_club_id_to_dojos.rb
+++ b/db/migrate/20260805073407_add_global_club_id_to_dojos.rb
@@ -1,0 +1,17 @@
+class AddGlobalClubIdToDojos < ActiveRecord::Migration[8.0]
+  # Raspberry Pi 財団の Clubs データベース上のクラブ ID (UUID)。
+  # 値は db/dojos.yml が持ち、dojos:update_db_by_yaml でこの列に入る。
+  #
+  # null 許容にしている。掲載を終えた道場は Clubs 側から消えており、
+  # 全件が値を持つ状態にはならないため（2026-08 時点で 261/339）。
+  # 最終的に null: false を目指す方針は Issue #1616 に記録している。
+  # https://github.com/coderdojo-japan/coderdojo.jp/issues/1616
+  #
+  # PostgreSQL のユニークインデックスは NULL を重複とみなさないので、
+  # 値を持たない道場が共存できる。ただし空文字は 1 件しか許されないため、
+  # update_db_by_yaml 側で nil に正規化する。
+  def change
+    add_column :dojos, :global_club_id, :string
+    add_index  :dojos, :global_club_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_14_184224) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_05_073407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -40,6 +40,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_14_184224) do
     t.integer "counter", default: 1, null: false
     t.text "note", default: "", null: false
     t.datetime "inactivated_at"
+    t.string "global_club_id"
+    t.index ["global_club_id"], name: "index_dojos_on_global_club_id", unique: true
     t.index ["inactivated_at"], name: "index_dojos_on_inactivated_at"
   end
 

--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -29,10 +29,26 @@ namespace :dojos do
 
     # DB 反映する前に YAML データをチェックする
     # https://railsguides.jp/error_reporting.html
+    #
+    # 全行を検証してから書き始める。1 行でも不正なら、DB を触る前に止まる
+    dojos.each { |dojo| raise_if_invalid_dojo(dojo) }
+
+    # YAML と一致しなくなった global_club_id を先に解放する。
+    #
+    # このタスクは行ごとに save! するだけで、YAML に無い DB 行は消さない。
+    # そのため「UUID を道場 A から B へ移す」編集は、YAML 内に重複が生じないので
+    # CI をすり抜け、本番 DB の既存行との衝突としてのみ現れる。毎デプロイ走る
+    # タスクなので、当たると release ごと止まる。
+    #
+    # A と B の入れ替えや、DB にだけ残った行が UUID を握っている場合も同じ。
+    # 後者はリポジトリのどこにも重複が見えないため、原因にたどり着きにくい。
+    # 先に解放しておけば、いずれも 1 回のデプロイで解決する。
+    expected_global_club_id = dojos.to_h { |dojo| [dojo['id'], dojo['global_club_id'].presence] }
+    Dojo.where.not(global_club_id: nil).find_each do |d|
+      d.update_columns(global_club_id: nil) if expected_global_club_id[d.id] != d.global_club_id
+    end
 
     dojos.each do |dojo|
-      raise_if_invalid_dojo(dojo)
-
       d = Dojo.find_or_initialize_by(id: dojo['id'])
       d.name           = dojo['name']
       d.counter        = dojo['counter'] || 1

--- a/lib/tasks/dojos.rake
+++ b/lib/tasks/dojos.rake
@@ -45,6 +45,9 @@ namespace :dojos do
       d.prefecture_id  = dojo['prefecture_id']
       d.order          = dojo['order'] || search_order_number_by(dojo['name'])
       d.is_private     = dojo['is_private'].nil? ? false : dojo['is_private']
+      # 空文字は nil に落とす。DB のユニークインデックスは NULL を重複とみなさないが、
+      # 空文字は 2 件目で落ちるため（値を持たない道場が 78 件ある）
+      d.global_club_id = dojo['global_club_id'].presence
       d.inactivated_at = dojo['inactivated_at'] ? Time.zone.parse(dojo['inactivated_at']) : nil
       d.created_at     = d.new_record? ? Time.zone.now : dojo['created_at'] || d.created_at
       d.updated_at     = Time.zone.now

--- a/spec/lib/tasks/dojos_spec.rb
+++ b/spec/lib/tasks/dojos_spec.rb
@@ -167,6 +167,40 @@ RSpec.describe 'dojos' do
         expect(Dojo.find(@dojo_1.id).global_club_id).to be_nil
       end
 
+      # 下の 2 つは YAML の中身だけを見ても検出できない衝突。
+      # YAML 内に重複が無いので spec も CI も通り、本番 DB の既存行との間でだけ
+      # ユニーク制約に当たる。毎デプロイ走るタスクなので、当たると release が止まる。
+      it '別の道場へ移した UUID は、先に解放される' do
+        uuid = 'b115e722-0000-4000-8000-000000000003'
+        @dojo_1.update_columns(global_club_id: uuid)
+
+        # 移動先を先に並べる。解放しないまま save! すると、ここで衝突する
+        allow(YAML).to receive(:unsafe_load_file).and_return([
+          @dojo_2.attributes.keep_if { |k,v| %w(id order name prefecture_id logo url description tags).include?(k) }
+                 .merge('global_club_id' => uuid),
+          dojo_base,
+        ])
+
+        expect(@rake[task].invoke).to be_truthy
+        expect(Dojo.find(@dojo_1.id).global_club_id).to be_nil
+        expect(Dojo.find(@dojo_2.id).global_club_id).to eq(uuid)
+      end
+
+      it 'YAML に無い道場が握っている UUID も解放される' do
+        # update_db_by_yaml は YAML に無い行を消さないため、DB にだけ残った行が
+        # UUID を握り続けることがある。この場合リポジトリのどこにも重複が見えない
+        uuid = 'b115e722-0000-4000-8000-000000000004'
+        @dojo_3.update_columns(global_club_id: uuid)
+
+        allow(YAML).to receive(:unsafe_load_file).and_return([
+          dojo_base.merge('global_club_id' => uuid)
+        ])
+
+        expect(@rake[task].invoke).to be_truthy
+        expect(Dojo.find(@dojo_3.id).global_club_id).to be_nil
+        expect(Dojo.find(@dojo_1.id).global_club_id).to eq(uuid)
+      end
+
       it '空文字 ⇒ nil に正規化される' do
         # 空文字のままだと 2 件目でユニークインデックスに引っかかり、
         # release スクリプトが落ちる

--- a/spec/lib/tasks/dojos_spec.rb
+++ b/spec/lib/tasks/dojos_spec.rb
@@ -141,6 +141,47 @@ RSpec.describe 'dojos' do
       end
     end
 
+    # global_club_id は提携先のクラブ ID (UUID)。値を持たない道場のほうが多いので、
+    # 空文字が入ると DB のユニークインデックスが 2 件目で落ちる。nil に正規化する。
+    context 'global_club_id' do
+      let(:dojo_base) do
+        @dojo_1.attributes.keep_if { |k,v| %w(id order name prefecture_id logo url description tags).include?(k) }
+      end
+
+      it 'UUID 指定 ⇒ 保存される' do
+        uuid = 'b115e722-0000-4000-8000-000000000001'
+        allow(YAML).to receive(:unsafe_load_file).and_return([
+          dojo_base.merge('global_club_id' => uuid)
+        ])
+
+        expect(@rake[task].invoke).to be_truthy
+        expect(Dojo.find(@dojo_1.id).global_club_id).to eq(uuid)
+      end
+
+      it '指定なし ⇒ nil' do
+        allow(YAML).to receive(:unsafe_load_file).and_return([dojo_base])
+
+        @dojo_1.update_columns(global_club_id: 'b115e722-0000-4000-8000-000000000002')
+
+        expect(@rake[task].invoke).to be_truthy
+        expect(Dojo.find(@dojo_1.id).global_club_id).to be_nil
+      end
+
+      it '空文字 ⇒ nil に正規化される' do
+        # 空文字のままだと 2 件目でユニークインデックスに引っかかり、
+        # release スクリプトが落ちる
+        allow(YAML).to receive(:unsafe_load_file).and_return([
+          dojo_base.merge('global_club_id' => ''),
+          @dojo_2.attributes.keep_if { |k,v| %w(id order name prefecture_id logo url description tags).include?(k) }
+                 .merge('global_club_id' => '')
+        ])
+
+        expect(@rake[task].invoke).to be_truthy
+        expect(Dojo.find(@dojo_1.id).global_club_id).to be_nil
+        expect(Dojo.find(@dojo_2.id).global_club_id).to be_nil
+      end
+    end
+
     context 'is_private' do
       let(:dojo_base) do
         @dojo_3.attributes.keep_if { |k,v| %w(id order name prefecture_id logo url description tags).include?(k) }

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -260,9 +260,9 @@ RSpec.describe Dojo, :type => :model do
     # global_club_id は Raspberry Pi 財団の Clubs API 上のクラブ ID (UUID)。
     # DojoMap が名前ではなくこの ID で突合できるようにするために持たせている。
     #
-    # 現時点では YAML に置いてあるだけで、どこからも読まれていない。
-    # 値の妥当性はこの spec だけが守っているため、手作業の追記で起きやすい
-    # typo と重複をここで検出する。
+    # 値の出どころは YAML で、dojos:update_db_by_yaml が DB に反映する。
+    # DB 側にもユニークインデックスがあるが、それが守るのは重複だけなので、
+    # 手作業の追記で起きやすい typo はここで検出する。
     #
     # 休止・閉鎖したクラブは Clubs API の一覧取得に現れないため、値が正しいかを
     # 突合で確かめられない。そのため形式と重複だけを検証し、実在性は検証しない。
@@ -323,6 +323,27 @@ RSpec.describe Dojo, :type => :model do
         expect(duplicated).to be_empty,
           "重複している global_club_id: #{duplicated.join(', ')}"
       end
+    end
+  end
+
+  # 上の spec は YAML を見る。こちらは DB のユニークインデックスそのものを確かめる。
+  # YAML を経由しない経路（コンソールでの手直しなど）でも重複を防げることの確認。
+  describe 'global_club_id の一意性 (DB)' do
+    let(:uuid) { 'b115e722-0000-4000-8000-000000000001' }
+
+    it '同じ値を 2 つの Dojo に持たせられない' do
+      create(:dojo, name: '先に登録', global_club_id: uuid)
+
+      expect { create(:dojo, name: '後から登録', global_club_id: uuid) }
+        .to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it '値を持たない Dojo は何件でも共存できる' do
+      # PostgreSQL のユニークインデックスは NULL を重複とみなさない。
+      # 値を持てない道場が 78 件あるため、この性質に依存している
+      create(:dojo, name: '未設定 1', global_club_id: nil)
+
+      expect { create(:dojo, name: '未設定 2', global_club_id: nil) }.not_to raise_error
     end
   end
 

--- a/spec/requests/dojos_spec.rb
+++ b/spec/requests/dojos_spec.rb
@@ -265,6 +265,32 @@ RSpec.describe "Dojos", type: :request do
       end
     end
 
+    # DojoMap は /dojos.json だけを見て提携先のクラブと突き合わせる。
+    # 名前ではなく UUID で突合できるようにするため、この列を JSON に出す。
+    # https://github.com/coderdojo-japan/coderdojo.jp/issues/1616
+    describe "global_club_id field in output" do
+      it "includes global_club_id in JSON response" do
+        uuid = 'b115e722-0000-4000-8000-000000000001'
+        @dojo_2020_active.update!(global_club_id: uuid)
+
+        get dojos_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.find { |d| d["id"] == @dojo_2020_active.id }["global_club_id"]).to eq(uuid)
+      end
+
+      it "returns null for dojos without global_club_id" do
+        # 値を持たない道場のほうが多い。キーごと消えると読む側で分岐が増えるので、
+        # キーは常に出して null を返す
+        get dojos_path(format: :json)
+        json_response = JSON.parse(response.body)
+
+        entry = json_response.find { |d| d["id"] == @dojo_2020_active.id }
+        expect(entry).to have_key("global_club_id")
+        expect(entry["global_club_id"]).to be_nil
+      end
+    end
+
     describe "counter field in output" do
       it "includes counter field in JSON response" do
         get dojos_path(format: :json)


### PR DESCRIPTION
`db/dojos.yml` にある `global_club_id`（261/339 件）は、これまで spec 以外のどこからも読まれていませんでした。DojoMap が名前ではなく UUID で突き合わせられるよう、DB に載せて `/dojos.json` に出します。Issue #1616 の一段目です。

### 変更点

| ファイル | 内容 |
|:---|:---|
| マイグレーション | `dojos.global_club_id` (string) + ユニークインデックス |
| `lib/tasks/dojos.rake` | `update_db_by_yaml` が YAML の値を反映。反映前に、一致しなくなった値を解放する |
| `app/controllers/dojos_controller.rb` | `/dojos.json` に `global_club_id` を追加 |

```diff
 {
   "id": 356,
   "name": "南城",
   ...
+  "global_club_id": "b115e722-3f39-4306-9041-3d323844182e"
 }
```

### null 許容にした理由

設計文書 (#1747) が指定していた `null: false` は**目標としては正しい**ものの、現時点では成立しません。掲載を終えた道場は提携先のデータベースからクラブごと消えており、全 339 件が値を持つ状態にはなりません（現在 261 件）。

段階的に `null: false` へ近づける方針は Issue #1616 に記録しています。

### CI では検出できない衝突を、前処理で塞ぐ

ユニークインデックスを張るにあたり、**spec でも CI でも原理的に検出できない衝突経路**が 2 つあります。

1. **UUID を道場 A から B へ移す編集** — YAML 内に重複が生じないため一意性の spec を通り抜けます。衝突は本番 DB の既存行との間でだけ起き、`release` フェーズで毎回走るこのタスクが落ちてデプロイごと止まります
2. **DB にだけ残った行が UUID を握っている場合** — `update_db_by_yaml` は YAML に無い行を消しません。この場合、リポジトリのどこにも重複が見えないまま `release` が落ちます

当初は PR 本文に「2 段階デプロイで回避する」と手順を書いていましたが、数か月後に YAML を触る人がその注記を読む保証はありません。反映前に一致しない値を解放する前処理で、機械的に解決します。

```ruby
expected_global_club_id = dojos.to_h { |dojo| [dojo['id'], dojo['global_club_id'].presence] }
Dojo.where.not(global_club_id: nil).find_each do |d|
  d.update_columns(global_club_id: nil) if expected_global_club_id[d.id] != d.global_club_id
end
```

あわせて `raise_if_invalid_dojo` を本処理の前に全行まとめて実行するようにしました。解放だけ済ませてから不正な行で止まると、DB が半端な状態で残るためです。

### 空文字の扱い

PostgreSQL のユニークインデックスは NULL を重複とみなさないため、値を持たない 78 件が共存できます。**ただし空文字は 2 件目で落ちます。** そのため `.presence` を通して nil に正規化しています。

### JSON はキーを常に出す

値を持たない道場も少なくないため、キーごと消えると読む側で分岐が増えます。キーは常に出して、値が無ければ `null` を返します。CSV 出力は `app/views/dojos/index.csv.ruby` が列を明示指定しているため、新しいキーは漏れません。

### 検証

spec を先に書き、RED になることを確認してから実装しました。

| 検証 | RED の内容 |
|:---|:---|
| rake が値を反映する | 未実装なので nil |
| 空文字 → nil | `.presence` を外すと `RecordNotUnique` |
| UUID の移動 | `RecordNotUnique` |
| DB 残留行との衝突 | `RecordNotUnique` |
| `/dojos.json` に出る | キーが無い |

- `bundle exec rspec spec` → 266 examples, 0 failures
- `brakeman` → No warnings found
- 実データ反映後: 全体 **261 / 339**、active **200 / 202**。連続 2 回実行しても同じ（冪等）
- `migrate_adding_id_to_yaml` を空回ししても `db/dojos.yml` に差分なし
- ローカルの `/dojos.json`: 339 件すべてが `global_club_id` キーを持ち、うち 261 件に値