### PR TITLE
test(statistics): 週次ジョブがガードに引っかからないことを固定する

### DIFF
--- a/spec/lib/statistics/aggregation_spec.rb
+++ b/spec/lib/statistics/aggregation_spec.rb
@@ -126,6 +126,21 @@ RSpec.describe Statistics::Aggregation do
       expect{ aggregate({}) }.not_to raise_error
     end
 
+    # 週次ジョブは毎週月曜 01:00 UTC（10:00 JST）に走る。ガードが誤って止めると、
+    # 今回復旧したのと同じ「静かな欠損」を生む。実際の実行曜日で確かめておく。
+    it '月曜の定期実行でも止めない' do
+      travel_to(Time.zone.parse('2026-08-31 10:00'))  # 月曜
+      expect(Time.zone.today.wday).to eq(1)
+      expect{ aggregate({}) }.not_to raise_error
+    end
+
+    # 復旧のために遡る期間は、気付いてから対応するまでの遅延を含めても数週間に収まる。
+    it '60 日前まで遡る復旧は止めない' do
+      from = (Time.zone.today - 60).strftime('%Y-%m-%d')
+      to   = (Time.zone.today - 54).strftime('%Y-%m-%d')
+      expect{ aggregate(from: from, to: to) }.not_to raise_error
+    end
+
     it '直近の期間を指定した復旧は止めない' do
       expect{ aggregate(from: '2026-08-17', to: '2026-08-23') }.not_to raise_error
     end


### PR DESCRIPTION
## 背景

PR #1883 で「開始日が 90 日より前なら外部プロバイダの再集計を中止する」ガードを入れました。

このガードには **最悪の失敗モード**があります。誤発動して週次ジョブを止めると、まさに今回復旧したのと同じ「静かな欠損」を生みます。

当初は「月曜の実行を見て確かめる」計画でしたが、**待つ必要はありません**。実行日時を固定すれば今日のうちに検証できます。

## 追加したテスト

```ruby
it '月曜の定期実行でも止めない' do
  travel_to(Time.zone.parse('2026-08-31 10:00'))  # 月曜
  expect(Time.zone.today.wday).to eq(1)
  expect{ aggregate({}) }.not_to raise_error
end

it '60 日前まで遡る復旧は止めない' do
  from = (Time.zone.today - 60).strftime('%Y-%m-%d')
  to   = (Time.zone.today - 54).strftime('%Y-%m-%d')
  expect{ aggregate(from: from, to: to) }.not_to raise_error
end
```

**ガード単体ではなく、引数なしで呼ぶ実際の経路で検証しています。** 週次ジョブがどんな開始日を渡すかは、デフォルト値の解決（`prev_week.beginning_of_week`）を含めて初めて決まるためです。ガードのロジックだけをテストしても、「週次ジョブが実際に何を渡すか」は検証できません。

`travel_to` で時刻を固定しているのは、実行日が変わってもテストの意味が変わらないようにするためです。

## 検証した条件

| ケース | 開始日 | 結果 |
|---|---|---|
| 週次ジョブ（月曜 10:00 JST） | 7 日前 | 通る |
| 60 日前まで遡る復旧 | 60 日前 | 通る |
| 直近の期間指定 | 8 日前 | 通る |
| static_yaml のみ全期間 | 2012-01-01 | 通る（対象外） |
| 90 日より前 | 2015-01-01 | **止まる** |
| 短い期間でも古い | 2013-01-01（7 日間） | **止まる** |

全 282 examples 通過。

## 補足

このガードは「気付いてから復旧するまでの遅延」を吸収する必要があります。今回の実例では 8 日でした。60 日のケースを固定したのは、しばらく気付かなかった場合でも復旧できることを保証するためです。
