### PR TITLE
fix(security): .php の遮断で IP ごと締め出さないようにする

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,14 @@
 Rails.application.config.middleware.use Rack::Attack
 
-# 攻撃的な探索を、ルーティングより前で遮断する。
+# wp-login への攻撃は意図が明確なので、その IP を 24 時間締め出す。
+Rack::Attack.blocklist('fail2ban pentesters') do |req|
+  Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", :maxretry => 1, :findtime => 1.hour, :bantime => 24.hours) do
+    req.path.include?('wp-login') ||
+      req.params.values.include?('wp-login')
+  end
+end
+
+# .php への探索を、ルーティングより前で遮断する。
 #
 # 2026/08/29 に本番ログで .php へのアクセスを 94 件観測した（2 つの IP に集中）。
 # 認証情報や設定ファイルの探索、Web シェル設置の試行が含まれていた。
@@ -12,12 +20,13 @@ Rails.application.config.middleware.use Rack::Attack
 # このアプリに .php は 1 つも無い（routes・public とも 0 件）ので、
 # .php へのアクセスに正当なものは存在しない。
 #
+# ただし上の Fail2Ban には含めない。1 度踏んだだけで IP ごと 24 時間締め出す
+# ため、古いリンクやブックマークで .php を踏んだ利用者まで、サイト全体から
+# 締め出してしまう。wp-login と違い .php は誤って踏む範囲が広い。
+# 該当のリクエストだけを拒否し、その利用者の他のアクセスは通す。
+#
 # 遮断がルーティングより前で効くため、コントローラに届かず Airbrake への
-# 通知も止まる。通知側でフィルタする必要はない。
-Rack::Attack.blocklist('fail2ban pentesters') do |req|
-  Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", :maxretry => 1, :findtime => 1.hour, :bantime => 24.hours) do
-    req.path.include?('wp-login') ||
-      req.params.values.include?('wp-login') ||
-      req.path.end_with?('.php')
-  end
+# 通知も発生しない。
+Rack::Attack.blocklist('php probes') do |req|
+  req.path.end_with?('.php')
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -18,7 +18,11 @@ require 'rails_helper'
 #
 # 遮断はルーティングより前で効くので、通知も自然に止まる。
 RSpec.describe 'Rack::Attack', type: :request do
+  # test 環境のキャッシュは null_store で、Fail2Ban の BAN が保存されない。
+  # 本番は memory_store なので、そのままでは本番と違う経路を検証してしまう。
   before do
+    @original_store = Rack::Attack.cache.store
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     Rack::Attack.enabled = true
     Rack::Attack.reset!
   end
@@ -26,6 +30,7 @@ RSpec.describe 'Rack::Attack', type: :request do
   after do
     Rack::Attack.enabled = false
     Rack::Attack.reset!
+    Rack::Attack.cache.store = @original_store
   end
 
   describe '.php へのアクセス' do
@@ -59,5 +64,35 @@ RSpec.describe 'Rack::Attack', type: :request do
   it 'wp-login を遮断する' do
     get '/wp-login', env: { 'REMOTE_ADDR' => '203.0.113.3' }
     expect(response).to have_http_status(:forbidden)
+  end
+
+  # .php を Fail2Ban に含めると、1 回踏んだだけで IP ごと 24 時間締め出される。
+  # 攻撃者には妥当だが、古いリンクやブックマークで .php を踏んだ利用者まで
+  # サイト全体から締め出してしまう。wp-login と違い .php は誤って踏む範囲が広い。
+  #
+  # 実際、この挙動で開発者自身の IP が本番から締め出された（2026/08/29）。
+  describe '.php を踏んでも他のアクセスは遮断しない' do
+    let(:ip) { '203.0.113.10' }
+
+    it '.php を繰り返しても通常のページを見られる' do
+      3.times { get '/news.php', env: { 'REMOTE_ADDR' => ip } }
+      expect(response).to have_http_status(:forbidden)
+
+      get '/', env: { 'REMOTE_ADDR' => ip }
+      expect(response).not_to have_http_status(:forbidden)
+    end
+  end
+
+  # wp-login は攻撃の意図が明確なので、これまでどおり IP を BAN する
+  describe 'wp-login を踏んだ IP は締め出す' do
+    let(:ip) { '203.0.113.11' }
+
+    # maxretry: 1 は「2 回目で BAN」を意味する（1 回目でカウントが 1 になる）
+    it 'wp-login を繰り返すと通常のページも遮断される' do
+      2.times { get '/wp-login', env: { 'REMOTE_ADDR' => ip } }
+
+      get '/', env: { 'REMOTE_ADDR' => ip }
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 end


### PR DESCRIPTION
## 何が起きたか

[PR #1898](https://github.com/coderdojo-japan/coderdojo.jp/pull/1898) で `.php` を `Fail2Ban` の対象に加えましたが、**1 度踏んだだけでその IP がサイト全体から 24 時間締め出される**状態になっていました。

本番で動作確認した際に、**開発者自身の IP が締め出されました**。

```
$ curl -o /dev/null -w "%{http_code}" https://coderdojo.jp/
403
```

## なぜ問題か

古いリンクやブックマークで `.php` を踏んだ利用者も、同じようにサイト全体から締め出されます。`wp-login` は誤って踏む可能性が低いので問題になりませんでしたが、**`.php` は誤って踏む範囲が広すぎます**。

## 対処

該当のリクエストだけを拒否する `blocklist` に分けます。

```ruby
# wp-login は攻撃の意図が明確なので、これまでどおり IP を締め出す
Rack::Attack.blocklist('fail2ban pentesters') do |req|
  Rack::Attack::Fail2Ban.filter(...) do
    req.path.include?('wp-login') || req.params.values.include?('wp-login')
  end
end

# .php は該当リクエストだけを拒否し、その利用者の他のアクセスは通す
Rack::Attack.blocklist('php probes') do |req|
  req.path.end_with?('.php')
end
```

| | PR #1898 | 本 PR |
|---|---|---|
| `.php` へのアクセス | 403 | 403（変わらず） |
| その IP の他のアクセス | **24 時間 403** | **通常どおり** |
| Airbrake への通知 | 発生しない | 発生しない（変わらず） |
| 攻撃者への効果 | 全遮断 | 各 `.php` を遮断 |

観測された 94 件はすべて `.php` だったため、**遮断の効果はほぼ変わりません**。

## テストが本番と同じ経路を通っていませんでした

PR #1898 のテストは通っていましたが、**この不具合を検出できませんでした**。

test 環境のキャッシュは `null_store` で、`Fail2Ban` の BAN が保存されません。

```
config/environments/test.rb:23  config.cache_store = :null_store
config/environments/production.rb:50  # config.cache_store = :mem_cache_store  ← 既定の memory_store
```

そのため「`.php` を踏むと IP ごと締め出される」という本番の挙動を、テストが再現できていませんでした。テスト内で `Rack::Attack.cache.store` を `MemoryStore` に差し替え、本番と同じ経路を通すようにしています。

あわせて `maxretry: 1` の意味も明示しました。**これは「2 回目で BAN」を意味します**（1 回目でカウントが 1 になり、2 回目に `count >= maxretry` が成立）。

## テスト

- `.php` を繰り返しても通常のページを見られる（**この PR で追加。修正前は失敗する**）
- `wp-login` を繰り返すと通常のページも遮断される（既存の挙動を維持）
- 本番ログで観測されたパス 7 件を遮断
- 通常のアクセス 5 件は遮断しない

- [x] `bundle exec rspec spec` → 316 examples, 0 failures

## マージ後に確認すること

デプロイで dyno が再起動されるため、現在の BAN（`memory_store` 上）も解消されます。

- [ ] デプロイ完了を待つ
- [ ] 通常のページが 200 に戻る
      `for u in / /dojos /events /news; do curl -s -o /dev/null -w "$u %{http_code}\n" "https://coderdojo.jp$u"; done`
- [ ] `.php` は 403 のまま
      `curl -s -o /dev/null -w "%{http_code}\n" https://coderdojo.jp/news.php`
- [ ] `.php` を踏んだ後も通常のページが 200 であること
