### PR TITLE
feat: CoderDojo 津和野の connpass グループを追加

### DIFF
--- a/db/dojo_event_services.yml
+++ b/db/dojo_event_services.yml
@@ -728,11 +728,16 @@
   group_id: 11027
   url: https://coderdojo-utsunomiya.doorkeeper.jp/
 
-# 津和野
+# 津和野（島根）- connpass に移行済み。
+# 記録保持のため、他の Dojo と同様に Doorkeeper のデータも保持しています。
 - dojo_id: 245
   name: doorkeeper
   group_id: 11024
   url: https://coderdojo-tsuwano.doorkeeper.jp/
+- dojo_id: 245
+  name: connpass
+  group_id: 15105
+  url: https://coderdojo-tsuwano.connpass.com/
 
 # 沖縄@補聴器のぴあ (Private)
 #- dojo_id: 244


### PR DESCRIPTION
CoderDojo 津和野は connpass に移行していますが、登録が Doorkeeper のままで近日開催のイベントが集約されていませんでした。

さいたま（dojo_id 9）と同じく、記録保持のため Doorkeeper のデータは残したまま connpass を追加します。

```diff
-# 津和野
+# 津和野（島根）- connpass に移行済み。
+# 記録保持のため、他の Dojo と同様に Doorkeeper のデータも保持しています。
 - dojo_id: 245
   name: doorkeeper
   group_id: 11024
   url: https://coderdojo-tsuwano.doorkeeper.jp/
+- dojo_id: 245
+  name: connpass
+  group_id: 15105
+  url: https://coderdojo-tsuwano.connpass.com/
```

`rails dojo_event_services:upsert` を実行し、両方が並存すること（`Deleted: 0`）を確認しました。
