### PR TITLE
feat(config): 本番で Host ヘッダを検証する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
     end
   end
 
-  # Host ヘッダは検証していない (config.hosts 未設定) ため、非 ASCII の
+  # 本番は config.hosts で不正な Host を 403 にするが、それが無い環境では非 ASCII の
   # バイト列がそのまま Host に入ることがある。Puma が env に入れる HTTP_HOST は
   # ASCII-8BIT で、request.url や *_url ヘルパーはそれを引き継ぐ。
   # UTF-8 のビューに結合すると Encoding::CompatibilityError でページごと 500 になる。

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,9 +89,26 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
+  # Heroku に登録しているドメイン。下の 2 つの設定で同じ集合を使う。
+  # ズレると www へのリダイレクトが 403 になるため、1 箇所で定義する。
+  canonical_host = 'coderdojo.jp'
+  alias_hosts    = %w[www.coderdojo.jp coderdojo-japan.herokuapp.com]
+
+  # Host ヘッダを検証する。
+  #
+  # Heroku のルータは「登録ドメイン + `:` 以降は何でも」を通すため、
+  # `Host: coderdojo.jp:abc` のような値がアプリまで届く。実際に
+  # /docs/<存在しない> が 500 になっていた（2026-09-07 に本番で確認）。
+  # X-Forwarded-Host も検証対象になるので、og:url に任意のホストが
+  # 反映される状態も閉じる。
+  #
+  # 上のヘルスチェック用の除外は付けない。/up のルートが存在しないため、
+  # 付けても意味のないバイパスが増えるだけになる。
+  config.hosts = [canonical_host, *alias_hosts]
+
   # Redirect if not in correct domains
   config.middleware.use Rack::SafeHostRedirect, {
-    %w(coderdojo-japan.herokuapp.com www.coderdojo.jp) => 'coderdojo.jp'
+    alias_hosts => canonical_host
   }
 
   # Mailer settings

--- a/lib/rack/safe_host_redirect.rb
+++ b/lib/rack/safe_host_redirect.rb
@@ -16,8 +16,10 @@ module Rack
   #
   # 前提が崩れているものは、リダイレクトせず後段へ渡す。apex 宛と同じ扱いになり、
   # パスがルートに一致すればその応答を、しなければ 404 を返す。
-  # （Host が壊れていても応答は返る。このアプリは config.hosts を設定しておらず、
-  #   Host の検証は元から行っていない。検証したいなら別の手当てが要る）
+  # 本番は config.hosts が Host と X-Forwarded-Host を検証するが、
+  # Rack::Request#host はそれより優先して Forwarded ヘッダ (RFC 7239) を読む。
+  # config.hosts は Forwarded を見ないので、ここに来る host が正規とは限らない。
+  # 実測: Host: coderdojo.jp + Forwarded: host="www.coderdojo.jp:" で host は nil になる。
   #
   # rescue で super を包まない。super には「リダイレクトしない場合の @app.call(env)」も
   # 含まれるため、後段が同じ例外を投げると後段を 2 回呼ぶ。POST の副作用や

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApplicationHelper, type: :helper do
   #
   # Puma が env に入れる HTTP_HOST は ASCII-8BIT で、request.url もその
   # エンコーディングを引き継ぐ。それを UTF-8 のビューに結合すると落ちる。
-  # このアプリは config.hosts を設定しておらず、Host は検証されない。
+  # 本番は config.hosts で 403 にするが、それが無い環境での防御を見る。
   describe '#full_url' do
     context '引数が空のとき' do
       it 'リクエストの URL を返す' do

--- a/spec/requests/broken_host_spec.rb
+++ b/spec/requests/broken_host_spec.rb
@@ -8,8 +8,8 @@ require 'rails_helper'
 # Puma が env に入れる HTTP_HOST は ASCII-8BIT で、request.url や *_url ヘルパーは
 # そのエンコーディングを引き継ぐ。UTF-8 のビューに結合すると落ちる。
 #
-# このアプリは config.hosts を設定しておらず Host を検証しないので、
-# 任意のホスト名がそのままレイアウトに反映される。
+# 本番は config.hosts で不正な Host を 403 にする。この spec は test 環境
+# (config.hosts が空) で動くので、その手前の防御が効いていることを見る。
 #
 # == 1 ページだけ見ても足りない ==
 # 最初は /kata だけを検査していた。Host を含む値の入口は複数あり、


### PR DESCRIPTION
## 概要

本番で Host ヘッダを検証します（`config.hosts`）。

## なぜ必要か

Heroku のルータは **「登録ドメイン + `:` 以降は何でも」** を通します。そのため `Host: coderdojo.jp:abc` のような値がアプリまで届きます。

**いまも本番で 500 を踏めます**（2026-09-07 に確認）。

```
curl -H "Host: coderdojo.jp:abc" https://coderdojo.jp/docs/no-such-doc   → 500
curl -H "Host: coderdojo.jp"     https://coderdojo.jp/docs/no-such-doc   → 302
```

`redirect_to root_url` が壊れた Host で `Location` を組めず `OpenRedirectError` になります。文字列の掃除では解けない経路です。

あわせて **`X-Forwarded-Host` が素通し**で、`og:url` に任意のホストが反映されます。

```
curl -H "X-Forwarded-Host: evil.example" https://coderdojo.jp/kata
  → <meta property="og:url" content="https://evil.example/kata">
```

PR #1907 / #1909 / #1912 は「届いたあとに壊れないようにする」個別対処で、4 件目が残っていました。ここで族ごと止めます。

## 設定

許可するのは Heroku に登録している 3 ドメインだけです（`heroku domains` で確認）。

```ruby
canonical_host = 'coderdojo.jp'
alias_hosts    = %w[www.coderdojo.jp coderdojo-japan.herokuapp.com]

config.hosts = [canonical_host, *alias_hosts]

config.middleware.use Rack::SafeHostRedirect, {
  alias_hosts => canonical_host
}
```

`SafeHostRedirect` と同じ集合を使うため、**1 箇所で定義**しています。ここがズレると www へのアクセスが 403 になります。

## 検証（本番と同じスタックを組んで実行）

| Host | 結果 |
|---|---|
| `coderdojo.jp` | 通る |
| `www.coderdojo.jp` | **301 → coderdojo.jp**（リダイレクトは生きている） |
| `coderdojo-japan.herokuapp.com` | 301 |
| `CODERDOJO.JP`（大文字） | 通る |
| `coderdojo.jp:443` | 通る |
| `coderdojo.jp:` / `:abc` / 非 ASCII / 末尾ドット | 403 |
| `evil.example` | 403 |
| `X-Forwarded-Host: evil.example` | 403 |
| `Host: coderdojo.jp:abc` の `/docs/<存在しない>` | **500 → 403** |

`bundle exec rspec spec` — 338 examples, 0 failures

## 書かなかったこと

**「DNS rebinding 対策」とは書いていません。** 未登録の Host は Heroku のルータが先に落とすため、実態と合いません（実測で `evil.example` は 404、非 ASCII 単体は 503）。この設定が塞ぐのは、ルータを通り抜けた `:` 以降のゴミと `X-Forwarded-Host` です。

## staging には設定しない

review app はホスト名が動的（`<app>-pr-<番号>.herokuapp.com`）で列挙できません。現在 review app は 0 件、`automatic_review_apps` も無効ですが、将来有効にしたときに全部 403 になるのを避けます。

## マージ後に確認すること

- [x] デプロイ完了を待つ
- [x] `curl -I https://coderdojo.jp/` が 200
- [x] `curl -I https://www.coderdojo.jp/` が 301
- [x] `curl -o /dev/null -w "%{http_code}" -H "Host: coderdojo.jp:abc" https://coderdojo.jp/docs/no-such-doc` が 403

失敗した場合は revert PR で戻します。

## 本番での実測（2026-09-07、デプロイ後）

設定は全リクエストに効くため、上の 4 項目に加えて `/dojos` と `/dojos.json` も確認しました。

| 対象 | 結果 |
|---|---|
| `coderdojo.jp/` | 200 |
| `www.coderdojo.jp/` | 301 |
| `coderdojo.jp/kata` | 200 |
| `coderdojo.jp/dojos` | 200 |
| `coderdojo.jp/dojos.json` | 200 |
| `Host: coderdojo.jp:abc` の `/docs/no-such-doc` | **403**（修正前は 500） |
| `X-Forwarded-Host: evil.example` | **403** |

