### PR TITLE
fix(airbrake): 通知が落ちる問題と、手元の実行が本番に混ざる問題を直す

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -70,8 +70,12 @@ if (project_id =  ENV['AIRBRAKE_PROJECT_ID']) &&
   # when it needs to stop an existing Puma process, typically during a new deployment/restart.
   # Puma traps this signal, which surfaces as SignalException: SIGTERM in the stack trace from launcher.rb.
   # It does not necessarily indicate a bug in the application.
+  # 例外は notice.stash[:exception] から取り出す。Airbrake::Notice に exception
+  # メソッドは無く、呼ぶと通知のたびに NoMethodError になる。
+  # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1884
   Airbrake.add_filter do |notice|
-    if notice.exception.is_a?(SignalException) && notice.exception.message == 'SIGTERM'
+    exception = notice.stash[:exception]
+    if exception.is_a?(SignalException) && exception.message == 'SIGTERM'
       notice.ignore!
     end
   end

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -41,7 +41,14 @@ if (project_id =  ENV['AIRBRAKE_PROJECT_ID']) &&
     # unwanted environments such as :test.  NOTE: This option *does not* work if
     # you don't set the 'environment' option.
     # https://github.com/airbrake/airbrake-ruby#ignore_environments
+    #
+    # 手元で RAILS_ENV=production を実行したときも production 扱いになるため、
+    # この一覧だけでは本番の通知に混ざる。Rails のアップグレード検証などで
+    # production のブートを確認するのは定石なので、気をつけるのではなく
+    # Heroku 上かどうかで機械的に切り分ける。DYNO は dyno 内でのみ設定される。
+    # cf. https://devcenter.heroku.com/articles/dyno-metadata
     c.ignore_environments = %w[test staging development]
+    c.ignore_environments << Rails.env if ENV['DYNO'].nil?
 
     # A list of parameters that should be filtered out of what is sent to
     # Airbrake. By default, all "password" attributes will have their contents

--- a/spec/airbrake_filter_spec.rb
+++ b/spec/airbrake_filter_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+# デプロイや再起動のたびに Heroku が Puma へ SIGTERM を送る。これは障害ではないので
+# Airbrake へ通知しないよう、config/initializers/airbrake.rb でフィルタしている。
+#
+# そのフィルタが notice.exception を呼んでいたが、Airbrake::Notice にそのメソッドは
+# 無く、通知のたびに NoMethodError で落ちていた。例外を取り出すには stash を使う。
+# cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1884
+RSpec.describe 'Airbrake の SIGTERM フィルタ' do
+  # 実際に通知が飛ばないよう、フィルタの処理だけを取り出して検証する
+  let(:filter) do
+    lambda do |notice|
+      exception = notice.stash[:exception]
+      notice.ignore! if exception.is_a?(SignalException) && exception.message == 'SIGTERM'
+    end
+  end
+
+  def build_notice(exception)
+    Airbrake::Notice.new(exception)
+  end
+
+  it 'SIGTERM は通知しない' do
+    notice = build_notice(SignalException.new('SIGTERM'))
+    filter.call(notice)
+    expect(notice).to be_ignored
+  end
+
+  it 'SIGTERM 以外のシグナルは通知する' do
+    notice = build_notice(SignalException.new('SIGINT'))
+    filter.call(notice)
+    expect(notice).not_to be_ignored
+  end
+
+  it 'ふつうの例外は通知する' do
+    notice = build_notice(RuntimeError.new('何かがおかしい'))
+    filter.call(notice)
+    expect(notice).not_to be_ignored
+  end
+
+  # Airbrake::Notice に exception メソッドは無い。あると思い込んだまま書くと、
+  # 通知が発生した瞬間に NoMethodError になる（本番でしか踏まない）。
+  it 'Airbrake::Notice は exception メソッドを持たない' do
+    notice = build_notice(RuntimeError.new('test'))
+    expect(notice).not_to respond_to(:exception)
+    expect(notice.stash[:exception]).to be_a(RuntimeError)
+  end
+
+  # 上のテストは「正しい書き方」を確かめるだけで、initializer が実際にそう書いて
+  # いるかは見ていない。壊れた書き方に戻っても気付けるよう、中身を直接検査する。
+  it 'initializer が notice.exception を呼んでいない' do
+    source = Rails.root.join('config/initializers/airbrake.rb').read
+    expect(source).not_to match(/notice\.exception/)
+    expect(source).to match(/notice\.stash\[:exception\]/)
+  end
+end

--- a/spec/airbrake_filter_spec.rb
+++ b/spec/airbrake_filter_spec.rb
@@ -52,4 +52,14 @@ RSpec.describe 'Airbrake の SIGTERM フィルタ' do
     expect(source).not_to match(/notice\.exception/)
     expect(source).to match(/notice\.stash\[:exception\]/)
   end
+
+  # ローカルで RAILS_ENV=production を実行すると、ignore_environments は
+  # production を除外していないため素通りし、本番の Airbrake に通知が飛ぶ。
+  # Rails のアップグレード検証では production でのブート確認が定石なので、
+  # 運用で気をつけるのではなく、Heroku 上かどうかで機械的に判定する。
+  # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1885
+  it 'Heroku 以外での実行を通知対象から外している' do
+    source = Rails.root.join('config/initializers/airbrake.rb').read
+    expect(source).to match(/ENV\['DYNO'\]/)
+  end
 end


### PR DESCRIPTION
## 何が起きていたか

デプロイや再起動のたびに Heroku が Puma へ SIGTERM を送ります。これは障害ではないので Airbrake へ通知しないようフィルタしていましたが、**そのフィルタ自体が例外を投げて落ちていました**。

```
config/initializers/airbrake.rb:74: undefined method `exception` for an instance of Airbrake::Notice (NoMethodError)
```

## 原因

`Airbrake::Notice` に `exception` メソッドは存在しません。gem のソースで確認したところ、公開されているのは `[]` / `[]=` / `to_json` / `context` などで、例外は **`stash[:exception]`** から取り出します。

```ruby
# airbrake-ruby-6.2.2/lib/airbrake-ruby/notice.rb:64
stash[:exception] = exception
```

gem 内の他のフィルタも同じ書き方をしています。

```ruby
# airbrake-ruby-6.2.2/lib/airbrake-ruby/filters/exception_attributes_filter.rb:17
exception = notice.stash[:exception]
```

## 影響

**フィルタが書かれた時点から壊れていました。** 本番では通知が発生したときだけ踏むため、これまで気付かれていません。SIGTERM が無視されず、デプロイのたびに不要な通知が飛んでいた可能性があります。

ローカルでは `RAILS_ENV=production` でのブートがこのエラーで止まるため、**本番相当の動作確認ができない状態**でもありました。

## 修正

```diff
 Airbrake.add_filter do |notice|
-  if notice.exception.is_a?(SignalException) && notice.exception.message == 'SIGTERM'
+  exception = notice.stash[:exception]
+  if exception.is_a?(SignalException) && exception.message == 'SIGTERM'
     notice.ignore!
   end
 end
```

## テスト

5 件追加しました。

```
✓ SIGTERM は通知しない
✓ SIGTERM 以外のシグナルは通知する
✓ ふつうの例外は通知する
✓ Airbrake::Notice は exception メソッドを持たない
✓ initializer が notice.exception を呼んでいない
```

最初は正しい実装を lambda で書いてテストしましたが、それだと**実装が壊れた書き方に戻っても気付けません**（テストが最初から緑になる）。最後の 1 件で initializer の中身を直接検査し、RED を確認してから修正しています。

## 検証

- `bundle exec rspec spec/airbrake_filter_spec.rb` — 5 examples, 0 failures
- `RAILS_ENV=production` でのブート — **成功**（修正前はこのエラーで停止）

## 経緯

Rails 8.1 アップグレード（#1884）の検証中に、`RAILS_ENV=production` でのブートを試したところ発見しました。当初は #1884 に含めていましたが、**Rails のバージョンとは無関係な不具合**なので分離しています。実際、この PR は main（Rails 8.0）ベースで、その状態でもテストとブートが通ることを確認しました。
