### PR TITLE
fix(partners): Hay未来の税理士法人のリンクを新しいサイトへ差し替える

### DIFF
--- a/app/views/shared/_partners.html.erb
+++ b/app/views/shared/_partners.html.erb
@@ -17,7 +17,7 @@
   <li style="margin: 20px auto;"><%= link_to lazy_image_tag('/partners/esa.webp', alt: 'esa LLC', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'ドキュメント共有サービスの提供'), 'https://docs.esa.io/posts/239', target: "_blank" %></li>
 
   <li style="margin: 20px auto;"><%= link_to lazy_image_tag('/partners/sakura-internet.png', alt: 'さくらインターネット', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'サーバー環境（クラウド）の提供'), 'https://www.sakura.ad.jp/information/pressreleases/2017/07/20/90191/', target: "_blank" %></li>
-  <li style="margin: 20px auto;"><%= link_to lazy_image_tag('/partners/hay-kaikei.png', alt: 'Hay未来の税理士法人', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'CoderDojo Japan の会計支援'), 'http://www.hay-kaikei.com/', target: "_blank" %></li>
+  <li style="margin: 20px auto;"><%= link_to lazy_image_tag('/partners/hay-kaikei.png', alt: 'Hay未来の税理士法人', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'CoderDojo Japan の会計支援'), 'https://www.mirai-no.co.jp/', target: "_blank" %></li>
 
   <li style="margin: 20px auto 30px;"><%= link_to lazy_image_tag('/partners/techsoup-japan.png', alt: 'TechSoup Japan', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'G Suite などの寄贈申請の支援'), 'https://news.coderdojo.jp/2019/03/03/google-for-nonprofits-via-techsoup-japan/', target: "_blank" %></li>
   <li style="margin: 20px auto 30px;"><%= link_to lazy_image_tag('/partners/progate.png', alt: 'Progate', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'プログラミング学習環境の支援'), 'https://news.coderdojo.jp/2018/10/29/プログラミング学習のprogate、全国のcoderdojoへ法人プラン/', target: "_blank" %></li>


### PR DESCRIPTION
## 概要

`hay-kaikei.com` は**証明書が 2022-11-24 に失効**しており、`http` でアクセスしても `https` へ転送されるため、訪問者のブラウザに全画面の警告が出る状態でした。

```
subject=CN=www.hay-kaikei.com
notAfter=Nov 24 10:42:54 2022 GMT
```

ヘッドレスブラウザでも再現します（`net::ERR_CERT_DATE_INVALID`）。

**パートナー欄はすべてのページに表示される**ため、露出が広い箇所です。

## 差し替え先

`https://www.mirai-no.co.jp/` — 法人名は「Hay未来の税理士法人」のままのため、`alt` は変更していません。

- HTTP 200 で到達する
- 証明書は有効（2026-08-26 発行）
- `mirai-no.co.jp` も同じ場所へ転送される

## 確認したこと

- [x] 新しい URL が 200 で到達する
- [x] 証明書が有効
- [x] `hay-kaikei.com` の参照が 0 件
- [x] `bundle exec rspec spec` — 338 examples, 0 failures

画像ファイル名（`public/partners/hay-kaikei.png` / `.webp`）は、法人名が同じため変更していません。
