### PR TITLE
test(errors): エラーページを本番と同じ経路で検証する

### DIFF
--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -5,6 +5,11 @@ require 'rails_helper'
 # 形式が合わないだけなのでサーバエラーではなく 406 を返す。
 # cf. https://github.com/coderdojo-japan/coderdojo.jp/pull/1887
 RSpec.describe '対応していない形式でのリクエスト', type: :request do
+  # test 環境は consider_all_requests_local が true で exceptions_app を通らない。
+  # そのままだとエラーページの描画不備を検出できず、本番だけ 500 になる。
+  # 実際 PR #1888 / #1891 / #1893 の 3 件を、この spec は通したまま見逃した。
+  include Rambulance::TestHelper
+
   # respond_to を持たない（HTML 専用の）アクション
   %w[
     /dojos/activity.json
@@ -13,7 +18,7 @@ RSpec.describe '対応していない形式でのリクエスト', type: :reques
     /spaces.json
   ].each do |path|
     it "#{path} は 406 を返す（500 にしない）" do
-      get path
+      with_exceptions_app { get path }
       expect(response).to have_http_status(:not_acceptable)
     end
   end
@@ -38,19 +43,19 @@ RSpec.describe '対応していない形式でのリクエスト', type: :reques
     # 配信される（本番でも 200 image/png）。ここでは扱わない。
     %w[.jpg .json].each do |ext|
       it "#{ext} でのアクセスは 406 を返す（500 にしない）" do
-        get "/podcasts/14#{ext}"
+        with_exceptions_app { get "/podcasts/14#{ext}" }
         expect(response).to have_http_status(:not_acceptable)
       end
     end
 
     it 'HTML でのアクセスは従来どおり 200 を返す' do
-      get '/podcasts/14'
+      with_exceptions_app { get '/podcasts/14' }
       expect(response).to have_http_status(:ok)
     end
   end
 
   it 'HTML でのアクセスは従来どおり 200 を返す' do
-    get '/dojos/activity'
+    with_exceptions_app { get '/dojos/activity' }
     expect(response).to have_http_status(:ok)
   end
 


### PR DESCRIPTION
## 背景

このセッションで**同じ落とし穴に 3 回続けて落ちました**。いずれも **test 環境では通るのに本番で 500** です。

| PR | 内容 |
|---|---|
| #1888 | `errors/not_acceptable` の JSON テンプレートが無かった |
| #1891 | `render_to_string` がリクエスト形式を引き継ぎ `.jpg` で 500 |
| #1893 | `text/plain` が `:md` の別名になり、rambulance のフォールバックが働かなかった |

原因は `consider_all_requests_local` が true のため **`exceptions_app`（rambulance）を通らない**ことです。エラーページの描画不備を、テストが構造的に検出できませんでした。

**特に #1891 では、この spec が緑になったことを根拠に「直った」と報告し、本番では 500 のままでした。** #1888 で同じ穴に落ちた直後の再発です。

## 対処

rambulance が提供する `with_exceptions_app` で各リクエストを包みます。

```ruby
include Rambulance::TestHelper

it "#{path} は 406 を返す（500 にしない）" do
  with_exceptions_app { get path }
  expect(response).to have_http_status(:not_acceptable)
end
```

このヘルパーは `show_exceptions` と **`show_detailed_exceptions` の両方**を切り替え、`ensure` で復元します。後者を倒さないと `DebugExceptions` がデバッグページを描画して `exceptions_app` に到達しないため、**片方だけでは不十分**です。自前で `env_config` を書き換えると復元漏れで後続の spec 全体を壊す危険がありますが、既存ヘルパーならその心配がありません。

`spec/requests/errors_spec.rb` が既にこのヘルパーを使っており、**新しい仕組みは何も足していません**。

## 検出できることの確認

過去の不具合を実際に戻して検証しました。

| 戻した状態 | 結果 |
|---|---|
| MIME 別名あり・JSON テンプレートなし（#1888 当時） | **7 件が失敗** |
| MIME 別名あり（#1893 当時） | **2 件が失敗**（`.jpg` が 500） |
| 現在（すべて修正済み） | 11 examples, 0 failures |

失敗の内容も本番と同じ `expected 406 but it was 500` です。

## 影響範囲

- 変更は **9 行**、この spec 内に閉じています
- **全 request spec に適用していません。** 全体で `exceptions_app` を通すと、通常のテストの本物の失敗が 500 レスポンスに化けてバックトレースが消えます
- `bundle exec rspec spec` は 301 examples / 0 failures

## 残る環境差

`exceptions_app` の経路はこれで塞げますが、本番との差は他にも残ります。

- **eager loading**（本番のみ起動時に全ロード）
- **アセットの precompile**（未 precompile の参照は本番だけ 500）

これらまで CI で網羅するには `RAILS_ENV=production` でのブート確認が要りますが、今回踏んだ 3 件はすべて `exceptions_app` 経路なので、まずはここだけで十分と判断しました。
