### PR TITLE
feat(dojos): 佐久の Doorkeeper を登録する

### DIFF
--- a/db/dojo_event_services.yml
+++ b/db/dojo_event_services.yml
@@ -54,11 +54,10 @@
 #  url: https://codeclub.org/ja/clubs/b115e722-3f39-4306-9041-3d323844182e
 
 # 佐久（長野県佐久市）
-# イベント管理サービスが判明したら group_id を取得してコメントアウトを外す。
-#- dojo_id: 355
-#  name: ???
-#  group_id: ???
-#  url: https://codeclub.org/ja/clubs/50f7407f-7eaa-4a71-9a36-710bc4192737
+- dojo_id: 355
+  name: doorkeeper
+  group_id: 112239
+  url: https://coderdojo-saku.doorkeeper.jp/
 
 # 伊佐@本城(鹿児島)- 独自のイベント管理システム?
 #- dojo_id: 354


### PR DESCRIPTION
## 概要

CoderDojo 佐久の近日開催イベントが `/events` に出ていませんでした。原因は **イベント管理サービスが未登録**だったことです。

掲載時（#1888）はサービスが判明していなかったため、`db/dojo_event_services.yml` にコメントアウトされたひな形が置かれたままでした。

```diff
 # 佐久（長野県佐久市）
-# イベント管理サービスが判明したら group_id を取得してコメントアウトを外す。
-#- dojo_id: 355
-#  name: ???
-#  group_id: ???
-#  url: https://codeclub.org/ja/clubs/50f7407f-7eaa-4a71-9a36-710bc4192737
+- dojo_id: 355
+  name: doorkeeper
+  group_id: 112239
+  url: https://coderdojo-saku.doorkeeper.jp/
```

## 確認したこと

- [x] `bin/d-search` でグループ ID を取得（112239）
- [x] Doorkeeper API で、そのグループから開催予定のイベントが取得できることを確認
- [x] ローカルで `rails dojo_event_services:upsert` を実行し、登録されることを確認
- [x] ローカルで `rails upcoming_events:aggregation[doorkeeper]` を実行し、イベントが 1 件取得できることを確認
- [x] `bundle exec rspec spec` — 320 examples, 0 failures

## マージ後に確認すること

近日開催の一覧は日次のバッチ（`upcoming_events:aggregation`、21:00 UTC）で更新されます。

- [ ] デプロイ完了を待つ
- [ ] 次回のバッチ後に https://coderdojo.jp/events へ佐久が出ることを確認
