### PR TITLE
chore(bin): 本番の統計集計を実行するラッパーを追加

### DIFF
--- a/bin/heroku-stats-aggregation
+++ b/bin/heroku-stats-aggregation
@@ -11,6 +11,7 @@
 # タスク名と app 名をここで固定している。`heroku run rails ...` を直接叩くと、
 # 打ち間違いで別のタスク（db:drop など）や別アプリを本番で実行してしまう余地が残る。
 # 実行を許可する対象をこのスクリプトに絞れば、操作が集計だけに限定される。
+# cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1882
 set -euo pipefail
 
 task='statistics:aggregation'

--- a/bin/heroku-stats-aggregation
+++ b/bin/heroku-stats-aggregation
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# 本番のイベント履歴を再集計する。
+#
+#   bin/heroku-stats-aggregation                        # 前週（週次ジョブと同じ）
+#   bin/heroku-stats-aggregation - - static_yaml        # static_yaml のみ全期間
+#   bin/heroku-stats-aggregation 2026/08/17 2026/08/23  # 期間を指定
+#
+# 引数は rake タスクの [from,to,provider,dojo_id] にそのまま渡る。
+#
+# タスク名と app 名をここで固定している。`heroku run rails ...` を直接叩くと、
+# 打ち間違いで別のタスク（db:drop など）や別アプリを本番で実行してしまう余地が残る。
+# 実行を許可する対象をこのスクリプトに絞れば、操作が集計だけに限定される。
+set -euo pipefail
+
+task='statistics:aggregation'
+if [ $# -gt 0 ]; then
+  IFS=','
+  task="${task}[$*]"
+fi
+
+exec heroku run rails "$task" --app coderdojo-japan


### PR DESCRIPTION
## 背景

PR #1881 で統計集計の障害を直しましたが、欠損したデータを戻すには本番で集計タスクを手動実行する必要があります。

そのとき叩くコマンドはこの形です。

```
heroku run rails 'statistics:aggregation[-,-,static_yaml]' --app coderdojo-japan
```

毎回この文字列を組み立てると、タスク名や app 名の打ち間違いで**別のタスク（`db:drop` など）や別アプリを本番で実行してしまう余地**が残ります。

## 変更

タスク名と app 名を固定したラッパーを `bin/` に追加します。

```
bin/heroku-stats-aggregation                        # 前週（週次ジョブと同じ）
bin/heroku-stats-aggregation - - static_yaml        # static_yaml のみ全期間
bin/heroku-stats-aggregation 2026/08/17 2026/08/23  # 期間を指定
```

引数は rake タスクの `[from,to,provider,dojo_id]` にそのまま渡ります。

## 検証

偽の `heroku` を PATH に置き、実際には叩かずに組み立てられるコマンドを確認しました。

| 実行 | 組み立てられるコマンド |
|---|---|
| 引数なし | `heroku run rails statistics:aggregation --app coderdojo-japan` |
| `- - static_yaml` | `heroku run rails statistics:aggregation[-,-,static_yaml] --app coderdojo-japan` |
| `2026/08/17 2026/08/23` | `heroku run rails statistics:aggregation[2026/08/17,2026/08/23] --app coderdojo-japan` |

`statistics:aggregation[...]` が 1 トークンとして渡り、`[]` がグロブ展開されないことも確認済みです。

## 検討して見送った案

- **コマンドを毎回手で組み立てる**: 打ち間違いのリスクが残るため見送り
- **エイリアスにする**: シェル設定はリポジトリで共有されないため、他の開発者が同じ操作を再現できない

## 補足

このスクリプトは本番に対する WRITE 操作を実行します。集計タスク自体は冪等（同じ期間で何度実行しても同じ結果）で、PR #1881 の修正で 1 つのトランザクションに入ったため、途中で失敗しても実行前の状態に戻ります。
