### PR TITLE
fix(docs): 紙屋町・広島へのリンクを保存版に差し替える

### DIFF
--- a/public/docs/how-to-change-dojo-name.md
+++ b/public/docs/how-to-change-dojo-name.md
@@ -29,7 +29,7 @@ CoderDojo では、次の手続きで Dojo 名を変更することができま�
 
 ## 変更例: CoderDojo 広島 → CoderDojo 紙屋町
 
-CoderDojo の名称が変更した例の1つに [CoderDojo 紙屋町](https://www.coderdojo-hiroshima.com/) (旧: CoderDojo 広島) があります。
+CoderDojo の名称が変更した例の1つに [CoderDojo 紙屋町](https://web.archive.org/web/20260519005549/https://www.coderdojo-hiroshima.com/) (旧: CoderDojo 広島) があります。
 
 当時まだ広島県内の CoderDojo が多くなかったときは「CoderDojo 広島」という名称で活動していましたが、現在は広島県内の CoderDojo も徐々に増えてきました。
 
@@ -42,7 +42,7 @@ CoderDojo の名称が変更した例の1つに [CoderDojo 紙屋町](https://ww
 というメッセージと共に、CoderDojo 広島から CoderDojo 紙屋町に名称が変更されました。
 
 参考: CoderDojo紙屋町に名称変更しました！ − CoderDojo紙屋町   
-[https://www.coderdojo-hiroshima.com/説明会/CoderDojo紙屋町に名称変更しました！](https://www.coderdojo-hiroshima.com/%E8%AA%AC%E6%98%8E%E4%BC%9A/coderdojo%E7%B4%99%E5%B1%8B%E7%94%BA%E3%81%AB%E5%90%8D%E7%A7%B0%E5%A4%89%E6%9B%B4%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%EF%BC%81)
+[https://www.coderdojo-hiroshima.com/説明会/CoderDojo紙屋町に名称変更しました！](https://web.archive.org/web/20260311163658/https://www.coderdojo-hiroshima.com/archives/1225)
 
 上記は１つの事例ではありますが、皆さんが Dojo 名の変更を検討する際のご参考になれば幸いです ;)
 

--- a/public/docs/naming-guidelines.md
+++ b/public/docs/naming-guidelines.md
@@ -52,7 +52,7 @@ CoderDojo の名前には、`道場名 @ スポンサー名` または `道場�
 
 <br>
 
-CoderDojo コミュニティの１つに [CoderDojo 紙屋町](https://www.coderdojo-hiroshima.com/) (旧: CoderDojo 広島) があります。当時、CoderDojo コミュニティが今ほどの規模ではなかった頃は「`CoderDojo 広島`」という名称で活動していましたが、その後、広島県内で他の Dojo も立ち上がっていきました。
+CoderDojo コミュニティの１つに [CoderDojo 紙屋町](https://web.archive.org/web/20260519005549/https://www.coderdojo-hiroshima.com/) (旧: CoderDojo 広島) があります。当時、CoderDojo コミュニティが今ほどの規模ではなかった頃は「`CoderDojo 広島`」という名称で活動していましたが、その後、広島県内で他の Dojo も立ち上がっていきました。
 
 ![広島の CoderDojo コミュニティ（当時）](/img/dojos-in-hiroshima.png)
 
@@ -62,9 +62,9 @@ CoderDojo コミュニティの１つに [CoderDojo 紙屋町](https://www.coder
 
 というメッセージと共に、CoderDojo 広島から CoderDojo 紙屋町に名称が変更されました。
 
-[![全文のスクショ](https://i.gyazo.com/4fcbe0cac2e8f0b1dcbbb24c2bc2bbf7.png)](https://www.coderdojo-hiroshima.com/archives/1225)
+[![全文のスクショ](https://i.gyazo.com/4fcbe0cac2e8f0b1dcbbb24c2bc2bbf7.png)](https://web.archive.org/web/20260311163658/https://www.coderdojo-hiroshima.com/archives/1225)
 
-参考記事: [CoderDojo紙屋町に名称変更しました！ − CoderDojo紙屋町](https://www.coderdojo-hiroshima.com/archives/1225)
+参考記事: [CoderDojo紙屋町に名称変更しました！ − CoderDojo紙屋町](https://web.archive.org/web/20260311163658/https://www.coderdojo-hiroshima.com/archives/1225)
 
 上記の事例にあるように **なるべく具体的な地域名をご使用いただけると近隣地域に新たな Dojo が立ち上げやすくなります** ので、よければ近隣に他の Dojo を立ち上げやすくなるような命名だと大変幸いです。
 

--- a/public/podcasts/5.md
+++ b/public/podcasts/5.md
@@ -40,7 +40,7 @@
 ---------------
 
 - [CoderDojo 札幌](https://www.facebook.com/coderdojo.sapporo/)
-- [CoderDojo 広島](http://www.coderdojo-hiroshima.com/)
+- [CoderDojo 広島](https://web.archive.org/web/20260519005549/https://www.coderdojo-hiroshima.com/)
 - [CoderDojo 岡山 岡南](http://coderdojo-konan.media-interesting.info/)
 
 

--- a/public/podcasts/8.md
+++ b/public/podcasts/8.md
@@ -32,7 +32,7 @@
 
 ### オマケ: CoderDojo コミュニティの特徴
 
-引用元: [CoderDojoは人が集まる◯◯である説](https://www.slideshare.net/MasanoriNezumiya/coderdojo-79835899/1) - [CoderDojo 広島](http://www.coderdojo-hiroshima.com/)
+引用元: [CoderDojoは人が集まる◯◯である説](https://www.slideshare.net/MasanoriNezumiya/coderdojo-79835899/1) - [CoderDojo 広島](https://web.archive.org/web/20260519005549/https://www.coderdojo-hiroshima.com/)
 
 ![CoderDojo の仕組み１](./dojo-figure-1.png)
 

--- a/public/podcasts/9.md
+++ b/public/podcasts/9.md
@@ -1,7 +1,7 @@
 CoderDojo 紙屋町 (旧: CoderDojo 広島) の活動をされている[鼠屋さん](https://www.facebook.com/masanori.nezumiya)、[安藤さん](https://www.facebook.com/ando.mitsuaki)と、広島における活動や DojoBudokai の話、子どもと接するときに考えていることなどについてお話してきました。
 
 DojoBudokai 2017 - CoderDojo 広島   
-[http://www.coderdojo-hiroshima.com/budokai/2017-fall](http://www.coderdojo-hiroshima.com/budokai/2017-fall)
+[http://www.coderdojo-hiroshima.com/budokai/2017-fall](https://web.archive.org/web/20260119053506/http://www.coderdojo-hiroshima.com/budokai/2017-fall)
 
 <div class='episode-cover'>
   <a href='https://www.youtube.com/watch?v=c9CZqYjTDGw&list=PL94GDfaSQTmJxxnapafkApHYgQUJ6ABUU&index=9'
@@ -17,8 +17,8 @@ DojoBudokai 2017 - CoderDojo 広島
 
 ## Shownote
 
-- [CoderDojo 広島](http://www.coderdojo-hiroshima.com/)
-- [DojoBudokai](http://www.coderdojo-hiroshima.com/budokai)
+- [CoderDojo 広島](https://web.archive.org/web/20260519005549/https://www.coderdojo-hiroshima.com/)
+- [DojoBudokai](https://web.archive.org/web/20260119045523/https://www.coderdojo-hiroshima.com/budokai)
 - [CoderDojo 広島を知ろう！](https://www.slideshare.net/kamera25/coderdojo-73712494)
 
 -----------


### PR DESCRIPTION
## 概要

PR #1915 では `/kata` だけを直しましたが、**同じドメインへのリンクが他の 5 ファイル・10 箇所に残っていました**。いずれも公開中です。

| ページ | 箇所 |
|---|---|
| `/docs/how-to-change-dojo-name` | 2 |
| `/docs/naming-guidelines` | 3 |
| `/podcasts/5` | 1 |
| `/podcasts/8` | 1 |
| `/podcasts/9` | 3 |

`coderdojo-hiroshima.com` は今年 5〜7 月に第三者の手に渡っており、転送先も `akunbos.live` から `mizu-ame.com` に変わっています。**転送先の内容は確認していません。**

## 差し替え先の選び方

Internet Archive の保存版です。**乗っ取り後の保存版を選ばないよう、4 件とも本文を確認しました**（タイトルと本文中の `CoderDojo` の出現回数）。

```
2026-05-19  CoderDojo紙屋町           ← 乗っ取り前の最終
2026-07-06  （別の内容・338 bytes）
```

日付だけで選ぶと後者を掴みます。

| 元の URL | 差し替え先の保存版 |
|---|---|
| `/` (トップ) | 2026-05-19 |
| `/archives/1225` | 2026-03-11 |
| `/説明会/CoderDojo紙屋町に名称変更しました！` | 2026-03-11（同じ記事の `/archives/1225`） |
| `/budokai` | 2026-01-19 |
| `/budokai/2017-fall` | 2026-01-19 |

`/説明会/…` は保存版が無かったため、**同じ記事の別 URL** を指すようにしました。両者が同じ記事であることは本文で確認しています。

## 実装上の注意

置換は `](URL)` の**完全一致**で行っています。`http://…/` は `http://…/budokai` の部分文字列なので、境界を含めないと入れ子になります（PR #1915 で一度壊しました）。

## 確認したこと

- [x] 差し替え後の 4 URL が 200 で到達する
- [x] 乗っ取られたドメインへの直リンクが 0 件
- [x] 入れ子が 0 件
- [x] `bundle exec rspec spec` — 338 examples, 0 failures

## 残る 2 箇所（この PR では変えていません）

リンク先は保存版にしましたが、**表示されている文字列が旧 URL のまま**です。クリックはできませんが、コピーはできます。

```
public/podcasts/9.md:4                     [http://www.coderdojo-hiroshima.com/budokai/2017-fall](…)
public/docs/how-to-change-dojo-name.md:45  [https://www.coderdojo-hiroshima.com/説明会/…](…)
```

どちらも「当時の URL がこれだった」という記録として読めるため、そのままにしています。書き換えるべきならお知らせください。
