### PR TITLE
fix(errors): .json リクエストにも 406 のテンプレートを用意する

### DIFF
--- a/app/views/errors/not_acceptable.json.jbuilder
+++ b/app/views/errors/not_acceptable.json.jbuilder
@@ -1,0 +1,1 @@
+json.error_message "This page is available in HTML only."


### PR DESCRIPTION
## 概要

PR #1887 で追加した 406 エラーページが本番で効いておらず、`.json` へのアクセスは 500 のままでした。JSON 形式のテンプレートを追加して修正します。

## 原因

`render` はリクエスト形式に応じてテンプレートを探します。`.json` でのアクセスには `not_acceptable.json.*` が必要ですが、PR #1887 では HTML 版しか追加していませんでした。テンプレートが見つからないと rambulance は `internal_server_error` にフォールバックするため、500 が返り続けていました。

既存の `bad_request` と `forbidden` はどちらも html と json の両方を持っています。同じ形に揃えました。

```
app/views/errors/
├── bad_request.html.erb
├── bad_request.json.jbuilder
├── forbidden.html.erb
├── forbidden.json.jbuilder
├── not_acceptable.html.erb
└── not_acceptable.json.jbuilder  ← 追加
```

## なぜ PR #1887 で気付けなかったか

`spec/requests/unknown_format_spec.rb` は test 環境で動きますが、test 環境は `consider_all_requests_local` が true で例外処理の経路が異なります。テンプレートが無くても 406 が返るため、**このテストでは検出できません**。

今回は production モードでサーバを起動して実測しました。

**修正前（本番）**

| パス | 結果 |
|---|---|
| /dojos/activity.json | 500 |
| /docs.json | 500 |
| /kata.json | 500 |
| /spaces.json | 500 |

**修正後（ローカルの production モード）**

| パス | 結果 |
|---|---|
| /dojos/activity.json | 406 |
| /docs.json | 406 |
| /kata.json | 406 |
| /spaces.json | 406 |
| /dojos/activity | 200 |
| /docs | 200 |

## マージ後に確認すること

- [ ] デプロイ完了を待つ（`gh run list --branch main --limit 1` が `completed`）
- [ ] 本番の 4 経路が 406 を返す
      `for u in /dojos/activity.json /docs.json /kata.json /spaces.json; do curl -s -o /dev/null -w "$u %{http_code}\n" "https://coderdojo.jp$u"; done`
- [ ] HTML 版が 200 のままであることを確認
- [ ] Airbrake に `UnknownFormat` の新規通知が来ないこと
