### PR TITLE
fix(helpers): Host が非 ASCII のときにページ全体が 500 になるのを直す

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,17 +8,29 @@ module ApplicationHelper
     end
   end
 
+  # Host ヘッダは検証していない (config.hosts 未設定) ため、非 ASCII の
+  # バイト列がそのまま Host に入ることがある。Puma が env に入れる HTTP_HOST は
+  # ASCII-8BIT で、request.url や *_url ヘルパーはそれを引き継ぐ。
+  # UTF-8 のビューに結合すると Encoding::CompatibilityError でページごと 500 になる。
+  #
+  # 入口は request.url だけではない。コントローラの @url、ビューの dojo_url /
+  # dojos_url など、Host を含む値は複数の経路から来る。全部がここを通るので、
+  # 個々の呼び出し元ではなくここで一度だけ落とす。
+  def sanitize_url(url)
+    url.to_s.dup.force_encoding(Encoding::UTF_8).scrub('')
+  end
+
   def full_url(page_url)
     # When URL is composed by Rails
     if page_url.empty?
       # Set og:url with request param
-      request.url
+      sanitize_url(request.url)
     elsif page_url.starts_with? '/'
       # Set og:url with given param
       'https://coderdojo.jp' + page_url
     else
       # 例: https://coderdojo.jp/...
-      page_url
+      sanitize_url(page_url)
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,4 +3,46 @@ require 'rails_helper'
 RSpec.describe ApplicationHelper, type: :helper do
   # News関連のメソッドはNewsモデルに移動しました
   # spec/models/news_spec.rb を参照
+
+  # og:url と Twitter カードの URL を組み立てる。
+  #
+  # == 経緯（2026/09/07）==
+  # Host ヘッダに非 ASCII のバイト列が入ると 500 になっていた。
+  #
+  #   ActionView::Template::Error: incompatible character encodings: UTF-8 and BINARY
+  #     app/views/layouts/application.html.erb:21
+  #
+  # Puma が env に入れる HTTP_HOST は ASCII-8BIT で、request.url もその
+  # エンコーディングを引き継ぐ。それを UTF-8 のビューに結合すると落ちる。
+  # このアプリは config.hosts を設定しておらず、Host は検証されない。
+  describe '#full_url' do
+    context '引数が空のとき' do
+      it 'リクエストの URL を返す' do
+        allow(helper).to receive(:request).and_return(double(url: 'https://coderdojo.jp/kata'))
+        expect(helper.full_url('')).to eq 'https://coderdojo.jp/kata'
+      end
+
+      it '非 UTF-8 のバイト列を含んでいても、ビューに埋め込める文字列を返す' do
+        broken = "https://www.coderdojo.jp\xFF/kata".dup.force_encoding(Encoding::ASCII_8BIT)
+        allow(helper).to receive(:request).and_return(double(url: broken))
+
+        result = helper.full_url('')
+        expect(result.encoding).to eq Encoding::UTF_8
+        expect(result).to be_valid_encoding
+        expect { +'' << result }.not_to raise_error
+      end
+    end
+
+    context '引数がパスのとき' do
+      it '本番のホストを補って返す' do
+        expect(helper.full_url('/kata')).to eq 'https://coderdojo.jp/kata'
+      end
+    end
+
+    context '引数が URL のとき' do
+      it 'そのまま返す' do
+        expect(helper.full_url('https://news.coderdojo.jp/')).to eq 'https://news.coderdojo.jp/'
+      end
+    end
+  end
 end

--- a/spec/requests/broken_host_spec.rb
+++ b/spec/requests/broken_host_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+# Host ヘッダに非 ASCII のバイト列が入ると、ページ全体が 500 になっていた。
+#
+#   ActionView::Template::Error: incompatible character encodings: UTF-8 and BINARY
+#     app/views/layouts/application.html.erb:21   ← og:url
+#
+# Puma が env に入れる HTTP_HOST は ASCII-8BIT で、request.url や *_url ヘルパーは
+# そのエンコーディングを引き継ぐ。UTF-8 のビューに結合すると落ちる。
+#
+# このアプリは config.hosts を設定しておらず Host を検証しないので、
+# 任意のホスト名がそのままレイアウトに反映される。
+#
+# == 1 ページだけ見ても足りない ==
+# 最初は /kata だけを検査していた。Host を含む値の入口は複数あり、
+# /kata が通っても他のページは落ちたままだった（8 ページ中 7 ページ）。
+#
+#   request.url を直接使う        /kata
+#   @url = request.url を渡す      /docs /news /events /podcasts
+#   *_url ヘルパーを使う           /dojos /stats /dojos/activity
+#
+# 経路ごとに 1 本ずつ置く。
+RSpec.describe 'Host ヘッダが壊れているリクエスト', type: :request do
+  BROKEN_HOST = "coderdojo.jp\xFF".dup.force_encoding(Encoding::ASCII_8BIT)
+
+  describe 'HTML ページ' do
+    %w[
+      /kata
+      /docs
+      /news
+      /events
+      /podcasts
+      /dojos
+      /stats
+      /dojos/activity
+    ].each do |path|
+      it "#{path} が 500 にならない" do
+        get path, headers: { 'HTTP_HOST' => BROKEN_HOST }
+
+        expect(response.status).not_to eq 500
+      end
+    end
+  end
+
+  # ロゴの絶対 URL を root_url から組み立てている
+  it '/dojos.json が 500 にならない' do
+    get '/dojos.json', headers: { 'HTTP_HOST' => BROKEN_HOST }
+
+    expect(response.status).not_to eq 500
+  end
+
+  # Rails は X-Forwarded-Host を無条件に採用するので、Host と同じ入口になる
+  it 'X-Forwarded-Host 経由でも 500 にならない' do
+    get '/docs', headers: { 'HTTP_X_FORWARDED_HOST' => BROKEN_HOST }
+
+    expect(response.status).not_to eq 500
+  end
+
+  it '通常のリクエストは変わらず 200' do
+    get '/kata'
+
+    expect(response.status).to eq 200
+  end
+end


### PR DESCRIPTION
## 概要

Host ヘッダに非 ASCII のバイト列が含まれると、**ページ全体が 500** になっていました。

```
ActionView::Template::Error: incompatible character encodings: UTF-8 and BINARY
  app/views/layouts/application.html.erb:21   ← og:url
```

## 何が起きているか

Puma が env に入れる `HTTP_HOST` は ASCII-8BIT で、`request.url` も `*_url` ヘルパーもそのエンコーディングを引き継ぎます。それを UTF-8 のビューに結合すると `Encoding::CompatibilityError` になります。

このアプリは `config.hosts` を設定しておらず Host を検証しないため、任意のホスト名がそのままレイアウトに反映されます。

## 入口が複数ある

最初は `request.url` だけを直しましたが、**8 ページ中 7 ページが落ちたまま**でした。

| 経路 | ページ |
|---|---|
| `request.url` を直接使う | `/kata` |
| `@url = request.url` を渡す | `/docs` `/news` `/events` `/podcasts` |
| `*_url` ヘルパーを使う | `/dojos` `/stats` `/dojos/activity` |

いずれも最終的に `full_url` を通るので、そこで一度だけ落とします。

```ruby
def sanitize_url(url)
  url.to_s.dup.force_encoding(Encoding::UTF_8).scrub('')
end
```

## テスト

`spec/requests/broken_host_spec.rb` に、**経路ごとに 1 本ずつ**置きました。

- HTML ページ 8 本（上の 3 経路すべてを含む）
- `/dojos.json`（ロゴの絶対 URL を `root_url` から組み立てている）
- `X-Forwarded-Host` 経由（Rails は無条件に採用するので Host と同じ入口）

## 確認したこと

- [x] 修正前に 8 ページ中 7 ページが落ちることを確認してから直した
- [x] `bundle exec rspec spec` — 338 examples, 0 failures

## この PR で直さないもの

存在しない `/docs/xxx` へのアクセスは、いまも `OpenRedirectError` になります。

```
Unsafe redirect to "http://coderdojo.jp\xFF/"
```

`redirect_to` は Host の正当性そのものを見るため、文字列の掃除では解けません。**Host を検証するかどうかは方針の判断**なので、`config.hosts` の設定とあわせて別に扱います。
