### PR TITLE
fix(airbrake): 対応していない形式でのアクセスを通知しない

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -87,6 +87,17 @@ if (project_id =  ENV['AIRBRAKE_PROJECT_ID']) &&
     end
   end
 
+  # NOTE: 対応していない形式でのアクセスは、アプリの異常ではなくクライアント側の
+  # 誤りなので通知しない。406 を返すのが正しい挙動であり、通知すると本物のエラーが
+  # 埋もれる。実例は PHP の脆弱性スキャンによる /news.php へのアクセス。
+  #
+  # 同じ理由で無視してよい 4xx の例外は他にもあるが（RoutingError,
+  # InvalidAuthenticityToken など）、まとめて無視すると本当に知りたい事象まで
+  # 落としかねない。実際に通知が来たものから 1 つずつ足す。
+  Airbrake.add_filter do |notice|
+    notice.ignore! if notice.stash[:exception].is_a?(ActionController::UnknownFormat)
+  end
+
   # If you want to convert your log messages to Airbrake errors, we offer an
   # integration with the Logger class from stdlib.
   # https://github.com/airbrake/airbrake#logger

--- a/spec/airbrake_filter_spec.rb
+++ b/spec/airbrake_filter_spec.rb
@@ -63,3 +63,38 @@ RSpec.describe 'Airbrake の SIGTERM フィルタ' do
     expect(source).to match(/ENV\['DYNO'\]/)
   end
 end
+
+# クライアントが対応していない形式を要求しただけのアクセスは、アプリの異常ではない。
+# 406 を返すのが正しい挙動なので、Airbrake へ通知せず本物のエラーを埋もれさせない。
+#
+# 実例: PHP の脆弱性スキャンが https://coderdojo.jp/news.php を叩き、
+# news#index の respond_to が ActionController::UnknownFormat を送出した。
+RSpec.describe 'Airbrake の UnknownFormat フィルタ' do
+  let(:filter) do
+    lambda do |notice|
+      notice.ignore! if notice.stash[:exception].is_a?(ActionController::UnknownFormat)
+    end
+  end
+
+  def build_notice(exception)
+    Airbrake::Notice.new(exception)
+  end
+
+  it 'UnknownFormat は通知しない' do
+    notice = build_notice(ActionController::UnknownFormat.new)
+    filter.call(notice)
+    expect(notice).to be_ignored
+  end
+
+  it 'ふつうの例外は通知する' do
+    notice = build_notice(RuntimeError.new('何かがおかしい'))
+    filter.call(notice)
+    expect(notice).not_to be_ignored
+  end
+
+  # 上のテストは書き方を確かめるだけで、initializer がそう書いているかは見ていない。
+  it 'initializer が UnknownFormat を無視している' do
+    source = Rails.root.join('config/initializers/airbrake.rb').read
+    expect(source).to match(/ActionController::UnknownFormat/)
+  end
+end


### PR DESCRIPTION
## 何が起きたか

`/news.php` へのアクセスで、Airbrake に通知が飛びました。

```
ActionController::UnknownFormat
WHERE: news#index
URL: https://coderdojo.jp/news.php
```

## アプリの動作は正しい

`/news.php` は **406 を返しています**。`news#index` の `respond_to` が html と json のみを受け付ける以上、これが正しい挙動です。**修正すべきはアプリではなく通知です。**

| パス | 応答 |
|---|---|
| /news.php | 406 |
| /news | 200 text/html |
| /news.json | 200 application/json |

## 対処

`ActionController::UnknownFormat` を Airbrake の通知対象から外します。通知したままだと**本物のエラーが埋もれます**。

## 影響範囲について

同じ理由（クライアント起因の 4xx がアプリのエラーとして通知される）で無視してよい例外は、他に 18 種類あります。

```
400 BadRequest / ParameterMissing / ParseError ...
404 RoutingError / RecordNotFound ...
406 MissingExactTemplate / InvalidType
422 InvalidAuthenticityToken / RecordInvalid ...
```

`status_code_for_exception` で一括除外することも可能ですが、**まとめて無視すると本当に知りたい事象まで落としかねません**（例: `RecordNotFound` の急増はリンク切れの兆候）。実際に通知が来たものから 1 つずつ足す方針にしています。

## アクセス元について

**このアクセスが何だったかは特定できていません。** 分かっているのは URL だけで、User-Agent・IP・頻度は通知に含まれていませんでした。

調べた範囲では、`news.php` はこのリポジトリの履歴に存在せず、参照もありません。`rack-attack` が `wp-login` を `fail2ban pentesters` としてブロックしているので、この種のアクセス自体は届いていますが、**この 1 件がそれに該当するかは確認できていません。**

修正の妥当性は原因に依存しないため、このまま進めます。

## テスト

`spec/airbrake_filter_spec.rb` に 3 件追加しました。既存の SIGTERM フィルタと同じ形式です。

- `UnknownFormat` は通知しない
- ふつうの例外は通知する
- **initializer が実際にそう書いているか**を検査する（書き方のテストだけでは、initializer が壊れても気付けないため）

修正を戻すと 1 件失敗し、戻すと 0 件になることを確認しています。

- [x] `bundle exec rspec spec` → 304 examples, 0 failures
- [x] production モードで `/news.php` が 406、`/news` と `/news.json` が 200 のままであることを確認

## マージ後に確認すること

- [ ] デプロイ完了を待つ（`gh run list --branch main --limit 1` が `completed`）
- [ ] `/news.php` が 406 のままであること
- [ ] `/news` と `/news.json` が 200 であること
- [ ] Airbrake に `UnknownFormat` の新規通知が来ないこと
