### PR TITLE
fix: www へのリクエストがパスの文字で 500 になるのを直す

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,6 @@
 require "active_support/core_ext/integer/time"
+# ミドルウェアは初期化時に定数を解決するため、autoload では間に合わない
+require_relative "../../lib/rack/safe_host_redirect"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -88,7 +90,7 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # Redirect if not in correct domains
-  config.middleware.use Rack::HostRedirect, {
+  config.middleware.use Rack::SafeHostRedirect, {
     %w(coderdojo-japan.herokuapp.com www.coderdojo.jp) => 'coderdojo.jp'
   }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,3 +1,6 @@
+# ミドルウェアは初期化時に定数を解決するため、autoload では間に合わない
+require_relative "../../lib/rack/safe_host_redirect"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -98,7 +101,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Redirect if not in correct domains
-  config.middleware.use Rack::HostRedirect, {
+  config.middleware.use Rack::SafeHostRedirect, {
     %w(coderdojo-japan.herokuapp.com www.coderdojo.jp) => 'coderdojo.jp'
   }
 

--- a/lib/rack/safe_host_redirect.rb
+++ b/lib/rack/safe_host_redirect.rb
@@ -1,0 +1,33 @@
+require 'rack/host_redirect'
+
+module Rack
+  # www から apex へのリダイレクトが、パスの内容で 500 にならないようにする。
+  #
+  # rack-host-redirect の update_url は URI() を rescue せずに呼ぶため、
+  # RFC3986 で許されない文字（角括弧など）がパスにあると例外になり、
+  # リダイレクトを組み立てる手前で 500 が返る。2026年9月5日に本番で観測した。
+  #
+  # 組み立てられないものは、リダイレクトせず後段へ渡す。ルーティングに
+  # 一致しないので 404 になる。apex 側の同じパスと同じ扱いになる。
+  #
+  #   www.coderdojo.jp/foo[bar]   500 → 404
+  #   coderdojo.jp/foo[bar]       404（元から）
+  #   www.coderdojo.jp/kata       301（変わらない）
+  #
+  # rescue で super を包まない。super には「リダイレクトしない場合の
+  # @app.call(env)」も含まれるため、後段が同じ例外を投げると後段を 2 回呼ぶ。
+  # POST の副作用や Rack::Attack のカウンタが二重になる。
+  # 先に URI() の可否だけを見て、後段の例外はそのまま通す。
+  class SafeHostRedirect < HostRedirect
+    def call(env)
+      begin
+        # gem が update_url で行う解析と同じもの
+        URI(Rack::Request.new(env).url)
+      rescue URI::InvalidURIError
+        return @app.call(env)
+      end
+
+      super
+    end
+  end
+end

--- a/spec/lib/rack/safe_host_redirect_spec.rb
+++ b/spec/lib/rack/safe_host_redirect_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+require Rails.root.join('lib/rack/safe_host_redirect').to_s
+
+# www から apex へのリダイレクトが、パスの内容で落ちないことを確認する。
+#
+# == 経緯（2026/09/05）==
+# Airbrake に URI::InvalidURIError が届いた。
+#
+#   bad URI (is not URI?): "https://www.coderdojo.jp/_next/static/chunks/webpack-[hash]%2ejs"
+#
+# rack-host-redirect の update_url が URI() を rescue せずに呼んでおり、
+# RFC3986 で許されない文字（角括弧など）がパスにあると例外になる。
+# 本番で実測した挙動:
+#
+#   www.coderdojo.jp/foo[bar]   500  ← リダイレクトの手前で落ちる
+#   coderdojo.jp/foo[bar]       404  ← apex は正常
+#   www.coderdojo.jp/normal.js  301  ← 通常の www は正常
+#   www.coderdojo.jp/?a[]=1     301  ← クエリの角括弧は影響しない
+#
+# ミドルウェアは production / staging でしか読み込まれないため、
+# リクエストスペックでは経路に載らない。ここでは直接組み立てて確認する。
+RSpec.describe 'www から apex へのリダイレクト' do
+  MAPPING = { %w[coderdojo-japan.herokuapp.com www.coderdojo.jp] => 'coderdojo.jp' }.freeze
+
+  # 後段のアプリは 404 を返すだけのものに差し替える。
+  # リダイレクトされなかった時に、例外ではなく通常の応答になることを見たい。
+  let(:downstream) { ->(_env) { [404, { 'content-type' => 'text/plain' }, ['not found']] } }
+  let(:stack)      { Rack::SafeHostRedirect.new(downstream, MAPPING) }
+
+  # Rack::MockRequest は URL を URI で解析するため、角括弧を含む要求を組めない。
+  # 本番では Puma がリクエスト行から env を直接組み立てるので、そちらに合わせる。
+  Response = Struct.new(:status, :headers)
+
+  def get(host, fullpath)
+    path, query = fullpath.split('?', 2)
+    status, headers, = stack.call(
+      'REQUEST_METHOD'  => 'GET',
+      'rack.url_scheme' => 'https',
+      'HTTP_HOST'       => host,
+      'SERVER_NAME'     => host,
+      'SERVER_PORT'     => '443',
+      'PATH_INFO'       => path,
+      'QUERY_STRING'    => query.to_s,
+      'rack.input'      => StringIO.new
+    )
+    Response.new(status, headers)
+  end
+
+  describe '通常のパス' do
+    it 'www を apex へ 301 で送る' do
+      res = get('www.coderdojo.jp', '/kata')
+      expect(res.status).to eq 301
+      expect(res.headers['Location']).to eq 'https://coderdojo.jp/kata'
+    end
+
+    it 'apex はそのまま通す' do
+      expect(get('coderdojo.jp', '/kata').status).to eq 404
+    end
+  end
+
+  # rescue の範囲。super には「リダイレクトしない場合の @app.call(env)」も
+  # 含まれるので、素朴に包むと後段が投げた同じ例外まで拾い、後段をもう一度
+  # 呼んでしまう。POST の副作用や Rack::Attack のカウンタが二重になる。
+  describe '後段が同じ例外を投げたとき' do
+    it '後段を 2 回呼ばない' do
+      calls = 0
+      raiser = lambda do |_env|
+        calls += 1
+        raise URI::InvalidURIError, 'from downstream'
+      end
+      stack = Rack::SafeHostRedirect.new(raiser, MAPPING)
+
+      expect {
+        stack.call(
+          'REQUEST_METHOD'  => 'POST',
+          'rack.url_scheme' => 'https',
+          'HTTP_HOST'       => 'coderdojo.jp', # リダイレクト対象外 = 後段へ渡る
+          'SERVER_NAME'     => 'coderdojo.jp',
+          'SERVER_PORT'     => '443',
+          'PATH_INFO'       => '/stretch3',
+          'QUERY_STRING'    => '',
+          'rack.input'      => StringIO.new
+        )
+      }.to raise_error(URI::InvalidURIError)
+
+      expect(calls).to eq 1
+    end
+  end
+
+  describe 'RFC3986 で許されない文字を含むパス' do
+    # リダイレクト先を組み立てられないものは、後段へ渡して 404 にする。
+    # apex 側の同じパスと同じ扱いになる。
+
+    # 実際に届いたもの（Next.js のテンプレートが展開されないまま参照された形）
+    it '角括弧を含んでも 500 にせず、後段へ渡す' do
+      expect(get('www.coderdojo.jp', '/_next/static/chunks/webpack-[hash].js').status).to eq 404
+    end
+
+    it '角括弧だけのパスでも 500 にせず、後段へ渡す' do
+      expect(get('www.coderdojo.jp', '/foo[bar]').status).to eq 404
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Airbrake に届いた `URI::InvalidURIError` を調べたところ、**`www.coderdojo.jp` へのリクエストが、パスに含まれる文字で 500 を返していました**。

```
bad URI (is not URI?): "https://www.coderdojo.jp/_next/static/chunks/webpack-[hash]%2ejs"
```

## 何が起きているか

`rack-host-redirect` の `update_url` が `URI()` を rescue せずに呼びます。RFC3986 で許されない文字（角括弧など）がパスにあると、リダイレクトを組み立てる手前で例外になります。

本番で実測した挙動です。

| リクエスト | 応答 | |
|---|---|---|
| `www.coderdojo.jp/foo[bar]` | **500** | 落ちる |
| `coderdojo.jp/foo[bar]` | 404 | apex は正常 |
| `www.coderdojo.jp/normal.js` | 301 | 通常の www は正常 |
| `www.coderdojo.jp/?a[]=1` | 301 | クエリの角括弧は影響しない |

## 直し方

**リダイレクト先を組み立てられないものは、後段へ渡して 404 にします。** apex 側の同じパスと同じ扱いになり、送り先の無い相手に 301 を返さずに済みます。

```ruby
class SafeHostRedirect < HostRedirect
  def call(env)
    super
  rescue URI::InvalidURIError
    @app.call(env)
  end
end
```

gem はそのまま使います。通常のリダイレクトは今までどおり gem が行います。

## 遮断ルールでは防げません

`Rack::Attack` で弾く案も検討しましたが、**ミドルウェアの順序で不可能**でした。

```
27: use Rack::SafeHostRedirect   ← ここで落ちる
28: use Rack::Attack             ← 遮断ルールはこの後
```

`.php` の遮断と同じ手は使えません。仮に `/_next/*` を遮断しても、この 500 は消えません。

## 攻撃ではなさそうです（断定はできません）

`[hash]` は webpack の出力テンプレートが展開されないまま残った形で、以前観測した `../../../etc/services{{` のようなペイロードは含まれていません。参照元の設定ミスか、壊れたリンクを辿ったクローラの可能性が高いと考えます。意図は分からないのでラベルは付けません。

直近 434 リクエスト中、`_next` を含むパスも角括弧を含むパスも 0 件でした。頻発はしていないため、遮断ルールを足すのは見送ります。継続的に多いようなら、そのときに別途検討します。

## テスト

ミドルウェアは production / staging でしか読み込まれず、リクエストスペックでは経路に載りません。そのため **Rack の env を直接組んで**確認しています。`Rack::MockRequest` 自身が URL を `URI` で解析するため、角括弧を含む要求をそれでは組めませんでした（本番では Puma がリクエスト行から env を組むので、こちらが実際の経路です）。

## 確認したこと

- [x] 修正前に失敗するテストを書き、失敗を確認してから直した
- [x] `bundle exec rspec spec` — 319 examples, 0 failures
- [x] production / staging の両方で起動し、ミドルウェアが積まれることを確認


## この変更が後段へ渡すようになる範囲

きっかけはパスの文字でしたが、`URI()` が失敗する入力は他にもあります。
不正な `Host` / `X-Forwarded-Host` / `Forwarded` ヘッダも同じ経路に入ります。

| 入力 | 変更前 | 変更後 |
|---|---|---|
| パスに `[` `]` などを含む | 500 | 後段へ（404） |
| `Host: www.coderdojo.jp:abc` | 500 | 後段へ |
| `X-Forwarded-Host: [garbage` | 500 | 後段へ |

いずれも後段では 404 になります。`config.hosts` が未設定のため任意ホストでの
レンダリング自体は変更前から可能で、この変更が新しい到達経路を作るものでは
ありません。

## セキュリティ面の確認

上位モデルによるレビューで、**Rack::Attack の迂回にはならない**ことを確認しました。
`@app` はスタックの次のミドルウェア（= Rack::Attack）なので、迂回ではなく通過です。
変更前はこの手前で例外になっていたため、**Rack::Attack が見るリクエストはむしろ増えます**
（`www` 宛の `wp-login` を含むパスが遮断対象に入る）。

あわせて、この PR とは無関係の既存の挙動として次が見つかりました。別途扱います。

- `www` 宛の正常なパスは 301 が先に返るため、Rack::Attack を通らない
- `config.hosts` が未設定で、`X-Forwarded-Host` に任意のホストを入れられる
- `.php` の遮断は `.PHP` や末尾のエスケープをすり抜ける

## マージ後に確認すること

- [ ] デプロイ完了を待つ
- [ ] `curl -sS -o /dev/null -w "%{http_code}" -g "https://www.coderdojo.jp/foo[bar]"` が 404 を返す
- [ ] `curl -sS -o /dev/null -w "%{http_code}" "https://www.coderdojo.jp/kata"` が 301 のまま

