### PR TITLE
fix(mime): text/plain を :md の別名にしない

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -4,5 +4,5 @@
 # Mime::Type.register "text/richtext", :rtf
 
 # MarkdownファイルのMIMEタイプを設定
-Mime::Type.register 'text/markdown', :md, %w( text/plain )
+Mime::Type.register 'text/markdown', :md
 Rack::Mime::MIME_TYPES['.md'] = 'text/markdown; charset=utf-8'

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe '対応していない形式でのリクエスト', type: :reques
   # text/plain が :md の別名になり、Mime::Type.lookup('text/plain') が
   # :text ではなく :md を返す。その結果この保険が働かず、html と json 以外の
   # 形式（.jpg など）でのアクセスがすべて 500 になっていた。
+  # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1893
   describe 'エラーページ描画の保険' do
     it "text/plain は :text に解決される（:md の別名にしない）" do
       expect(Mime::Type.lookup('text/plain').symbol).to eq :text

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -53,4 +53,20 @@ RSpec.describe '対応していない形式でのリクエスト', type: :reques
     get '/dojos/activity'
     expect(response).to have_http_status(:ok)
   end
+
+  # rambulance はエラーページを描画できないときの保険として
+  # request.formats に text/plain を足す。ところが :md を
+  # `Mime::Type.register 'text/markdown', :md, %w( text/plain )` と登録すると
+  # text/plain が :md の別名になり、Mime::Type.lookup('text/plain') が
+  # :text ではなく :md を返す。その結果この保険が働かず、html と json 以外の
+  # 形式（.jpg など）でのアクセスがすべて 500 になっていた。
+  describe 'エラーページ描画の保険' do
+    it "text/plain は :text に解決される（:md の別名にしない）" do
+      expect(Mime::Type.lookup('text/plain').symbol).to eq :text
+    end
+
+    it ':md は text/markdown として使える' do
+      expect(Mime::Type.lookup('text/markdown').symbol).to eq :md
+    end
+  end
 end


### PR DESCRIPTION
## 概要

**html と json 以外の形式でのアクセスがすべて 500 になっていました。** 影響は podcasts に限りません。

[PR #1891](https://github.com/coderdojo-japan/coderdojo.jp/pull/1891) で `/podcasts/14.json` は 406 になりましたが、`.jpg` は 500 のままでした。調べたところ、より広い範囲の原因が別にありました。

## 真因

ローカルの production モードで再現し、ログから特定しました。

```
Processing by PodcastsController#show as JPEG
Completed 406 Not Acceptable
ActionController::UnknownFormat (...)
Processing by Rambulance::ExceptionsApp#not_acceptable as JPEG
Completed 500 Internal Server Error
Error during failsafe response:
  Missing template errors/internal_server_error with {locale: [:ja], formats: [:jpeg, :md], ...}
```

エラーページを描画する rambulance は、保険として `request.formats << Mime::Type.lookup('text/plain')` を実行します。ところが formats に入ったのは `:text` ではなく **`:md`** でした。

`config/initializers/mime_types.rb` の第 3 引数が原因です。

```ruby
Mime::Type.register 'text/markdown', :md, %w( text/plain )
                                          ^^^^^^^^^^^^^^^^ synonyms（別名）
```

これにより `text/plain` が `:md` の別名になり、`Mime::Type.lookup('text/plain')` が `:md` を返します。`errors/*.md.*` は存在しないので保険が働かず、フォールバック先の `internal_server_error` も見つからずに 500 になっていました。

## 修正

```diff
-Mime::Type.register 'text/markdown', :md, %w( text/plain )
+Mime::Type.register 'text/markdown', :md
 Rack::Mime::MIME_TYPES['.md'] = 'text/markdown; charset=utf-8'
```

この別名は [2025-05-16 のコミット](https://github.com/coderdojo-japan/coderdojo.jp/commit/3c3d6142b5e0d0d9981761c8d43fb2ba53c12623)（`/docs/*.md` の文字化け修正）で入りましたが、**文字化け対策を担っているのは `Rack::Mime::MIME_TYPES` の行**です。raw の `.md` は `public/docs/` から `ActionDispatch::Static` 経由で配信され、Content-Type はそちらで決まります。別名は静的配信に関与しません。

アプリ内に別名へ依存する箇所はありません（`format.md` を使う `respond_to`、`*.md.erb` テンプレート、`Mime::Type.lookup('text/plain')` の呼び出しはいずれも無し）。

## 実測（ローカルの production モード）

| パス | 修正前 | 修正後 |
|---|---|---|
| /podcasts/14.jpg | **500** | **406** |
| /podcasts/14.json | 406 | 406 |
| /podcasts/14 | 200 text/html | 200 text/html |
| /docs/private-dojo.md | 200 text/markdown; charset=utf-8 | 同左（日本語も正常） |
| /podcasts/14.png | 200 image/png | 200 image/png |
| /dojos.json /events.json /stats.json | 200 | 200 |
| /podcasts.rss | 200 application/rss+xml | 200 application/rss+xml |
| /docs /kata | 200 text/html | 200 text/html |

`errors/not_acceptable.text.erb` を足す案も試しましたが**不要**でした。lookup が `:md` を返す以上そもそも届かず、別名を外せば Rails が既定の本文を返します。

## テストについて

**test 環境ではこの不具合を再現できません。** `consider_all_requests_local` が true で `exceptions_app` を通らないためです。そこで MIME の解決そのものを検査しています。

```ruby
expect(Mime::Type.lookup('text/plain').symbol).to eq :text
expect(Mime::Type.lookup('text/markdown').symbol).to eq :md
```

修正を戻すと前者が `:md` になって落ちることを確認済みです。`bundle exec rspec spec` は 293 examples / 0 failures。

## 反省

PR #1891 で「`.jpg` も 406 になる」とテストで確認しましたが、**test 環境でしか確かめていませんでした**。[PR #1888](https://github.com/coderdojo-japan/coderdojo.jp/pull/1888) で同じ落とし穴を踏んだ直後に繰り返しています。今回は production モードでサーバを起動し、再現してから直しました。

## マージ後に確認すること

- [ ] デプロイ完了を待つ（`gh run list --branch main --limit 1` が `completed`）
- [ ] `.jpg` が 406 を返す
      `curl -s -o /dev/null -w "%{http_code}\n" https://coderdojo.jp/podcasts/14.jpg`
- [ ] `.md` の配信が壊れていない
      `curl -s -o /dev/null -w "%{http_code} %{content_type}\n" https://coderdojo.jp/docs/private-dojo.md`
- [ ] JSON API・RSS・画像配信が従来どおり
- [ ] Airbrake に `MissingTemplate` の新規通知が来ないこと
