### PR TITLE
fix: Host ヘッダが壊れていても 500 にしない

### DIFF
--- a/lib/rack/safe_host_redirect.rb
+++ b/lib/rack/safe_host_redirect.rb
@@ -1,33 +1,42 @@
 require 'rack/host_redirect'
 
 module Rack
-  # www から apex へのリダイレクトが、パスの内容で 500 にならないようにする。
+  # www から apex へのリダイレクトが、リクエストの内容で 500 にならないようにする。
   #
-  # rack-host-redirect の update_url は URI() を rescue せずに呼ぶため、
-  # RFC3986 で許されない文字（角括弧など）がパスにあると例外になり、
-  # リダイレクトを組み立てる手前で 500 が返る。2026年9月5日に本番で観測した。
+  # rack-host-redirect は次の 2 つを前提にしているが、どちらも rescue していない。
   #
-  # 組み立てられないものは、リダイレクトせず後段へ渡す。ルーティングに
-  # 一致しないので 404 になる。apex 側の同じパスと同じ扱いになる。
+  #   1. Rack::Request#host が nil でない（get_updated_uri_opts が host.downcase を呼ぶ）
+  #   2. Rack::Request#url が URI() で解析できる（update_url が URI() を呼ぶ）
   #
-  #   www.coderdojo.jp/foo[bar]   500 → 404
-  #   coderdojo.jp/foo[bar]       404（元から）
-  #   www.coderdojo.jp/kata       301（変わらない）
+  # 前提が崩れると、リダイレクトを組み立てる手前で例外になり 500 が返る。
+  # 2026年9月に本番で両方とも観測した。
   #
-  # rescue で super を包まない。super には「リダイレクトしない場合の
-  # @app.call(env)」も含まれるため、後段が同じ例外を投げると後段を 2 回呼ぶ。
-  # POST の副作用や Rack::Attack のカウンタが二重になる。
-  # 先に URI() の可否だけを見て、後段の例外はそのまま通す。
+  #   www.coderdojo.jp/foo[bar]        URI::InvalidURIError（パスの文字）
+  #   Host: www.coderdojo.jp:          NoMethodError（host が nil。URI() は通る）
+  #
+  # 前提が崩れているものは、リダイレクトせず後段へ渡す。ルーティングに一致しないので
+  # 404 になり、apex 側の同じリクエストと同じ扱いになる。
+  #
+  # rescue で super を包まない。super には「リダイレクトしない場合の @app.call(env)」も
+  # 含まれるため、後段が同じ例外を投げると後段を 2 回呼ぶ。POST の副作用や
+  # Rack::Attack のカウンタが二重になる。
   class SafeHostRedirect < HostRedirect
     def call(env)
-      begin
-        # gem が update_url で行う解析と同じもの
-        URI(Rack::Request.new(env).url)
-      rescue URI::InvalidURIError
-        return @app.call(env)
-      end
+      return @app.call(env) unless redirectable?(env)
 
       super
+    end
+
+    private
+
+    def redirectable?(env)
+      request = Rack::Request.new(env)
+      return false if request.host.nil?
+
+      URI(request.url)
+      true
+    rescue URI::InvalidURIError
+      false
     end
   end
 end

--- a/spec/lib/rack/safe_host_redirect_spec.rb
+++ b/spec/lib/rack/safe_host_redirect_spec.rb
@@ -87,6 +87,21 @@ RSpec.describe 'www から apex へのリダイレクト' do
     end
   end
 
+  # gem の get_updated_uri_opts は request.host.downcase を呼ぶ。
+  # Host ヘッダが壊れていると Rack::Request#host は nil を返し、NoMethodError になる。
+  # URI() は通ってしまう形（末尾コロンなど）があるので、URI の可否だけでは足りない。
+  describe 'Host ヘッダが壊れているとき' do
+    {
+      'ポートが数値でない' => 'www.coderdojo.jp:abc',
+      '末尾がコロン'       => 'www.coderdojo.jp:',
+      '括弧が壊れている'   => '[',
+    }.each do |label, host|
+      it "#{label}でも 500 にせず、後段へ渡す" do
+        expect(get(host, '/kata').status).to eq 404
+      end
+    end
+  end
+
   describe 'RFC3986 で許されない文字を含むパス' do
     # リダイレクト先を組み立てられないものは、後段へ渡して 404 にする。
     # apex 側の同じパスと同じ扱いになる。


### PR DESCRIPTION
## 概要

PR #1907 で `www` 宛の 500 を直しましたが、**塞ぎきれていませんでした**。マージ後に別の形の 500 が本番で観測されています。

```
NoMethodError: undefined method 'downcase' for nil
  rack-host-redirect-1.3.0/lib/rack/host_redirect.rb:51 in 'get_updated_uri_opts'
```

## 何を見落としていたか

gem は 2 つのことを前提にしていますが、#1907 で rescue したのは片方だけでした。

| # | 前提 | 崩れたときの例外 | #1907 での扱い |
|---|---|---|---|
| 1 | `Rack::Request#url` が `URI()` で解析できる | `URI::InvalidURIError` | 拾えていた |
| 2 | `Rack::Request#host` が nil でない | `NoMethodError` | **拾えていなかった** |

`Host: www.coderdojo.jp:` のように末尾がコロンだと、`request.host` は nil になりますが `URI("https://www.coderdojo.jp:/kata")` は成功します。そのため事前チェックを通り抜け、gem 側で落ちていました。

## 直し方

両方の前提を先に確かめます。

```ruby
def redirectable?(env)
  request = Rack::Request.new(env)
  return false if request.host.nil?

  URI(request.url)
  true
rescue URI::InvalidURIError
  false
end
```

## 実測（修正前後）

| ケース | 修正前 | 修正後 |
|---|---|---|
| 正常（`www/kata`） | 301 | 301 |
| パスに `[` `]` | `URI::InvalidURIError` | 404 |
| `Host: www.coderdojo.jp:abc` | `NoMethodError` | 404 |
| `Host: www.coderdojo.jp:` | **`NoMethodError`** | **404** |
| `Host: [` | `NoMethodError` | 404 |
| apex（対象外） | 404 | 404 |

太字が今回塞いだ穴です。

## 確認したこと

- [x] 修正前に失敗するテストを書き、失敗を確認してから直した
- [x] `bundle exec rspec spec` — 323 examples, 0 failures
- [x] 本番と同じ形の Rack env を組み、修正前後を並べて実測

## マージ後に確認すること

- [ ] デプロイ完了を待つ
- [ ] `curl -sS -o /dev/null -w "%{http_code}" -H 'Host: www.coderdojo.jp:' https://coderdojo.jp/kata` が 500 でないこと
- [ ] `curl -sS -o /dev/null -w "%{http_code}" https://www.coderdojo.jp/kata` が 301 のまま
