### PR TITLE
fix(kata): 紙屋町・広島の教材リンクを保存版に差し替える

### DIFF
--- a/app/views/docs/kata.html.erb
+++ b/app/views/docs/kata.html.erb
@@ -382,8 +382,8 @@
 	    <p>by <a href="https://coderdojoowari.org/">CoderDojo 尾張</a></p>
 	  </li>
 	  <li>
-	    <h4 id='learn-scratch-ninja'><a href="https://www.coderdojo-hiroshima.com/wp-content/uploads/2019/01/coderdojo-kamiyacho-beginner.pdf">プログラミング入門</a> + <a href="https://scratch.mit.edu/projects/119995141/">忍者テンプレート</a></h4>
-	    <p>by <a href="https://www.coderdojo-hiroshima.com/">CoderDojo 紙屋町</a></p>
+	    <h4 id='learn-scratch-ninja'><a href="https://web.archive.org/web/20201019125120/https://www.coderdojo-hiroshima.com/wp-content/uploads/2019/01/coderdojo-kamiyacho-beginner.pdf">プログラミング入門</a> + <a href="https://scratch.mit.edu/projects/119995141/">忍者テンプレート</a></h4>
+	    <p>by <a href="https://web.archive.org/web/20210115182553/http://www.coderdojo-hiroshima.com/">CoderDojo 紙屋町</a></p>
 	  </li>
 	  <li>
 	    <h4 id='learn-scratch-collect-gems'><a href="https://coderdojo-hommachi.github.io/assets/pdf/collect_gems.pdf">Collect gems - Learn Scratch</a></h4>
@@ -467,12 +467,12 @@
 	    <p>by 松浦<small><small>さん</small></small> @ <a href="https://coderdojo-ise.jimdo.com/">CoderDojo 伊勢</a></p>
 	  </li>
 	  <li>
-	    <h4 id='learn-microbit-game'><a href="https://www.coderdojo-hiroshima.com/学習ヒント/microbitでゲームを作る">micro:bit でゲームを作る</a></h4>
-	    <p>by 小川<small><small>さん</small></small> @ <a href="https://www.coderdojo-hiroshima.com/">CoderDojo 紙屋町</a></p>
+	    <h4 id='learn-microbit-game'><a href="https://web.archive.org/web/20210115182531/https://www.coderdojo-hiroshima.com/%E5%AD%A6%E7%BF%92%E3%83%92%E3%83%B3%E3%83%88/microbit%E3%81%A7%E3%82%B2%E3%83%BC%E3%83%A0%E3%82%92%E4%BD%9C%E3%82%8B">micro:bit でゲームを作る</a></h4>
+	    <p>by 小川<small><small>さん</small></small> @ <a href="https://web.archive.org/web/20210115182553/http://www.coderdojo-hiroshima.com/">CoderDojo 紙屋町</a></p>
 	  </li>
 	  <li>
-	    <h4 id='learn-microbit-hiragana'><a href="https://www.coderdojo-hiroshima.com/学習ヒント/microbitでひらがなを表示させてみよう">micro:bit でひらがなを表示させて見よう</a></h4>
-	    <p>by ナカオク<small><small>さん</small></small> @ <a href="https://www.coderdojo-hiroshima.com/">CoderDojo 紙屋町</a></p>
+	    <h4 id='learn-microbit-hiragana'><a href="https://web.archive.org/web/20210115173244/https://www.coderdojo-hiroshima.com/%E5%AD%A6%E7%BF%92%E3%83%92%E3%83%B3%E3%83%88/microbit%E3%81%A7%E3%81%B2%E3%82%89%E3%81%8C%E3%81%AA%E3%82%92%E8%A1%A8%E7%A4%BA%E3%81%95%E3%81%9B%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86">micro:bit でひらがなを表示させて見よう</a></h4>
+	    <p>by ナカオク<small><small>さん</small></small> @ <a href="https://web.archive.org/web/20210115182553/http://www.coderdojo-hiroshima.com/">CoderDojo 紙屋町</a></p>
 	  </li>
 	  <li>
 	    <h4 id='learn-microbit-ble'><a href="https://memakura.github.io/s2microbit-ble/">Smi:bit / スマイビー (Scratch 2.0 対応)</a></h4>
@@ -556,8 +556,8 @@
 	    </p>
 	  </li>
 	  <li>
-	    <h4 id='learn-basics-website'><a href="http://www.coderdojo-hiroshima.com/My_first_website_ja.pdf">はじめてのWebサイト</a></h4>
-	    <p>by 鼠屋<small><small>さん</small></small> @ <a href="https://www.coderdojo-hiroshima.com/">CoderDojo 広島</a></p>
+	    <h4 id='learn-basics-website'><a href="https://web.archive.org/web/20201027211238/http://www.coderdojo-hiroshima.com/My_first_website_ja.pdf">はじめてのWebサイト</a></h4>
+	    <p>by 鼠屋<small><small>さん</small></small> @ <a href="https://web.archive.org/web/20210115182553/http://www.coderdojo-hiroshima.com/">CoderDojo 広島</a></p>
 	  </li>
 	  <li>
 	    <h4 id='learn-basics-bistro-programming'><a href="https://bistro-programming.github.io/">ビストロプログラミング</a></h4>


### PR DESCRIPTION
## 概要

`coderdojo-hiroshima.com` が **別ドメイン (`akunbos.live`) に転送される状態**になっています。ドメイン失効後に第三者が取得したものとみられます。

`/kata` から辿る教材 4 本とトップページへのリンク 4 本、**計 8 箇所**が対象です。子どもが学習資料として開くと、無関係なサイトに飛びます。

```
https://www.coderdojo-hiroshima.com/                          → akunbos.live
https://www.coderdojo-hiroshima.com/wp-content/uploads/...pdf → akunbos.live
https://www.coderdojo-hiroshima.com/学習ヒント/microbit...    → akunbos.live
http://www.coderdojo-hiroshima.com/My_first_website_ja.pdf    → akunbos.live
```

**転送先の内容は確認していません。** 何が置かれているかに関わらず、CoderDojo の教材として案内し続ける状態を解消します。

## 対象の教材

| 見出し | 提供 |
|---|---|
| プログラミング入門 | CoderDojo 紙屋町 |
| micro:bit でゲームを作る | CoderDojo 紙屋町 |
| micro:bit でひらがなを表示させて見よう | CoderDojo 紙屋町 |
| はじめてのWebサイト | CoderDojo 広島 |

## 直し方

5 種類とも Internet Archive に残っていたので、そこを指すようにしました。差し替え後の 5 URL が **200 で到達する**ことを確認済みです。

滑川の `note`（PR #1911）と同じ方針です。

## 実装上の注意

置換は `href` の**属性値が完全一致**したときだけ行っています。部分文字列で置換すると、トップページの URL が PDF の URL の一部でもあるため、差し替え済みの URL の内側にも当たって二重に入れ子になります（実際に一度壊しました）。

```
❌ https://web.archive.org/web/20201019125120/https://web.archive.org/web/20210115182553/http://...
```

## 確認したこと

- [x] 差し替え後の 5 URL が 200 で到達する
- [x] 二重の入れ子が発生していない
- [x] `bundle exec rspec spec` — 338 examples, 0 failures

## 補足: 他にも確認しました

`/kata` の外部リンク **312 件**を機械的に確認しました（PR #1906 に「別途行う」と書いた分）。

| 分類 | 件数 |
|---|---|
| 正常 | 280 |
| 404 / 401 | 9 |
| 接続不可 (000) | 9 |
| 403 / 500 | 14（connpass・Amazon の bot 判定。ブラウザでは開く） |

**この PR は転送の乗っ取りだけを扱います。** 残る 18 件は 1 件ずつ判断が要る（代替 URL を探す / 保存版にする / 記述ごと削る）ため、別途扱います。
