### PR TITLE
Set inactivated_at column to CoderDojo 蒲田

### DIFF
--- a/db/dojo_event_services.yml
+++ b/db/dojo_event_services.yml
@@ -254,10 +254,10 @@
   group_id: 14718
   url: https://coderdojo-komae.connpass.com/
 
-# 蒲田
+# 蒲田（2026-09-07 時点で inactive）
 #- dojo_id: 321
 #  name: connpass
-#  group_id: イベントが追加されたら group_id を取得してコメントアウトを外す
+#  group_id: 15065
 #  url: https://coderdojo-kamata.connpass.com/
 
 # 長野

--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -1368,6 +1368,8 @@
 - id: 321
   order: '131113'
   created_at: '2024-06-10'
+  inactivated_at: '2026-09-07'
+  note: 2026-09-07 https://coderdojo-kamata.connpass.com/
   name: 蒲田
   prefecture_id: 13
   url: https://coderdojo-kamata.connpass.com/


### PR DESCRIPTION
```diff
 - id: 321
   order: '131113'
   created_at: '2024-06-10'
+  inactivated_at: '2026-09-07'
+  note: 2026-09-07 https://coderdojo-kamata.connpass.com/
   name: 蒲田
```

```diff
-# 蒲田
+# 蒲田（2026-09-07 時点で inactive）
 #- dojo_id: 321
 #  name: connpass
-#  group_id: イベントが追加されたら group_id を取得してコメントアウトを外す
+#  group_id: 15065
 #  url: https://coderdojo-kamata.connpass.com/
```
