### PR TITLE
fix: Minecraftカップのリンクを移行先ドメインに合わせる

### DIFF
--- a/app/views/docs/kata.html.erb
+++ b/app/views/docs/kata.html.erb
@@ -500,16 +500,16 @@
 	  </li>
 	  -->
 	  <li>
-	    <h4 id='learn-minecraft-cup-interview-0'><a href="https://minecraftcup.com/news/782/">Minecraftカップ取り組み事例：CoderDojo名護</a></h4>
-	    <p>by <a href="https://minecraftcup.com/">Minecraftカップ全国大会</a></p>
+	    <h4 id='learn-minecraft-cup-interview-0'><a href="https://mccup.jp/782/">Minecraftカップ取り組み事例：CoderDojo名護</a></h4>
+	    <p>by <a href="https://mccup.jp/">Minecraftカップ全国大会</a></p>
 	  </li>
 	  <li>
-	    <h4 id='learn-minecraft-cup-interview-1'><a href="https://minecraftcup.com/news/2564/">CoderDojo船橋・若葉みつわ台連合チームの取り組みを取材しました①</a></h4>
-	    <p>by <a href="https://minecraftcup.com/">Minecraftカップ全国大会</a></p>
+	    <h4 id='learn-minecraft-cup-interview-1'><a href="https://mccup.jp/2564/">CoderDojo船橋・若葉みつわ台連合チームの取り組みを取材しました①</a></h4>
+	    <p>by <a href="https://mccup.jp/">Minecraftカップ全国大会</a></p>
 	  </li>
 	  <li>
-	    <h4 id='learn-minecraft-cup-interview-2'><a href="https://minecraftcup.com/news/2586/">CoderDojo船橋・若葉みつわ台連合チームの取り組みを取材しました②</a></h4>
-	    <p>by <a href="https://minecraftcup.com/">Minecraftカップ全国大会</a></p>
+	    <h4 id='learn-minecraft-cup-interview-2'><a href="https://mccup.jp/2586/">CoderDojo船橋・若葉みつわ台連合チームの取り組みを取材しました②</a></h4>
+	    <p>by <a href="https://mccup.jp/">Minecraftカップ全国大会</a></p>
 	  </li>
 	  <li>
 	    <h4 id='learn-minecraft-edu-multi-play'><a href="https://docs.google.com/presentation/d/1gys6T_X51ldAB8Dqj_6uZAByBgBoGGWdSjN3d8AzSZU/edit?usp=sharing">教育版マイクラ体験会! できることを知る・マルチプレイで遊ぶ</a></h4>
@@ -1204,7 +1204,7 @@
 	  <li>
 	    <h4 id='minecraft-cup'>
 	      教育版マインクラフトのライセンス貸出
-	      <small>(提供: <a href="https://minecraftcup.com/">Minecraftカップ</a>)</small>
+	      <small>(提供: <a href="https://mccup.jp/">Minecraftカップ</a>)</small>
 	    </h4>
 	    <p>希望する Dojo は、所定の手続きを経た上で、教育版マインクラフトのライセンス貸出プログラムに申請できるようになりました。詳細は <strong><a href="https://news.coderdojo.jp/2022/05/31/partnership-with-minecraftcup/">news.coderdojo.jp のお知らせ記事</a></strong>をご参照ください。</p>
 	    <br>

--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -2148,7 +2148,7 @@
 - id: 279
   order: '162060'
   created_at: '2022-03-01'
-  note: 2025-12-31 https://minecraftcup.com/works/workarticle/?work_id=5658
+  note: 2025-12-31 https://web.archive.org/web/20260214071325/https://minecraftcup.com/works/workarticle/?work_id=5658
   name: 滑川
   prefecture_id: 16
   url: https://www.coderdojo-namerikawa.org
@@ -3732,7 +3732,7 @@
   order: '302066'
   created_at: '2017-09-06'
   inactivated_at: '2026-08-29'
-  note: 2024-12-31 https://minecraftcup.com/works/workarticle/?work_id=3656
+  note: 2024-12-31 https://mccup.jp/works2024/workarticle2024/?work_id=3656
   name: 南紀田辺
   prefecture_id: 30
   url: https://coderdojo-nanki-tanabe.jimdo.com/


### PR DESCRIPTION
## 概要

Minecraft カップ全国大会のサイトが `minecraftcup.com` から `mccup.jp` へ移行しています。
301 は返りますが、**記事の URL は転送先で記事にたどり着けません**。

```
https://minecraftcup.com/news/2564/  →  https://mccup.jp/news/  （ニュース一覧）
```

リンクチェッカーでは 200 に見えるため気づきにくい状態でした。

## /kata の記事リンク（3 件）

`/news/` を含まない形が移行先の正規 URL です（`<link rel="canonical">` と一致）。

| 変更後 | 記事タイトル |
|---|---|
| https://mccup.jp/782/ | CoderDojo名護の取り組みを取材しました |
| https://mccup.jp/2564/ | CoderDojo船橋・若葉みつわ台連合チームの取り組みを取材しました① |
| https://mccup.jp/2586/ | CoderDojo船橋・若葉みつわ台連合チームの取り組みを取材しました② |

あわせて、同ページのトップページへのリンク 4 件も `https://mccup.jp/` に揃えました。
転送は正常に効いていますが、新旧が混在すると次に読む人が判断できないためです。

## db/dojos.yml の note（2 件）

`note` の URL は `/dojos/activity` に表示され、活動日の根拠として使われます。

```diff
 - id: 99   # 南紀田辺
-  note: 2024-12-31 https://minecraftcup.com/works/workarticle/?work_id=3656
+  note: 2024-12-31 https://mccup.jp/works2024/workarticle2024/?work_id=3656

 - id: 279  # 滑川
-  note: 2025-12-31 https://minecraftcup.com/works/workarticle/?work_id=5658
+  note: 2025-12-31 https://web.archive.org/web/20260214071325/https://minecraftcup.com/works/workarticle/?work_id=5658
```

滑川の第 7 回（2025 年度）作品ページは移行先に無く、`mccup.jp/works2025/` 自体が 404 です。
日付の根拠を失わないよう、内容を確認できる保存版を指すようにしました。

## 確認したこと

- [x] 差し替えた 3 記事のタイトルが `/kata` の記載と一致すること
- [x] 保存版に滑川の作品が含まれること
- [x] `db/dojos.yml` がパースできること
- [x] `bundle exec rspec spec/models/dojo_spec.rb spec/requests/docs_spec.rb`（44 examples, 0 failures）

## 別件

`/kata` の外部リンク 315 件を機械的に確認したところ、他にも応答しないものがありました。
ただし connpass や Amazon の 403 / 500 は bot 判定によるもので、ブラウザでは開けます。
実際に切れているものの切り分けは、別途行います。
