### PR TITLE
fix(upcoming_events): 500 をリトライし、失敗を握り潰さない

### DIFF
--- a/lib/event_service/providers/doorkeeper.rb
+++ b/lib/event_service/providers/doorkeeper.rb
@@ -49,8 +49,15 @@ module EventService
             raise e
           end
         rescue Faraday::ServerError => e
-          # 502, 503, 504: Server errors
-          if [502, 503, 504].include?(e.response[:status]) && retry_count < 2
+          # 500, 502, 503, 504: Server errors
+          #
+          # 500 も対象にする。2026/08 に Doorkeeper が特定のグループへ 500 を返し、
+          # リトライされずに収集全体が停止した。その後 API は 200 を返しており、
+          # 一過性の障害だった。
+          #
+          # Faraday::ServerError は 5xx すべてを捕まえるが、再試行するのは
+          # 一過性でありうる主要な 4 つに絞る。501 などは再試行しても直らない。
+          if [500, 502, 503, 504].include?(e.response[:status]) && retry_count < 2
             wait_time = 2 ** retry_count * 5  # Exponential backoff: 5, 10 seconds
             puts "Server error (#{e.response[:status]}) for group_id: #{group_id}."
             puts "Retrying in #{wait_time} seconds... (attempt #{retry_count + 1}/2)"

--- a/lib/upcoming_events/aggregation.rb
+++ b/lib/upcoming_events/aggregation.rb
@@ -43,7 +43,17 @@ module UpcomingEvents
       yield
       Notifier.notify_success(@provider)
     rescue => e
-      Notifier.notify_failure(@provider, e)
+      # 通知したうえで再送出し、ジョブを失敗させる。握り潰すと、イベント情報が
+      # 古いまま正常終了したように見え、異常に気づけない。統計集計と同じ方針。
+      # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1881
+      #
+      # Slack への通知自体が失敗しても、元の例外を失わないようにする。
+      begin
+        Notifier.notify_failure(@provider, e)
+      rescue => notification_error
+        $stdout.puts "Failed to notify: #{notification_error.class}: #{notification_error.message}"
+      end
+      raise e
     end
 
     def delete_upcoming_events

--- a/spec/lib/upcoming_events/resilience_spec.rb
+++ b/spec/lib/upcoming_events/resilience_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+require 'upcoming_events'
+require 'event_service'
+
+# 近日開催イベントの収集が、外部 API の一時的な不調で全体停止しないことを守るテスト。
+#
+# == 不具合の経緯（2026/08）==
+# Doorkeeper API が 1 つのグループに対して 500 を返し、夜間の収集が止まった。
+#
+#   the server responded with status 500 for
+#   GET https://api.doorkeeper.jp/groups/11839/events?...
+#
+# 影響は 1 道場にとどまらなかった。Doorkeeper 連携の 53 道場のうち、失敗した
+# 道場は 4 番目に処理されており、それ以降の 50 道場のイベント情報が更新され
+# なかった。API は後に 200 を返しており、一過性の障害だった。
+#
+# == 2 つの欠陥 ==
+#   A. リトライ対象が 502/503/504 のみで、500 が含まれていなかった。
+#      A を直せば、今回のような一過性の障害は収集を止めずに済む。
+#   C. 例外を握り潰していたため、ジョブは成功扱いで終わり異常に気づけなかった。
+#      通知が届かなければ気づく手段がない状態だった。
+#
+# 「1 道場の失敗で以降の道場を巻き込まない」という改修も検討したが、A で
+# 一過性の障害を吸収できるため、恒久的な失敗が実際に起きるまでは見送る。
+RSpec.describe '近日開催イベント収集の耐障害性' do
+  # A. 一過性のサーバエラーはリトライする
+  describe EventService::Providers::Doorkeeper do
+    let(:responses) { [] }
+
+    let(:stub_connection) do
+      queue = responses.dup
+      Faraday.new do |f|
+        f.response :json, content_type: /\bjson$/
+        f.response :raise_error, include_request: true
+        f.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.get(%r{/groups/\d+/events}) { queue.shift }
+        end
+      end
+    end
+
+    before do
+      allow(EventService::Client).to receive(:new).and_return(
+        EventService::Client.allocate.tap { |c| c.instance_variable_set(:@conn, stub_connection) }
+      )
+      # リトライの待機で時間を使わない
+      allow_any_instance_of(described_class).to receive(:sleep)
+    end
+
+    let(:success) { [200, { 'Content-Type' => 'application/json' }, [].to_json] }
+
+    [500, 502, 503, 504].each do |status|
+      context "#{status} が返ったとき" do
+        let(:responses) { [[status, {}, ''], success] }
+
+        it 'リトライして回復する' do
+          expect { described_class.new.fetch_events(group_id: 5555) }.not_to raise_error
+        end
+      end
+    end
+
+    context 'リトライしても回復しないとき' do
+      let(:responses) { [[500, {}, ''], [500, {}, ''], [500, {}, '']] }
+
+      it '例外を送出する' do
+        expect { described_class.new.fetch_events(group_id: 5555) }.to raise_error(Faraday::ServerError)
+      end
+    end
+  end
+
+  # C. 収集に失敗したらジョブも失敗させる
+  describe UpcomingEvents::Aggregation do
+    include_context 'Use stubs UpcomingEvents for Connpass'
+    include_context 'Use stubs UpcomingEvents for Doorkeeper'
+
+    before do
+      dojo = create(:dojo, name: 'Dojo', prefecture_id: 13)
+      create(:dojo_event_service, dojo_id: dojo.id, name: :doorkeeper, group_id: 5555)
+    end
+
+    it '収集に失敗したら例外を送出する（ジョブを失敗させる）' do
+      allow_any_instance_of(UpcomingEvents::Tasks::Doorkeeper)
+        .to receive(:run).and_raise(StandardError, 'boom')
+
+      expect { described_class.new(provider: 'doorkeeper').run }.to raise_error(StandardError, /boom/)
+    end
+
+    # rake タスクは全体を UpcomingEvent.transaction で囲んでいる。例外を握り潰すと
+    # コミットされてしまい、「古いイベントは削除済み・新しいものは未取得」という
+    # 中途半端な状態が残る。再送出すればロールバックされる。
+    it '失敗時はロールバックされ、削除済みの古いイベントも巻き戻る' do
+      service = DojoEventService.find_by(group_id: '5555')
+      create(:upcoming_event, dojo_event_service_id: service.id, service_name: 'doorkeeper',
+                              event_id: 'old', event_title: '過去のイベント',
+                              event_at:     "#{Time.zone.today - 2.months} 10:00:00".in_time_zone,
+                              event_end_at: "#{Time.zone.today - 2.months} 12:00:00".in_time_zone)
+
+      allow_any_instance_of(UpcomingEvents::Tasks::Doorkeeper)
+        .to receive(:run).and_raise(StandardError, 'boom')
+
+      expect {
+        begin
+          UpcomingEvent.transaction { described_class.new(provider: 'doorkeeper').run }
+        rescue StandardError
+          # rake タスクと同じく、例外はトランザクションの外へ抜ける
+        end
+      }.not_to change { UpcomingEvent.count }
+    end
+
+    it '失敗しても通知は行う' do
+      allow_any_instance_of(UpcomingEvents::Tasks::Doorkeeper)
+        .to receive(:run).and_raise(StandardError, 'boom')
+
+      expect(UpcomingEvents::Aggregation::Notifier).to receive(:notify_failure)
+      expect { described_class.new(provider: 'doorkeeper').run }.to raise_error(StandardError)
+    end
+  end
+end


### PR DESCRIPTION
## 何が起きたか

夜間の `upcoming_events:aggregation` が Doorkeeper API の 500 で停止しました。

```
the server responded with status 500 for
GET https://api.doorkeeper.jp/groups/11839/events?page=1&since=...&until=...
```

該当は **CoderDojo 富谷**。API は現在 200 を返すので**一過性の障害**でした。

**影響は 1 道場にとどまりません。**

| 項目 | 値 |
|---|---|
| Doorkeeper 連携の道場 | 53 件 |
| 富谷の処理順 | **4 件目** |
| 更新されなかった道場 | **50 件** |
| connpass 側 | 先に処理されるため影響なし |

## 2 つの欠陥

### A. リトライ対象に 500 が入っていなかった

```ruby
if [502, 503, 504].include?(e.response[:status]) && retry_count < 2
```

502/503/504 はリトライしますが、**500 は素通りして送出**していました。今回の障害はリトライすれば回復していたはずです。

`Faraday::ServerError` は 5xx すべてを捕まえますが、再試行するのは一過性でありうる 4 つに絞ります。501 のように再試行しても直らないものは従来どおり即座に送出します。

### B. 例外を握り潰していた

```ruby
rescue => e
  Notifier.notify_failure(@provider, e)   # ← raise がない
```

Heroku 上では**ジョブが成功扱いで終わり**、イベント情報が古いままでも異常として検知できませんでした。気づける手段が Slack 通知ひとつしかない状態です。統計集計は [PR #1881](https://github.com/coderdojo-japan/coderdojo.jp/pull/1881) で同じ修正を入れています。

## 想定外の効果: 中途半端な状態も解消されます

rake タスクは全体をトランザクションで囲んでいます。

```ruby
UpcomingEvent.transaction do
  UpcomingEvents::Aggregation.new(args).run
end
```

例外を握り潰すと**ブロックの外に出ないためコミットされ**、「古いイベントは削除済み・新しいものは未取得」という状態が残っていました。再送出すればロールバックされます。

| | 例外 | トランザクション |
|---|---|---|
| 修正前 | 握り潰す | **コミット**（中途半端な状態が残る） |
| 修正後 | 再送出 | **ロールバック** |

## 見送ったこと

**「1 道場の失敗で以降の道場を巻き込まない」隔離**も実装しましたが、見送りました。500 のリトライで一過性の障害は吸収できるため、この改修が効くのは「リトライしても直らない恒久的な失敗」（グループ削除等）だけです。その事例が実際に起きた履歴は確認できていないので、起きてから入れます。

**connpass 側には 5xx のリトライがありません**（429 のみ）。provider 未指定の夜間実行では connpass が先に走るため、そちらの 500 なら依然として全体が止まります。同じ理由で今回は触りません。失敗すれば通知とジョブ失敗で気づけます。

**サーキットブレーカー**も検討しましたが撤回しました。1 日 1 回・バックオフ付きの実行で、全面障害時でも十数分に収まるためです。

## テスト

`spec/lib/upcoming_events/resilience_spec.rb` を新設しました。Faraday のテストアダプタを使い、`sleep` はスタブして待ちません。

- 500 / 502 / 503 / 504 それぞれでリトライして回復する
- リトライ上限を超えたら送出する
- 収集失敗時に例外を送出する（ジョブを失敗させる）
- **失敗時にロールバックされ、削除済みの古いイベントも巻き戻る**
- 失敗しても通知は行う

修正を戻すと 3 件が失敗し、戻すと 0 件になることを確認しています。`bundle exec rspec spec` は 301 examples / 0 failures です。

## 運用メモ

同じグループの失敗通知が連日続く場合は、恒久的な障害なので道場ごとの隔離（見送った改修）を検討してください。

## マージ後に確認すること

- [ ] デプロイ完了を待つ（`gh run list --branch main --limit 1` が `completed`）
- [ ] 翌朝 6:00 JST の定期実行が成功する
- [ ] `/events` にイベントが掲載されている
      `curl -s https://coderdojo.jp/events.json | ruby -rjson -e 'puts JSON.parse(STDIN.read).size'`
- [ ] 失敗した場合、Slack 通知に加えて Heroku 上でもジョブが失敗として現れる
