### PR TITLE
fix(security): .php への探索をルーティング前で遮断する

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,8 +1,23 @@
 Rails.application.config.middleware.use Rack::Attack
 
+# 攻撃的な探索を、ルーティングより前で遮断する。
+#
+# 2026/08/29 に本番ログで .php へのアクセスを 94 件観測した（2 つの IP に集中）。
+# 認証情報や設定ファイルの探索、Web シェル設置の試行が含まれていた。
+#
+#   /aws_sdk_settings.php    /application.config.php   /php_info.php
+#   /wp-admin/sc.php         /a1vx.php /lmfi2.php /koiy.php
+#
+# wp-login だけを見ていたため /wp-admin/sc.php はすり抜けていた。
+# このアプリに .php は 1 つも無い（routes・public とも 0 件）ので、
+# .php へのアクセスに正当なものは存在しない。
+#
+# 遮断がルーティングより前で効くため、コントローラに届かず Airbrake への
+# 通知も止まる。通知側でフィルタする必要はない。
 Rack::Attack.blocklist('fail2ban pentesters') do |req|
   Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", :maxretry => 1, :findtime => 1.hour, :bantime => 24.hours) do
     req.path.include?('wp-login') ||
-      req.params.values.include?('wp-login')
+      req.params.values.include?('wp-login') ||
+      req.path.end_with?('.php')
   end
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+# 攻撃的な探索を、コントローラに届く前に遮断する。
+#
+# == 経緯（2026/08/29）==
+# Airbrake に ActionController::UnknownFormat（/news.php）の通知が来た。
+# 本番ログを見ると .php へのアクセスが 94 件、2 つの IP に集中していた。
+#
+#   /aws_sdk_settings.php    認証情報の探索
+#   /application.config.php  設定ファイルの探索
+#   /php_info.php            環境情報の露出確認
+#   /wp-admin/sc.php         Web シェル設置の試行
+#   /a1vx.php /lmfi2.php     既知の Web シェルのファイル名
+#
+# 既存の遮断は wp-login だけを見ており、/wp-admin/sc.php はすり抜けていた。
+# このアプリに .php は 1 つも無いため（routes・public とも 0 件）、
+# .php へのアクセスに正当なものは存在しない。
+#
+# 遮断はルーティングより前で効くので、通知も自然に止まる。
+RSpec.describe 'Rack::Attack', type: :request do
+  before do
+    Rack::Attack.enabled = true
+    Rack::Attack.reset!
+  end
+
+  after do
+    Rack::Attack.enabled = false
+    Rack::Attack.reset!
+  end
+
+  describe '.php へのアクセス' do
+    # 実際に本番ログで観測されたパス
+    %w[
+      /news.php
+      /aws_sdk_settings.php
+      /application.config.php
+      /php_info.php
+      /wp-admin/sc.php
+      /a1vx.php
+      //koiy.php
+    ].each do |path|
+      it "#{path} を遮断する" do
+        get path, env: { 'REMOTE_ADDR' => '203.0.113.1' }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe '通常のアクセス' do
+    %w[/ /dojos /events /news /news.json].each do |path|
+      it "#{path} は遮断しない" do
+        get path, env: { 'REMOTE_ADDR' => '203.0.113.2' }
+        expect(response).not_to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  # 既存の遮断（wp-login）が壊れていないこと
+  it 'wp-login を遮断する' do
+    get '/wp-login', env: { 'REMOTE_ADDR' => '203.0.113.3' }
+    expect(response).to have_http_status(:forbidden)
+  end
+end


### PR DESCRIPTION
## 経緯

Airbrake に `ActionController::UnknownFormat`（`/news.php`）の通知が来ました。**当初は「ノイズなので通知を止める」と判断しましたが、これは誤りでした。**

本番ログを確認したところ、事実は次のとおりでした。

```
$ heroku logs -n 1500 | grep '\.php'
.php へのアクセス: 94 件
送信元: 52.139.37.240 (70 件), 4.205.62.107 (23 件), その他 (1 件)
```

叩かれていたパスの内訳です。

| パス | 狙い |
|---|---|
| `/aws_sdk_settings.php` | 認証情報の探索 |
| `/application.config.php` | 設定ファイルの探索 |
| `/php_info.php` | 環境情報の露出確認 |
| `/wp-admin/sc.php` | Web シェル設置の試行 |
| `/a1vx.php` `/lmfi2.php` `/koiy.php` `/333.php` | 既知の Web シェルのファイル名 |

`/news.php` もこの 94 件に含まれていました（`UnknownFormat` の 2 件は両方これ）。

## 既存の遮断はすり抜けられていた

```ruby
req.path.include?('wp-login') || req.params.values.include?('wp-login')
```

**`/wp-admin/sc.php` は `wp-login` を含まないため、遮断されていませんでした。**

## 対処

`.php` へのアクセスを遮断対象に加えます。このアプリに `.php` は 1 つもありません（`routes.rb` に 0 件、`public/` に 0 件）。**正当な `.php` アクセスは存在しません。**

```diff
     req.path.include?('wp-login') ||
-      req.params.values.include?('wp-login')
+      req.params.values.include?('wp-login') ||
+      req.path.end_with?('.php')
```

## 通知側のフィルタは不要になります

当初 Airbrake 側で `UnknownFormat` を無視する案（PR #1897）を出しましたが、**取り下げます**。

- `Rack::Attack` は**ルーティングより前**で動くため、遮断すればコントローラに届かず、例外も通知も発生しません
- ログで確認したところ、`UnknownFormat` は **2 件とも `/news.php`** でした。他の経路では起きていません
- 通知を止める案は**検知手段を消す方向**でした。`rack-attack` が `wp-login` しか見ていない以上、Airbrake の通知が実質的に唯一の検知手段だったためです

## テスト

`spec/requests/rack_attack_spec.rb` を新設しました（既存のテストはありませんでした）。

- **本番ログで実際に観測されたパス 7 件**を遮断する
- 通常のアクセス（`/` `/dojos` `/events` `/news` `/news.json`）は遮断しない
- 既存の `wp-login` の遮断が壊れていない

`.php` の遮断を外すと 7 件失敗し、戻すと 0 件になることを確認しています。

- [x] `bundle exec rspec spec` → 314 examples, 0 failures

## 実害について

観測された 94 件はすべて 404 または 406 を返しており、このアプリに PHP 処理系は存在しません。**ただし確認したのは直近ログ 1500 行の範囲のみで、それ以前は保持期間外のため未確認です。** 全期間にわたる安全性を主張するものではありません。

## マージ後に確認すること

- [ ] デプロイ完了を待つ（`gh run list --branch main --limit 1` が `completed`）
- [ ] `.php` が 403 を返す
      `curl -s -o /dev/null -w "%{http_code}\n" https://coderdojo.jp/news.php`
- [ ] 通常のページが従来どおり
      `for u in / /dojos /events /news /news.json; do curl -s -o /dev/null -w "$u %{http_code}\n" "https://coderdojo.jp$u"; done`
- [ ] Airbrake に `UnknownFormat` の新規通知が来ないこと
