### PR TITLE
fix(statistics): 開催日の変更で集計が止まり、イベント履歴が消えるのを直す

### DIFF
--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -17,9 +17,17 @@ module Statistics
       dojo_info = "[#{@dojo_id}]" if @dojo_id
       puts "Aggregate for #{@from}~#{@to}#{dojo_info}"
       with_notifying do
-        delete_event_histories
-        execute
-        execute_once
+        # 「削除だけが確定し、再登録されない」状態を残さないため、全体を1つの
+        # トランザクションにまとめる。呼び出し側に任せると rails console から
+        # 直接呼んだときに原子性が失われる。
+        EventHistory.transaction do
+          delete_event_histories(@externals.keys)
+          execute
+          # static_yaml は期間を問わず全件を入れ替えるため、削除と再登録を隣接させる。
+          # 先に削除すると、外部プロバイダの失敗に巻き込まれて履歴が丸ごと消える。
+          delete_event_histories(@internals.keys)
+          execute_once
+        end
       end
     end
 
@@ -97,12 +105,21 @@ module Statistics
       yield
       Notifier.notify_success(date_format(@from), date_format(@to), @provider, @dojo_id)
     rescue => e
-      Notifier.notify_failure(date_format(@from), date_format(@to), @provider, @dojo_id, e)
+      # 通知したうえで再送出し、週次ジョブを失敗させる。握り潰すと、データが
+      # 欠けたまま正常終了したように見える。
+      #
+      # Slack への通知自体が失敗しても、元の例外を失わないようにする。
+      begin
+        Notifier.notify_failure(date_format(@from), date_format(@to), @provider, @dojo_id, e)
+      rescue => notification_error
+        $stdout.puts "Failed to notify: #{notification_error.message}"
+      end
+      raise e
     end
 
-    def delete_event_histories
+    def delete_event_histories(kinds)
       target_period = @from.beginning_of_day..@to.end_of_day
-      (@externals.keys + @internals.keys).each do |kind|
+      kinds.each do |kind|
         "Statistics::Tasks::#{kind.to_s.camelize}".constantize.delete_event_histories(target_period, @dojo_id)
       end
     end
@@ -137,7 +154,13 @@ module Statistics
         end
 
         def notify_failure(from, to, provider, dojo_id, exception)
-          notify("#{from}~#{to}#{provider_info(provider)}#{dojo_info(dojo_id)}のイベント履歴の集計でエラーが発生しました\n#{exception.message}\n#{exception.backtrace.join("\n")}")
+          # 期間を指定せずに再実行すると「実行時点の前週」を集計するため、翌週以降に
+          # 再実行しても欠けた週は埋まらない。再実行するコマンドを添える。
+          # zsh では [] がグロブとして解釈されるため、引用符ごとコピペできる形にする
+          retry_command = "rails 'statistics:aggregation[#{from},#{to}#{",#{provider}" if provider}]'"
+          notify("#{from}~#{to}#{provider_info(provider)}#{dojo_info(dojo_id)}のイベント履歴の集計でエラーが発生しました\n" \
+                 "原因を直したあと、期間を指定して再実行してください: #{retry_command}\n" \
+                 "#{exception.message}\n#{exception.backtrace.join("\n")}")
         end
 
         private

--- a/lib/statistics/aggregation.rb
+++ b/lib/statistics/aggregation.rb
@@ -20,6 +20,7 @@ module Statistics
         # 「削除だけが確定し、再登録されない」状態を残さないため、全体を1つの
         # トランザクションにまとめる。呼び出し側に任せると rails console から
         # 直接呼んだときに原子性が失われる。
+        # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
         EventHistory.transaction do
           delete_event_histories(@externals.keys)
           execute
@@ -107,6 +108,7 @@ module Statistics
     rescue => e
       # 通知したうえで再送出し、週次ジョブを失敗させる。握り潰すと、データが
       # 欠けたまま正常終了したように見える。
+      # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
       #
       # Slack への通知自体が失敗しても、元の例外を失わないようにする。
       begin
@@ -156,6 +158,7 @@ module Statistics
         def notify_failure(from, to, provider, dojo_id, exception)
           # 期間を指定せずに再実行すると「実行時点の前週」を集計するため、翌週以降に
           # 再実行しても欠けた週は埋まらない。再実行するコマンドを添える。
+          # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
           # zsh では [] がグロブとして解釈されるため、引用符ごとコピペできる形にする
           retry_command = "rails 'statistics:aggregation[#{from},#{to}#{",#{provider}" if provider}]'"
           notify("#{from}~#{to}#{provider_info(provider)}#{dojo_info(dojo_id)}のイベント履歴の集計でエラーが発生しました\n" \

--- a/lib/statistics/tasks/connpass.rb
+++ b/lib/statistics/tasks/connpass.rb
@@ -26,15 +26,17 @@ module Statistics
           dojo_event_service = DojoEventService.find_by(group_id: e.dig('group', 'id').to_s)
           next unless dojo_event_service
 
-          EventHistory.create!(dojo_id:          dojo_event_service.dojo_id,
-                               dojo_name:        dojo_event_service.dojo.name,
-                               service_name:     dojo_event_service.name,
-                               service_group_id: dojo_event_service.group_id,
-                               event_id:         e.fetch('id'),
-                               event_url:        e.fetch('url'),
-                               participants:     e.fetch('accepted'),
-                               evented_at:       Time.zone.parse(e.fetch('started_at'))
-            )
+          # 道場がイベントページを作り直さずに開催日だけ変更すると、集計期間の外に
+          # 残った履歴と event_id が衝突して集計が止まる。作成ではなく更新にして
+          # 開催日の変更に追随する。
+          history = EventHistory.find_or_initialize_by(service_name: dojo_event_service.name,
+                                                       event_id:     e.fetch('id').to_s)
+          history.update!(dojo_id:          dojo_event_service.dojo_id,
+                          dojo_name:        dojo_event_service.dojo.name,
+                          service_group_id: dojo_event_service.group_id,
+                          event_url:        e.fetch('url'),
+                          participants:     e.fetch('accepted'),
+                          evented_at:       Time.zone.parse(e.fetch('started_at')))
         end
       end
 

--- a/lib/statistics/tasks/connpass.rb
+++ b/lib/statistics/tasks/connpass.rb
@@ -29,6 +29,7 @@ module Statistics
           # 道場がイベントページを作り直さずに開催日だけ変更すると、集計期間の外に
           # 残った履歴と event_id が衝突して集計が止まる。作成ではなく更新にして
           # 開催日の変更に追随する。
+          # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
           history = EventHistory.find_or_initialize_by(service_name: dojo_event_service.name,
                                                        event_id:     e.fetch('id').to_s)
           history.update!(dojo_id:          dojo_event_service.dojo_id,

--- a/lib/statistics/tasks/doorkeeper.rb
+++ b/lib/statistics/tasks/doorkeeper.rb
@@ -23,14 +23,15 @@ module Statistics
             (events || []).compact.each do |e|
               next unless e[:group].to_s == dojo_event_service.group_id
 
-              EventHistory.create!(dojo_id:          dojo.id,
-                                   dojo_name:        dojo.name,
-                                   service_name:     dojo_event_service.name,
-                                   service_group_id: dojo_event_service.group_id,
-                                   event_id:     e[:id],
-                                   event_url:    e[:public_url],
-                                   participants: e[:participants],
-                                   evented_at:   Time.zone.parse(e[:starts_at]))
+              # connpass と同じく、開催日の変更に追随するため作成ではなく更新にする。
+              history = EventHistory.find_or_initialize_by(service_name: dojo_event_service.name,
+                                                           event_id:     e[:id].to_s)
+              history.update!(dojo_id:          dojo.id,
+                              dojo_name:        dojo.name,
+                              service_group_id: dojo_event_service.group_id,
+                              event_url:        e[:public_url],
+                              participants:     e[:participants],
+                              evented_at:       Time.zone.parse(e[:starts_at]))
             end
             puts "    ✓ Successfully fetched #{events&.size || 0} events"
           rescue => e

--- a/lib/statistics/tasks/doorkeeper.rb
+++ b/lib/statistics/tasks/doorkeeper.rb
@@ -24,6 +24,7 @@ module Statistics
               next unless e[:group].to_s == dojo_event_service.group_id
 
               # connpass と同じく、開催日の変更に追随するため作成ではなく更新にする。
+              # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
               history = EventHistory.find_or_initialize_by(service_name: dojo_event_service.name,
                                                            event_id:     e[:id].to_s)
               history.update!(dojo_id:          dojo.id,

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -2,10 +2,9 @@ require_relative '../statistics.rb'
 
 namespace :statistics do
   desc '指定期間/プロバイダのイベント履歴を集計します'
+  # トランザクションは Statistics::Aggregation#run が持つ。
   task :aggregation, [:from, :to, :provider, :dojo_id] => :environment do |tasks, args|
-    EventHistory.transaction do
-      Statistics::Aggregation.new(args).run
-    end
+    Statistics::Aggregation.new(args).run
   end
 
   desc '集計が静かに壊れていないかを確認します（直近 N 日で 0 件のプロバイダを検知）'

--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -3,6 +3,7 @@ require_relative '../statistics.rb'
 namespace :statistics do
   desc '指定期間/プロバイダのイベント履歴を集計します'
   # トランザクションは Statistics::Aggregation#run が持つ。
+  # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
   task :aggregation, [:from, :to, :provider, :dojo_id] => :environment do |tasks, args|
     Statistics::Aggregation.new(args).run
   end

--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -17,15 +17,15 @@ RSpec.describe Statistics::Aggregation do
     let(:yaml_provider) { instance_double(EventService::Providers::StaticYaml) }
 
     before do
-      d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.example.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://example.com/dojo1', prefecture_id: 13)
-      d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.example.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://example.org/dojo2', prefecture_id: 13)
-      create(:dojo_event_service, dojo_id: d1.id, name: :connpass, group_id: 9876)
-      create(:dojo_event_service, dojo_id: d2.id, name: :doorkeeper, group_id: 5555)
+      @d1 = create(:dojo, name: 'Dojo1', email: 'info@dojo1.example.com', description: 'CoderDojo1', tags: %w(CoderDojo1), url: 'https://example.com/dojo1', prefecture_id: 13)
+      @d2 = create(:dojo, name: 'Dojo2', email: 'info@dojo2.example.com', description: 'CoderDojo2', tags: %w(CoderDojo2), url: 'https://example.org/dojo2', prefecture_id: 13)
+      create(:dojo_event_service, dojo_id: @d1.id, name: :connpass, group_id: 9876)
+      create(:dojo_event_service, dojo_id: @d2.id, name: :doorkeeper, group_id: 5555)
 
-      d3 = create(:dojo, name: 'Dojo3', email: 'info@dojo3.example.com', description: 'CoderDojo3', tags: %w(CoderDojo3), url: 'https://example.com/dojo3', prefecture_id: 13)
+      @d3 = create(:dojo, name: 'Dojo3', email: 'info@dojo3.example.com', description: 'CoderDojo3', tags: %w(CoderDojo3), url: 'https://example.com/dojo3', prefecture_id: 13)
       allow(EventService::Providers::StaticYaml).to receive(:new).and_return(yaml_provider)
       allow(yaml_provider).to receive(:fetch_events).and_return([
-        { 'dojo_id' => d3.id, 'event_url' => 'https://example.com/event/12345', 'evented_at' => '2023-12-10 14:00', 'participants' => 1 }
+        { 'dojo_id' => @d3.id, 'event_url' => 'https://example.com/event/12345', 'evented_at' => '2023-12-10 14:00', 'participants' => 1 }
       ])
     end
 
@@ -46,6 +46,54 @@ RSpec.describe Statistics::Aggregation do
       event = EventHistory.for(:connpass).first
       expect(event.service_group_id).to eq('9876')
       expect(event.participants).to eq(10)
+    end
+
+    # 道場がイベントページを作り直さずに開催日だけ変更すると、集計期間の外に残った
+    # 履歴と event_id が衝突し、集計が途中で止まっていた。
+    #
+    # NOTE: 追随できるのは「期間外 -> 期間内」への移動のみ。期間外へ移された
+    #       イベントは API が返さなくなるため、古い evented_at のまま残る。
+    #       全期間を差分同期しない限り直せないため、仕様として受け入れている。
+    it '開催日が変更されたイベントは、既存の履歴を更新する' do
+      existing = EventHistory.create!(dojo_id:          @d1.id,
+                                      dojo_name:        @d1.name,
+                                      service_name:     'connpass',
+                                      service_group_id: '9876',
+                                      event_id:         '12345',
+                                      event_url:        'https://coderdojo-okutama.connpass.com/event/12345/',
+                                      participants:     3,
+                                      evented_at:       Time.zone.parse('2016-01-01 10:00'))
+
+      expect{ subject }.not_to change{ EventHistory.for(:connpass).where(event_id: '12345').count }
+
+      existing.reload
+      expect(existing.evented_at).to   eq(Time.zone.parse('2017-05-07 10:00'))
+      expect(existing.participants).to eq(10)
+    end
+
+    # 例外を握り潰すと、削除だけが確定した状態で正常終了してしまう。
+    # 週次ジョブを失敗させて、欠損に気付けるようにする。
+    it '集計に失敗したとき、例外を握り潰さない' do
+      allow_any_instance_of(Statistics::Tasks::Connpass).to receive(:run).and_raise('connpass の取得に失敗しました')
+
+      expect{ subject }.to raise_error('connpass の取得に失敗しました')
+    end
+
+    # static_yaml は期間を問わず全件を入れ替えるため、削除が先に走ると
+    # 他プロバイダの失敗に巻き込まれて履歴が丸ごと消える。
+    it '外部プロバイダの失敗で static_yaml のイベント履歴が消えない' do
+      EventHistory.create!(dojo_id:      @d3.id,
+                           dojo_name:    @d3.name,
+                           service_name: 'static_yaml',
+                           event_id:     '99999',
+                           event_url:    'https://example.com/event/99999',
+                           participants: 5,
+                           evented_at:   Time.zone.parse('2023-12-10 14:00'))
+
+      allow_any_instance_of(Statistics::Tasks::Connpass).to receive(:run).and_raise('connpass の取得に失敗しました')
+
+      expect{ subject }.to raise_error('connpass の取得に失敗しました')
+      expect(EventHistory.for(:static_yaml).count).to eq(1)
     end
   end
 

--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Statistics::Aggregation do
 
     # 道場がイベントページを作り直さずに開催日だけ変更すると、集計期間の外に残った
     # 履歴と event_id が衝突し、集計が途中で止まっていた。
+    # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
     #
     # NOTE: 追随できるのは「期間外 -> 期間内」への移動のみ。期間外へ移された
     #       イベントは API が返さなくなるため、古い evented_at のまま残る。
@@ -73,6 +74,7 @@ RSpec.describe Statistics::Aggregation do
 
     # 例外を握り潰すと、削除だけが確定した状態で正常終了してしまう。
     # 週次ジョブを失敗させて、欠損に気付けるようにする。
+    # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
     it '集計に失敗したとき、例外を握り潰さない' do
       allow_any_instance_of(Statistics::Tasks::Connpass).to receive(:run).and_raise('connpass の取得に失敗しました')
 
@@ -81,6 +83,7 @@ RSpec.describe Statistics::Aggregation do
 
     # static_yaml は期間を問わず全件を入れ替えるため、削除が先に走ると
     # 他プロバイダの失敗に巻き込まれて履歴が丸ごと消える。
+    # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
     it '外部プロバイダの失敗で static_yaml のイベント履歴が消えない' do
       EventHistory.create!(dojo_id:      @d3.id,
                            dojo_name:    @d3.name,


### PR DESCRIPTION
## 何が起きたか

2026/08/17〜08/23 の週次集計が途中で停止し、`static_yaml` のイベント履歴 143 件が本番から欠損しました。過去年の統計値もその分だけ減っています。

### 原因の連鎖

1. イベントページが作り直されずに開催日だけ変更されると、集計期間の外に残った履歴と `event_id` が衝突する
2. `EventHistory.create!` が `ActiveRecord::RecordInvalid` で失敗する
3. `with_notifying` が例外を握り潰すため、`execute_once`（static_yaml）まで到達しない
4. `delete_event_histories` は先に完走している。しかも `static_yaml` の削除は期間を問わない**全件削除**
5. バリデーションエラーは Ruby レベルで起きるため DB トランザクションはアボートせず、rescue 後に commit される

### 裏取り

本番 `/stats` の年次開催回数と、ローカルの DB コピー（7/12 時点）との差が、各年の `static_yaml` 件数と一致しました。

| 年 | 本番との差 | うち static_yaml |
|---|---|---|
| 2014 | -6 | 6 |
| 2015 | -12 | 12 |
| 2016 | -28 | 28 |
| 2017 | -29 | 29 |
| 2023 | -31 | 31 |
| 2024 | -28 | 28 |

## 修正

- **connpass / doorkeeper**: `create!` を `find_or_initialize_by(service_name:, event_id:)` + `update!` に変更し、開催日の変更に追随する。DB の一意インデックス `["service_name", "event_id"]` と同じキーを使う
- **static_yaml**: 全件削除を再登録の直前へ移し、他プロバイダの失敗と切り離す
- **例外**: 通知したうえで再送出し、週次ジョブを失敗させる。Slack 通知自体が失敗しても元の例外を失わない
- **トランザクション**: rake タスクから `Statistics::Aggregation#run` へ移す。呼び出し側に任せると `rails console` から直接呼んだときに原子性が失われるため
- **失敗通知**: 期間を指定した再実行コマンドを添える

最後の項目は、期間を指定せずに再実行すると「実行時点の前週」を集計するためです。翌週以降に気付いて再実行しても、欠けた週は埋まりません。

### 追随できない範囲

追随できるのは「期間外 → 期間内」への移動のみです。期間外へ移されたイベントは API が返さなくなるため、古い `evented_at` のまま残ります。全期間の差分同期が必要になり、コード量が増えるため仕様として受け入れています（spec のコメントに明記）。

## テスト

TDD で RED を確認してから実装しました。追加したのは 3 件です。

- 開催日が変更されたイベントは、既存の履歴を更新する
- 集計に失敗したとき、例外を握り潰さない
- 外部プロバイダの失敗で static_yaml のイベント履歴が消えない

全 269 examples が通っています。

## 本番の復旧（この PR とは別作業）

1. 同一の回を指すイベントが connpass 上に 2 件ある状態を整理する（先にやらないと二重計上になります）
2. デプロイ後の最初の成功実行で `static_yaml` の 143 件は自動復旧します
3. `rails 'statistics:aggregation[2026/08/17,2026/08/23]'` を手動実行する（定期実行では窓が進むため、この週は自動では埋まりません）
