### PR TITLE
Update URL for Himeji dojo

### DIFF
--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -3413,7 +3413,7 @@
   created_at: '2026-05-13'
   name: 姫路
   prefecture_id: 28
-  url: https://x.com/CoderDojoHimeji
+  url: https://coderdojo.himeji.club/
   logo: "/img/dojos/himeji.webp"
   description: 姫路市で毎月開催
   tags:


### PR DESCRIPTION
サイトのURL変更しました。

また、地図(https://map.coderdojo.jp/) に表示されるアイコンが旧画像のようなので、修正いただけますでしょうか。
https://map.coderdojo.jp/images/dojos/himeji.webp