### PR TITLE
fix(podcasts): 対応していない形式のアクセスで 500 になるのを直す

### DIFF
--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -50,8 +50,9 @@ class PodcastsController < ApplicationController
     # formats を明示する。省略するとリクエストの形式を引き継ぐため、/podcasts/14.jpg
     # のようなアクセスで _youtube_embed.jpeg.* を探しに行き ActionView::MissingTemplate
     # (500) になる。この埋め込みは常に HTML なので形式は固定でよい。
-    # 形式が合わないだけのリクエストは、この後の暗黙の render が 406 を返す。
-    # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1888
+    # 形式が合わないだけのリクエストは、この後の暗黙の render が
+    # ActionController::UnknownFormat を投げ、Rails がそれを 406 にマップする。
+    # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1891
     embed = render_to_string(partial: 'podcasts/youtube_embed',
                              formats: [:html],
                              locals:  { youtube_id: youtube_id })

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -47,7 +47,14 @@ class PodcastsController < ApplicationController
 
     return content unless content.match?(Podcast::REGEX_YOUTUBE_ID)
     youtube_id = content.match(Podcast::REGEX_YOUTUBE_ID)[1]
-    embed = render_to_string(partial: 'podcasts/youtube_embed', locals: { youtube_id: youtube_id })
+    # formats を明示する。省略するとリクエストの形式を引き継ぐため、/podcasts/14.jpg
+    # のようなアクセスで _youtube_embed.jpeg.* を探しに行き ActionView::MissingTemplate
+    # (500) になる。この埋め込みは常に HTML なので形式は固定でよい。
+    # 形式が合わないだけのリクエストは、この後の暗黙の render が 406 を返す。
+    # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1888
+    embed = render_to_string(partial: 'podcasts/youtube_embed',
+                             formats: [:html],
+                             locals:  { youtube_id: youtube_id })
     content.gsub!(/<a[^>]+>\s*<img[^>]+Cover Photo[^>]*>\s*<\/a>/m, embed)
     return content unless content.match?(Podcast::REGEX_TIMESTAMP)
     content.gsub!(Podcast::REGEX_TIMESTAMP) do

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -18,6 +18,30 @@ RSpec.describe '対応していない形式でのリクエスト', type: :reques
     end
   end
 
+  # /podcasts/:id は show 内で render_to_string(partial:) を呼ぶ。
+  # render_to_string はリクエストの形式を引き継ぐため、.jpg でアクセスされると
+  # _youtube_embed.jpeg.* を探しに行き ActionView::MissingTemplate で 500 になる。
+  # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1888
+  describe '/podcasts/:id' do
+    # content は DB のカラムではなく public/podcasts/<id>.md を読む実装のため、
+    # YouTube 埋め込みを含む実ファイルがある id を使って再現する。
+    let!(:episode) { create(:podcast, id: 14) }
+
+# public/podcasts/<id>.png はカバー画像として実在し、静的ファイルとして
+# 配信される（本番でも 200 image/png）。ここでは扱わない。
+%w[.jpg .json].each do |ext|
+      it "#{ext} でのアクセスは 406 を返す（500 にしない）" do
+        get "/podcasts/14#{ext}"
+        expect(response).to have_http_status(:not_acceptable)
+      end
+    end
+
+    it 'HTML でのアクセスは従来どおり 200 を返す' do
+      get '/podcasts/14'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   it 'HTML でのアクセスは従来どおり 200 を返す' do
     get '/dojos/activity'
     expect(response).to have_http_status(:ok)

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe '対応していない形式でのリクエスト', type: :reques
     # YouTube 埋め込みを含む実ファイルがある id を使って再現する。
     let!(:episode) { create(:podcast, id: 14) }
 
-# public/podcasts/<id>.png はカバー画像として実在し、静的ファイルとして
-# 配信される（本番でも 200 image/png）。ここでは扱わない。
-%w[.jpg .json].each do |ext|
+    # public/podcasts/<id>.png はカバー画像として実在し、静的ファイルとして
+    # 配信される（本番でも 200 image/png）。ここでは扱わない。
+    %w[.jpg .json].each do |ext|
       it "#{ext} でのアクセスは 406 を返す（500 にしない）" do
         get "/podcasts/14#{ext}"
         expect(response).to have_http_status(:not_acceptable)

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe '対応していない形式でのリクエスト', type: :reques
     # YouTube 埋め込みを含む実ファイルがある id を使って再現する。
     let!(:episode) { create(:podcast, id: 14) }
 
+    # 14.md から YouTube 埋め込みが消えると render_to_string を通らなくなり、
+    # このテストは通ったまま回帰を検出しなくなる。前提を明示しておく。
+    it '前提: 14.md に YouTube 埋め込みが含まれる' do
+      expect(File.read(Rails.root.join('public/podcasts/14.md')))
+        .to match(Podcast::REGEX_YOUTUBE_ID)
+    end
+
     # public/podcasts/<id>.png はカバー画像として実在し、静的ファイルとして
     # 配信される（本番でも 200 image/png）。ここでは扱わない。
     %w[.jpg .json].each do |ext|


### PR DESCRIPTION
## 概要

Airbrake に届いた `ActionView::MissingTemplate` を直します。PR #1888 と同じ「対応していない形式でのアクセスが 500 になる」問題の別経路です。

```
Missing partial podcasts/_youtube_embed with {locale: [:ja], formats: [:jpeg], ...}
URL: https://coderdojo.jp/podcasts/14.jpg
WHERE: podcasts#show
```

## 原因

`render_to_string` は `formats` を省略すると**リクエストの形式を引き継ぎます**。`/podcasts/14.jpg` でアクセスされると `_youtube_embed.jpeg.*` を探しに行き、テンプレートが見つからず 500 になっていました。

この埋め込みは常に HTML なので、形式を明示すれば十分です。形式が合わないだけのリクエストは、この後の暗黙の render が 406 を返します。

## 本番の実測

| パス | 修正前 | 修正後（期待） |
|---|---|---|
| /podcasts/14.jpg | **500** | 406 |
| /podcasts/14.json | **500** | 406 |
| /podcasts/14.png | 200 image/png | 200 image/png（変更なし） |
| /podcasts/14 | 200 | 200 |

`.png` は `public/podcasts/14.png` がカバー画像として実在するため、静的ファイルとして配信されます。この経路には影響しません。

## TDD

`spec/requests/unknown_format_spec.rb` に追加しました。

**RED**（修正前）: 本番と同じ例外を再現

```
ActionView::MissingTemplate:
  Missing partial podcasts/_youtube_embed with {locale: [:ja], formats: [:json], ...}
```

**GREEN**（修正後）: `.jpg` `.json` が 406、HTML は 200

修正を戻すと 2 件失敗し、戻すと 0 件になることを確認しています。

`content` は DB のカラムではなく `public/podcasts/<id>.md` を読む実装のため、YouTube 埋め込みを含む実ファイルがある id 14 を使って再現しています。

## 確認したこと

- [x] `bundle exec rspec spec` → 290 examples, 0 failures
- [x] 修正を戻すとテストが落ちる（テストが本当に効いている）
- [x] `.png` のカバー画像配信に影響しないことを本番で確認

## マージ後に確認すること

- [ ] デプロイ完了を待つ（`gh run list --branch main --limit 1` が `completed`）
- [ ] `.jpg` と `.json` が 406 を返す
      `for u in /podcasts/14.jpg /podcasts/14.json; do curl -s -o /dev/null -w "$u %{http_code}\n" "https://coderdojo.jp$u"; done`
- [ ] カバー画像が従来どおり返る
      `curl -s -o /dev/null -w "%{http_code} %{content_type}\n" https://coderdojo.jp/podcasts/14.png`
- [ ] Airbrake に `MissingTemplate` の新規通知が来ないこと
