### PR TITLE
feat(dojos): 連名道場にも global_club_id を設定する

### DIFF
--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -2944,6 +2944,7 @@
 - id: 42
   order: '271004'
   created_at: '2014-02-11'
+  note: 'TODO: 連名道場。Clubs 上の 2 クラブのうち 1 件しか地図に出ない。全件を出すには 1 エントリ 1 クラブへ分割する'
   name: 西宮・梅田
   prefecture_id: 27
   url: https://coderdojo-nishinomiya.info/
@@ -3776,7 +3777,7 @@
 - id: 224
   order: '320005'
   created_at: '2019-09-06'
-  note: 2024-11-22 から別イベント管理サービスを使用 https://reserva.be/iwapro/news?search_osh_no=46684&mode=list_detail
+  note: '2024-11-22 から別イベント管理サービスを使用 https://reserva.be/iwapro/news?search_osh_no=46684&mode=list_detail / TODO: 連名道場。Clubs 上の 7 クラブのうち 1 件しか地図に出ない。全件を出すには 1 エントリ 1 クラブへ分割する'
   name: 大田・邑南、他
   prefecture_id: 32
   url: https://iwapro.connpass.com/

--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -2944,7 +2944,6 @@
 - id: 42
   order: '271004'
   created_at: '2014-02-11'
-  note: 'TODO: 連名道場 (counter: 2)。Clubs 上の 2 クラブのうち 1 件しか地図に出ず、1 箇所が地図に出ていない。全件を出すには 1 エントリ 1 クラブへ分割する'
   name: 西宮・梅田
   prefecture_id: 27
   url: https://coderdojo-nishinomiya.info/
@@ -3777,7 +3776,7 @@
 - id: 224
   order: '320005'
   created_at: '2019-09-06'
-  note: '2024-11-22 から別イベント管理サービスを使用 https://reserva.be/iwapro/news?search_osh_no=46684&mode=list_detail / TODO: 連名道場 (counter: 7)。Clubs 上の 7 クラブのうち 1 件しか地図に出ず、6 箇所が地図に出ていない。全件を出すには 1 エントリ 1 クラブへ分割する'
+  note: 2024-11-22 から別イベント管理サービスを使用 https://reserva.be/iwapro/news?search_osh_no=46684&mode=list_detail
   name: 大田・邑南、他
   prefecture_id: 32
   url: https://iwapro.connpass.com/

--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -2944,7 +2944,7 @@
 - id: 42
   order: '271004'
   created_at: '2014-02-11'
-  note: 'TODO: 連名道場。Clubs 上の 2 クラブのうち 1 件しか地図に出ない。全件を出すには 1 エントリ 1 クラブへ分割する'
+  note: 'TODO: 連名道場 (counter: 2)。Clubs 上の 2 クラブのうち 1 件しか地図に出ず、1 箇所が地図に出ていない。全件を出すには 1 エントリ 1 クラブへ分割する'
   name: 西宮・梅田
   prefecture_id: 27
   url: https://coderdojo-nishinomiya.info/
@@ -3777,7 +3777,7 @@
 - id: 224
   order: '320005'
   created_at: '2019-09-06'
-  note: '2024-11-22 から別イベント管理サービスを使用 https://reserva.be/iwapro/news?search_osh_no=46684&mode=list_detail / TODO: 連名道場。Clubs 上の 7 クラブのうち 1 件しか地図に出ない。全件を出すには 1 エントリ 1 クラブへ分割する'
+  note: '2024-11-22 から別イベント管理サービスを使用 https://reserva.be/iwapro/news?search_osh_no=46684&mode=list_detail / TODO: 連名道場 (counter: 7)。Clubs 上の 7 クラブのうち 1 件しか地図に出ず、6 箇所が地図に出ていない。全件を出すには 1 エントリ 1 クラブへ分割する'
   name: 大田・邑南、他
   prefecture_id: 32
   url: https://iwapro.connpass.com/

--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -2954,6 +2954,7 @@
   - Webサイト
   - 電子工作
   counter: 2
+  global_club_id: 1e10bdbc-8d55-438b-8714-380b073378b9
 - id: 43
   order: '271004'
   created_at: '2016-09-27'
@@ -3788,6 +3789,7 @@
   - Ruby
   - micro:bit
   counter: 7
+  global_club_id: 0c422d07-3cd2-4cdb-a8fe-a54eec5c3605
 - id: 211
   order: '322059'
   created_at: '2019-06-11'

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -287,12 +287,17 @@ RSpec.describe Dojo, :type => :model do
       # クラブごと消えているため、埋めるべき対象は active に限られる。
       #
       # 2026年8月29日、例外だった連名道場 2 件（西宮・梅田、大田・邑南、他）にも値を
-      # 入れ、active な Dojo は全件が global_club_id を持つ状態になった。連名道場は
-      # 1 エントリが Clubs API 上の複数クラブに対応するが、地図には元から 1 件しか
-      # 出ていない（重複排除がある）。どのクラブが選ばれるかは API の返却順まかせ
-      # だったので、地図に出ていたクラブの UUID をそのまま設定して固定した。
-      #
+      # 入れ、active な**エントリ**は全件が global_club_id を持つ状態になった。
       # これにより DojoMap は dojo2dojo.csv の名前照合を必要としなくなる。
+      #
+      # ただし「エントリ数」と「道場数」は一致しない。連名道場は counter で
+      # 実際の箇所数を持つ（西宮・梅田は 2、大田・邑南、他は 7）。
+      # エントリ 202 に対し、counter を合算した道場数は 209（stats の active_dojos）。
+      #
+      # 地図には 1 エントリにつき 1 件しか出ないため（upsert_dojos_geojson.rb の
+      # 重複排除）、7 箇所は地図に出ていない。どのクラブが選ばれるかは Clubs API の
+      # 返却順まかせだったので、地図に出ていたクラブの UUID を設定して固定した。
+      # 全箇所を出すには 1 エントリ 1 クラブへの分割が要る（各 note に TODO）。
       it 'is set for every active dojo' do
         missing = Dojo.load_attributes_from_yaml.reject { |dojo| dojo['inactivated_at'].present? }
                       .reject { |dojo| dojo['global_club_id'].present? }

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -297,7 +297,14 @@ RSpec.describe Dojo, :type => :model do
       # 地図には 1 エントリにつき 1 件しか出ないため（upsert_dojos_geojson.rb の
       # 重複排除）、7 箇所は地図に出ていない。どのクラブが選ばれるかは Clubs API の
       # 返却順まかせだったので、地図に出ていたクラブの UUID を設定して固定した。
-      # 全箇所を出すには 1 エントリ 1 クラブへの分割が要る（各 note に TODO）。
+      #
+      # 全箇所を地図に出すには 1 エントリ 1 クラブへの分割が要る。掲載名の変更を
+      # 伴うため運営者への確認が必要で、counter の再設計とあわせて扱う。
+      #
+      # この経緯は db/dojos.yml の note には書かない。note を長くすると
+      # dojos:migrate_adding_id_to_yaml が YAML を書き直す際に折り返され、
+      # 次の実行者に無関係な差分が出る（実際に起こして戻した）。
+      # 同じ理由で、YAML にインラインコメントを置いても書き直しで消える。
       it 'is set for every active dojo' do
         missing = Dojo.load_attributes_from_yaml.reject { |dojo| dojo['inactivated_at'].present? }
                       .reject { |dojo| dojo['global_club_id'].present? }

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -286,34 +286,20 @@ RSpec.describe Dojo, :type => :model do
       # DojoMap は active な Dojo だけを地図に出す。閉鎖済みの Dojo は Clubs API 側からも
       # クラブごと消えているため、埋めるべき対象は active に限られる。
       #
-      # 下記は現時点で値を入れられない Dojo。解決したらこの一覧から消すこと。
-      # 一覧に無い active な Dojo が増えたら、このテストが落ちて気づける。
-      dojos_without_global_club_id = {
-        # 連名道場。1 エントリが Clubs API 上の複数クラブに対応するため、
-        # 単一カラムでは表現できない。counter の再設計とあわせて対応する。
-        42  => '西宮・梅田（2 クラブ）',
-        224 => '大田・邑南、他（6 クラブ）',
-      }.freeze
-
+      # 2026年8月29日、例外だった連名道場 2 件（西宮・梅田、大田・邑南、他）にも値を
+      # 入れ、active な Dojo は全件が global_club_id を持つ状態になった。連名道場は
+      # 1 エントリが Clubs API 上の複数クラブに対応するが、地図には元から 1 件しか
+      # 出ていない（重複排除がある）。どのクラブが選ばれるかは API の返却順まかせ
+      # だったので、地図に出ていたクラブの UUID をそのまま設定して固定した。
+      #
+      # これにより DojoMap は dojo2dojo.csv の名前照合を必要としなくなる。
       it 'is set for every active dojo' do
         missing = Dojo.load_attributes_from_yaml.reject { |dojo| dojo['inactivated_at'].present? }
                       .reject { |dojo| dojo['global_club_id'].present? }
-                      .reject { |dojo| dojos_without_global_club_id.key?(dojo['id']) }
 
         expect(missing).to be_empty,
           "global_club_id が未設定の active な Dojo: " +
           missing.map { |dojo| "#{dojo['id']} (#{dojo['name']})" }.join(', ')
-      end
-
-      it 'has no stale entry in the exception list' do
-        resolved = Dojo.load_attributes_from_yaml.select do |dojo|
-          dojos_without_global_club_id.key?(dojo['id']) &&
-            (dojo['global_club_id'].present? || dojo['inactivated_at'].present?)
-        end
-
-        expect(resolved).to be_empty,
-          "解決済みなので dojos_without_global_club_id から消してください: " +
-          resolved.map { |dojo| "#{dojo['id']} (#{dojo['name']})" }.join(', ')
       end
 
       it 'is not shared by two dojos' do


### PR DESCRIPTION
## 概要

連名道場 2 件に `global_club_id` を設定します。これで **active な全エントリが `global_club_id` を持つ**状態になり、DojoMap は `dojo2dojo.csv` の名前照合を必要としなくなります。

```diff
 - id: 42
   name: 西宮・梅田
+  global_club_id: 1e10bdbc-8d55-438b-8714-380b073378b9

 - id: 224
   name: 大田・邑南、他
+  global_club_id: 0c422d07-3cd2-4cdb-a8fe-a54eec5c3605
```

変更は `db/dojos.yml` の **2 行だけ**です。

## 例外にしていた理由と、実際の挙動

1 エントリが Clubs API 上の複数クラブに対応するため、単一カラムでは表現できないとして例外にしていました。

| 登録名 | Clubs 上の該当クラブ |
|---|---|
| 西宮・梅田 | `Nishinomiya` / `Umeda, Osaka, @ Cybozu`（2 件） |
| 大田・邑南、他 | `Shimane @ Matsue` / `@ Ohda` / `@ Gotsu` / `@ Hamada` / `@ Ohnan` / `@ Unnan` / `@ Masuda`（7 件） |

**ただし地図には元から 1 件しか出ていません。** `upsert_dojos_geojson.rb` に重複排除があるためです。

```ruby
# 複数道場で一括登録している場合は１つのみ地図上に配置する
next if marked_dojos.include? dojo[:name]
```

つまり複数クラブのうちどれが出るかは **Clubs API の返却順で決まっており、制御できていませんでした**。実際に出ていたのは次のクラブです。

| 登録名 | 地図に出ていたクラブ |
|---|---|
| 西宮・梅田 | `Umeda, Osaka, @ Cybozu`（西宮ではない） |
| 大田・邑南、他 | **`Shimane @ Gotsu`（江津。大田でも邑南でもない）** |

## 地図に出ているクラブの UUID をそのまま設定します

マーカーの位置が変わると道場の方に説明のつかない変化が起きるため、**現在出ているクラブ**を選びました。

**マーカー数も座標も変わりません。** 変わるのは、どのクラブが選ばれるかが返却順まかせでなくなる点だけです。

## エントリ数と道場数は一致しません

連名道場は `counter` で実際の箇所数を持つため、次のようにずれます。

| 数え方 | 件数 |
|---|---|
| `db/dojos.yml` の active なエントリ | 202 |
| **道場数**（`counter` を合算 / `stats.json` の `active_dojos`） | **209** |
| **地図に出る数** | **202** |

**7 箇所（西宮 or 梅田で 1、島根で 6）は地図に出ていません。** これは本 PR で生じるものではなく、元からある乖離です。本 PR はこの乖離を解消しません。

全箇所を出すには 1 エントリ 1 クラブへの分割が要りますが、掲載名の変更を伴うため運営者への確認が必要で、`counter` の再設計とあわせて扱う話になります。この経緯は `spec/models/dojo_spec.rb` のコメントに残しました。

## note には書いていません

当初 `note` に TODO を書きましたが、**取り下げました**。note を長くすると `dojos:migrate_adding_id_to_yaml` が YAML を書き直す際に折り返され、次の実行者に無関係な差分が出るためです。

```
note: '... 全件を出すには
  1 エントリ 1 クラブへ分割する'
```

main の版では rake を実行しても差分が出ないことを確認したうえで、追記が原因だと特定し、元に戻して冪等性を検証しています。同じ理由で **YAML にインラインコメントを置いても書き直しで消えます**。

## テスト

例外リスト `dojos_without_global_club_id` が空になったので削除しました。「active な全エントリが `global_club_id` を持つ」という検査は残ります。

- [x] `bundle exec rspec spec` → 315 examples, 0 failures
- [x] UUID を外すとテストが落ちることを確認
- [x] `dojos:update_db_by_yaml` で反映し、ユニーク制約に触れないことを確認
- [x] `dojos:migrate_adding_id_to_yaml` を実行しても差分が出ないことを確認

## この後の段取り

1. 本 PR をマージ・デプロイ（`/dojos.json` が全エントリで UUID を返す）
2. [map#42](https://github.com/coderdojo-japan/map.coderdojo.jp/pull/42) を rebase し、CSV 救済の経路を削除
3. `dojo2dojo.csv` を削除

## マージ後に確認すること

- [ ] デプロイ完了を待つ（`gh run list --branch main --limit 1` が `completed`）
- [ ] 2 件に `global_club_id` が入っている
      `curl -s https://coderdojo.jp/dojos.json | ruby -rjson -e 'JSON.parse(STDIN.read).select { |d| [42,224].include?(d["id"]) }.each { |d| puts "#{d["name"]} #{d["global_club_id"]}" }'`
- [ ] `stats.json` の `active_dojos` が 209 のままであること
- [ ] 翌日の DojoMap 更新後、マーカーの座標が変わっていないこと
