### PR TITLE
docs(rack): 後段へ渡したときの応答の説明を実態に合わせる

### DIFF
--- a/lib/rack/safe_host_redirect.rb
+++ b/lib/rack/safe_host_redirect.rb
@@ -14,8 +14,10 @@ module Rack
   #   www.coderdojo.jp/foo[bar]        URI::InvalidURIError（パスの文字）
   #   Host: www.coderdojo.jp:          NoMethodError（host が nil。URI() は通る）
   #
-  # 前提が崩れているものは、リダイレクトせず後段へ渡す。ルーティングに一致しないので
-  # 404 になり、apex 側の同じリクエストと同じ扱いになる。
+  # 前提が崩れているものは、リダイレクトせず後段へ渡す。apex 宛と同じ扱いになり、
+  # パスがルートに一致すればその応答を、しなければ 404 を返す。
+  # （Host が壊れていても応答は返る。このアプリは config.hosts を設定しておらず、
+  #   Host の検証は元から行っていない。検証したいなら別の手当てが要る）
   #
   # rescue で super を包まない。super には「リダイレクトしない場合の @app.call(env)」も
   # 含まれるため、後段が同じ例外を投げると後段を 2 回呼ぶ。POST の副作用や

--- a/spec/lib/rack/safe_host_redirect_spec.rb
+++ b/spec/lib/rack/safe_host_redirect_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe 'www から apex へのリダイレクト' do
   MAPPING = { %w[coderdojo-japan.herokuapp.com www.coderdojo.jp] => 'coderdojo.jp' }.freeze
 
   # 後段のアプリは 404 を返すだけのものに差し替える。
+  #
+  # ここで見たいのは「後段へ渡ったか」であって、本番の応答そのものではない。
+  # 404 はこのスタブが返す値で、本番ではパスがルートに一致すればその応答になる。
   # リダイレクトされなかった時に、例外ではなく通常の応答になることを見たい。
   let(:downstream) { ->(_env) { [404, { 'content-type' => 'text/plain' }, ['not found']] } }
   let(:stack)      { Rack::SafeHostRedirect.new(downstream, MAPPING) }
@@ -103,7 +106,7 @@ RSpec.describe 'www から apex へのリダイレクト' do
   end
 
   describe 'RFC3986 で許されない文字を含むパス' do
-    # リダイレクト先を組み立てられないものは、後段へ渡して 404 にする。
+    # リダイレクト先を組み立てられないものは、後段へ渡す。
     # apex 側の同じパスと同じ扱いになる。
 
     # 実際に届いたもの（Next.js のテンプレートが展開されないまま参照された形）


### PR DESCRIPTION
## 概要

PR #1909 で入れたコメントに事実誤認がありました。**挙動は変えず、記述だけ**を直します。

```
書いていたこと: 「ルーティングに一致しないので 404 になり、apex 側の同じリクエストと同じ扱いになる」
実際:           パスがルートに一致すれば、そのページが返る
```

**404 は spec のスタブ（常に 404 を返す lambda）が返していた値**で、ルーティングの結果ではありませんでした。スタブの戻り値を本番の挙動として書いていました。

## 直した内容

`lib/rack/safe_host_redirect.rb`

```diff
-# 前提が崩れているものは、リダイレクトせず後段へ渡す。ルーティングに一致しないので
-# 404 になり、apex 側の同じリクエストと同じ扱いになる。
+# 前提が崩れているものは、リダイレクトせず後段へ渡す。apex 宛と同じ扱いになり、
+# パスがルートに一致すればその応答を、しなければ 404 を返す。
+# （Host が壊れていても応答は返る。このアプリは config.hosts を設定しておらず、
+#   Host の検証は元から行っていない。検証したいなら別の手当てが要る）
```

`spec/lib/rack/safe_host_redirect_spec.rb` にも、スタブの 404 を本番の応答と読み違えないよう一言添えました。

## 確認したこと

- [x] `bundle exec rspec spec` — 323 examples, 0 failures
- [x] コードの変更は無し（コメントのみ）

## 補足: 別途扱うもの

同じレビューで、**この PR とは無関係の既存の挙動**が 1 件見つかりました。

非 ASCII バイトを含む Host は、いまも 500 になります。原因はこのミドルウェアではなく、`og:url` に `request.url` をそのまま入れている箇所です。

```
ActionView::Template::Error: incompatible character encodings: UTF-8 and BINARY
  app/views/layouts/application.html.erb:21
```

修正前も 500 だったので新しい問題ではありません。直すなら `full_url`（`app/helpers/application_helper.rb`）で、Heroku が非 ASCII の Host を通すかを staging で確認してからが安全です。
