### PR TITLE
fix(errors): HTML 専用ページへの .json アクセスが 500 になるのを直す

### DIFF
--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -2,6 +2,7 @@ module ErrorsHelper
   def error_title(code)
     case code
     when 404 then "ページが見つかりませんでした... 🥺💦"
+    when 406 then "対応していない形式のリクエストです 🙏"
     when 422 then "リクエストが処理できませんでした… 😢"
     when 500 then "予期しないエラーが発生しました 😵‍💫"
     else           "予期せぬエラーが発生しました…😵"
@@ -11,6 +12,7 @@ module ErrorsHelper
   def error_desc(code)
     case code
     when 404 then "ページが削除された可能性があります 🤔💭"
+    when 406 then "このページは HTML でのみ提供しています。拡張子を外してアクセスしてください。"
     when 422 then "入力内容に誤りがあるか、リクエストが正しく送信されなかった可能性があります。"
     when 500 then "申し訳ありません。サーバーで問題が発生しています。"
     else           "改善されない場合は、お手数ですがエラー報告をお願いいたします🙇‍♀️"

--- a/app/views/errors/not_acceptable.html.erb
+++ b/app/views/errors/not_acceptable.html.erb
@@ -1,0 +1,1 @@
+<%= render template: "errors/show", locals: { status_code: 406 } %>

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+# HTML しか返さないアクションに .json でアクセスすると 500 になっていた。
+# クローラーが .json を試すたびに Airbrake へ通知が飛び、本物のエラーが埋もれる。
+# 形式が合わないだけなのでサーバエラーではなく 406 を返す。
+RSpec.describe '対応していない形式でのリクエスト', type: :request do
+  # respond_to を持たない（HTML 専用の）アクション
+  %w[
+    /dojos/activity.json
+    /docs.json
+    /kata.json
+    /spaces.json
+  ].each do |path|
+    it "#{path} は 406 を返す（500 にしない）" do
+      get path
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+
+  it 'HTML でのアクセスは従来どおり 200 を返す' do
+    get '/dojos/activity'
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 # HTML しか返さないアクションに .json でアクセスすると 500 になっていた。
 # クローラーが .json を試すたびに Airbrake へ通知が飛び、本物のエラーが埋もれる。
 # 形式が合わないだけなのでサーバエラーではなく 406 を返す。
+# cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1887
 RSpec.describe '対応していない形式でのリクエスト', type: :request do
   # respond_to を持たない（HTML 専用の）アクション
   %w[


### PR DESCRIPTION
## 何が起きていたか

HTML しか返さないアクションに `.json` を付けてアクセスすると、**500 が返っていました**。

```
/dojos/activity.json   500
/docs.json             500
/kata.json             500
/spaces.json           500
```

クローラーやスキャナーが拡張子を試すたびに Airbrake へ通知が飛び、**本物のエラーが埋もれます**。

## 原因

例外のマッピング自体は正しく設定されていました。

```
ActionController::UnknownFormat        -> :not_acceptable
ActionController::MissingExactTemplate -> :not_acceptable
```

足りなかったのは **`app/views/errors/not_acceptable.html.erb`** です。rambulance が 406 のエラーページを描画しようとして失敗し、`internal_server_error`（500）にフォールバックしていました。

`test` 環境では 406 が返るため、**テストでは検出できない**種類の問題でした（`config.consider_all_requests_local = true` のため例外処理の経路が異なります）。

## 修正

既存の 404 と同じ構造でテンプレートを追加し、`errors_helper` に文言を足しました。

```erb
<%= render template: "errors/show", locals: { status_code: 406 } %>
```

```ruby
when 406 then "対応していない形式のリクエストです 🙏"
when 406 then "このページは HTML でのみ提供しています。拡張子を外してアクセスしてください。"
```

## テスト

```
✓ /dojos/activity.json は 406 を返す（500 にしない）
✓ /docs.json は 406 を返す（500 にしない）
✓ /kata.json は 406 を返す（500 にしない）
✓ /spaces.json は 406 を返す（500 にしない）
✓ HTML でのアクセスは従来どおり 200 を返す
```

同じ構造のアクションが今後増えても気付けるよう、テストにパスを列挙しています。

## 経緯

Rails 8.1（#1884）の検証中、公開エンドポイントを一通り叩いて見つけました。**Rails のバージョンとは無関係**で、以前からこの状態だったはずです。

調査の途中で、`rescue_responses` が Rails のデフォルトを置換していると誤って判断しました。実際には `ActionDispatch::ExceptionWrapper.rescue_responses` に `merge!` されており、設定は正しく効いていました。確認する場所を間違えていたので、gem の実装を読んで訂正しています。
