### PR TITLE
fix(spec): テストで作る道場の ID が実在の ID と衝突しないようにする

### DIFF
--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -1,18 +1,5 @@
 class DojosController < ApplicationController
 
-  # 開催日を共有している道場 (借りる側の ID => 貸す側の ID)。
-  # 借りる側はイベントサービスを登録していないため、group_id からは導けない。
-  #
-  # ここに書いた ID は、テストで作る道場と衝突すると無関係な開催日が混ざる。
-  # 衝突しないことは spec/models/dojo_factory_spec.rb で守っている。
-  SHARED_EVENT_DATE_DOJOS = {
-     36 =>  35, # 生駒は奈良の開催日を参照 (同じ connpass)
-    294 =>  35, # 平群は奈良の開催日を参照 (同じ connpass)
-    112 =>  23, # 南柏は柏の開催日を参照 (同じイベントサービス)
-    311 =>  23, # 柏の葉は柏の開催日を参照 (同じイベントサービス)
-    106 => 205, # 宜野湾は浦添の開催日を参照 (同じ主催者)
-  }.freeze
-
   # GET /dojos[.html|.json|.csv]
   def index
     # yearパラメータがある場合は、その年末時点でアクティブだった道場に絞り込む
@@ -142,8 +129,17 @@ class DojosController < ApplicationController
       }
     end
 
-    # 開催日を共有している道場に、貸す側の開催日を反映する
-    SHARED_EVENT_DATE_DOJOS.each { |target_id, source_id| sync_event_date(target_id, source_id) }
+    # 同じイベントサービスを共有している道場の開催日を同期
+    # 生駒 (ID: 36) と平群 (ID: 294) は奈良 (ID: 35) と同じ connpass を使用
+    sync_event_date(36,  35) # 生駒は奈良の開催日を参照
+    sync_event_date(294, 35) # 平群は奈良の開催日を参照
+
+    # 南柏 (ID: 112) と柏の葉 (ID: 311) は柏 (ID: 23) と同じイベントサービスを使用
+    sync_event_date(112, 23) # 南柏は、柏の開催日を参照
+    sync_event_date(311, 23) # 柏の葉は柏の開催日を参照
+
+    # 宜野湾 (ID: 106) は浦添 (ID: 205) と同じ主催者で運営
+    sync_event_date(106, 205) # 宜野湾は浦添の開催日を参照
 
     # アクティブな道場と非アクティブな道場を分けてソート
     active_dojos   = @latest_event_by_dojos.select { |d| d[:is_active] }

--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -1,5 +1,18 @@
 class DojosController < ApplicationController
 
+  # 開催日を共有している道場 (借りる側の ID => 貸す側の ID)。
+  # 借りる側はイベントサービスを登録していないため、group_id からは導けない。
+  #
+  # ここに書いた ID は、テストで作る道場と衝突すると無関係な開催日が混ざる。
+  # 衝突しないことは spec/models/dojo_factory_spec.rb で守っている。
+  SHARED_EVENT_DATE_DOJOS = {
+     36 =>  35, # 生駒は奈良の開催日を参照 (同じ connpass)
+    294 =>  35, # 平群は奈良の開催日を参照 (同じ connpass)
+    112 =>  23, # 南柏は柏の開催日を参照 (同じイベントサービス)
+    311 =>  23, # 柏の葉は柏の開催日を参照 (同じイベントサービス)
+    106 => 205, # 宜野湾は浦添の開催日を参照 (同じ主催者)
+  }.freeze
+
   # GET /dojos[.html|.json|.csv]
   def index
     # yearパラメータがある場合は、その年末時点でアクティブだった道場に絞り込む
@@ -129,17 +142,8 @@ class DojosController < ApplicationController
       }
     end
 
-    # 同じイベントサービスを共有している道場の開催日を同期
-    # 生駒 (ID: 36) と平群 (ID: 294) は奈良 (ID: 35) と同じ connpass を使用
-    sync_event_date(36,  35) # 生駒は奈良の開催日を参照
-    sync_event_date(294, 35) # 平群は奈良の開催日を参照
-
-    # 南柏 (ID: 112) と柏の葉 (ID: 311) は柏 (ID: 23) と同じイベントサービスを使用
-    sync_event_date(112, 23) # 南柏は、柏の開催日を参照
-    sync_event_date(311, 23) # 柏の葉は柏の開催日を参照
-
-    # 宜野湾 (ID: 106) は浦添 (ID: 205) と同じ主催者で運営
-    sync_event_date(106, 205) # 宜野湾は浦添の開催日を参照
+    # 開催日を共有している道場に、貸す側の開催日を反映する
+    SHARED_EVENT_DATE_DOJOS.each { |target_id, source_id| sync_event_date(target_id, source_id) }
 
     # アクティブな道場と非アクティブな道場を分けてソート
     active_dojos   = @latest_event_by_dojos.select { |d| d[:is_active] }

--- a/spec/factories/dojos.rb
+++ b/spec/factories/dojos.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :dojo do
+    # ID は DB のシーケンスに任せる。開始値は spec/rails_helper.rb で
+    # 実在の道場より大きい値に進めている（→ spec/models/dojo_factory_spec.rb）。
     name          { 'dojo name' }
     email         { '' }
     description   { 'description' }
@@ -11,7 +13,7 @@ FactoryBot.define do
     order         { 131001 }
     # デフォルトはアクティブ（inactivated_at: nil）
     inactivated_at { nil }
-    
+
     # 非アクティブなDojoを作成するためのtrait
     trait :inactive do
       inactivated_at { Time.current }

--- a/spec/models/dojo_factory_spec.rb
+++ b/spec/models/dojo_factory_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+# DojosController は開催日を共有している道場を ID の即値で束ねている
+# (SHARED_EVENT_DATE_DOJOS)。テストで作る道場がその ID を引き当てると、
+# 無関係な道場の開催日とリンクが行に混ざる。
+#
+# 採番の開始値は spec/rails_helper.rb の before(:suite) で進めている。
+# その仕組みが外れたことを、ここで検出する。
+RSpec.describe 'テストで作る道場の ID' do
+  it '開催日を共有している道場の ID と衝突しない' do
+    synced_ids = DojosController::SHARED_EVENT_DATE_DOJOS.to_a.flatten
+
+    expect(create(:dojo).id).to be > synced_ids.max
+  end
+
+  it '実在する道場の ID と衝突しない' do
+    max_real_id = Dojo.load_attributes_from_yaml.map { |dojo| dojo['id'].to_i }.max
+
+    expect(create(:dojo).id).to be > max_real_id
+  end
+end

--- a/spec/models/dojo_factory_spec.rb
+++ b/spec/models/dojo_factory_spec.rb
@@ -1,32 +1,29 @@
 require 'rails_helper'
 
-# DojosController は開催日を共有している道場を ID の即値で束ねている
-# (SHARED_EVENT_DATE_DOJOS)。テストで作る道場がその ID を引き当てると、
+# DojosController#activity は開催日を共有する道場を sync_event_date に
+# ID の即値で渡している。テストで作る道場がその ID を引き当てると、
 # 無関係な道場の開催日とリンクが行に混ざる。
 #
 # 採番の開始値は spec/rails_helper.rb の TEST_DOJO_ID_START で決めている。
+# 経緯は PR #1919 を参照。
 RSpec.describe 'テストで作る道場の ID' do
-  let(:synced_ids)  { DojosController::SHARED_EVENT_DATE_DOJOS.to_a.flatten }
-  let(:max_real_id) { Dojo.load_attributes_from_yaml.map { |dojo| dojo['id'].to_i }.max }
-
   # 開始値そのものを見る。DB のシーケンスの現在値に左右されないので、
   # 道場が増えて開始値を追い越したときに、実行環境によらず落ちる。
-  describe '採番の開始値' do
-    it '開催日を共有している道場の ID より大きい' do
-      expect(TEST_DOJO_ID_START).to be > synced_ids.max
-    end
+  it '採番の開始値が、実在する道場の ID より大きい' do
+    max_real_id = Dojo.load_attributes_from_yaml.map { |dojo| dojo['id'].to_i }.max
 
-    it '実在する道場の ID より大きい' do
-      expect(TEST_DOJO_ID_START).to be > max_real_id
-    end
+    expect(TEST_DOJO_ID_START).to be > max_real_id
   end
 
   # 開始値を適用する before(:suite) が外れたことを検出する。
-  # ただしシーケンスが既に進んでいる環境では通ってしまうため、
-  # 実質的な関門は毎回まっさらな DB で走る CI になる。
-  describe '実際に採番される ID' do
-    it '実在する道場の ID と衝突しない' do
-      expect(create(:dojo).id).to be > max_real_id
-    end
+  #
+  # 閾値に実在の最大 ID ではなく開始値を使う。実在の最大 ID にすると、
+  # 「スイートが作る道場の数 < 実在の最大 ID」が崩れた時点で、
+  # 最後に走った example だけ通ってしまう（順序依存になる）。
+  #
+  # なお、シーケンスが既に進んでいる環境では通ってしまう。
+  # 実質的な関門は、毎回まっさらな DB で走る CI になる。
+  it '実際に採番される ID が、開始値以上になる' do
+    expect(create(:dojo).id).to be >= TEST_DOJO_ID_START
   end
 end

--- a/spec/models/dojo_factory_spec.rb
+++ b/spec/models/dojo_factory_spec.rb
@@ -4,18 +4,29 @@ require 'rails_helper'
 # (SHARED_EVENT_DATE_DOJOS)。テストで作る道場がその ID を引き当てると、
 # 無関係な道場の開催日とリンクが行に混ざる。
 #
-# 採番の開始値は spec/rails_helper.rb の before(:suite) で進めている。
-# その仕組みが外れたことを、ここで検出する。
+# 採番の開始値は spec/rails_helper.rb の TEST_DOJO_ID_START で決めている。
 RSpec.describe 'テストで作る道場の ID' do
-  it '開催日を共有している道場の ID と衝突しない' do
-    synced_ids = DojosController::SHARED_EVENT_DATE_DOJOS.to_a.flatten
+  let(:synced_ids)  { DojosController::SHARED_EVENT_DATE_DOJOS.to_a.flatten }
+  let(:max_real_id) { Dojo.load_attributes_from_yaml.map { |dojo| dojo['id'].to_i }.max }
 
-    expect(create(:dojo).id).to be > synced_ids.max
+  # 開始値そのものを見る。DB のシーケンスの現在値に左右されないので、
+  # 道場が増えて開始値を追い越したときに、実行環境によらず落ちる。
+  describe '採番の開始値' do
+    it '開催日を共有している道場の ID より大きい' do
+      expect(TEST_DOJO_ID_START).to be > synced_ids.max
+    end
+
+    it '実在する道場の ID より大きい' do
+      expect(TEST_DOJO_ID_START).to be > max_real_id
+    end
   end
 
-  it '実在する道場の ID と衝突しない' do
-    max_real_id = Dojo.load_attributes_from_yaml.map { |dojo| dojo['id'].to_i }.max
-
-    expect(create(:dojo).id).to be > max_real_id
+  # 開始値を適用する before(:suite) が外れたことを検出する。
+  # ただしシーケンスが既に進んでいる環境では通ってしまうため、
+  # 実質的な関門は毎回まっさらな DB で走る CI になる。
+  describe '実際に採番される ID' do
+    it '実在する道場の ID と衝突しない' do
+      expect(create(:dojo).id).to be > max_real_id
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,14 +29,14 @@ ActiveRecord::Migration.maintain_test_schema!
 
 # テストで作る道場の ID の開始値。実在の道場より大きくする。
 #
-# DojosController は開催日を共有する道場を ID の即値で束ねているため
-# (SHARED_EVENT_DATE_DOJOS)、テストの道場がその ID を引き当てると、
+# DojosController#activity は開催日を共有する道場を sync_event_date に
+# ID の即値で渡している。テストの道場がその ID を引き当てると、
 # 無関係な開催日とリンクが行に混ざる。
 #
 # PostgreSQL のシーケンスはトランザクションでロールバックされないので、
 # 採番はスイート全体で進み続ける。CI は毎回まっさらな DB なので 1 から始まり、
 # 実行順序 (config.order = :random) によって、どの example が衝突するかが
-# 実行ごとに変わる。実際に main の CI で 1 件落ちた (2026-09-08)。
+# 実行ごとに変わる。経緯は PR #1919 を参照。
 #
 # この値が十分に大きいことは spec/models/dojo_factory_spec.rb で検証している。
 TEST_DOJO_ID_START = 100_000

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,20 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+# テストで作る道場の ID の開始値。実在の道場より大きくする。
+#
+# DojosController は開催日を共有する道場を ID の即値で束ねているため
+# (SHARED_EVENT_DATE_DOJOS)、テストの道場がその ID を引き当てると、
+# 無関係な開催日とリンクが行に混ざる。
+#
+# PostgreSQL のシーケンスはトランザクションでロールバックされないので、
+# 採番はスイート全体で進み続ける。CI は毎回まっさらな DB なので 1 から始まり、
+# 実行順序 (config.order = :random) によって、どの example が衝突するかが
+# 実行ごとに変わる。実際に main の CI で 1 件落ちた (2026-09-08)。
+#
+# この値が十分に大きいことは spec/models/dojo_factory_spec.rb で検証している。
+TEST_DOJO_ID_START = 100_000
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
@@ -61,16 +75,8 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     Rails.application.load_seed
-
-    # テストで作る道場の ID を、実在の道場より大きい値から始める。
-    # DojosController は開催日を共有する道場を ID の即値で束ねているため
-    # (SHARED_EVENT_DATE_DOJOS)、テストの道場がその ID を引き当てると、
-    # 無関係な開催日とリンクが行に混ざる。
-    #
-    # PostgreSQL のシーケンスはトランザクションでロールバックされないので、
-    # 採番はスイート全体で進み続ける。CI は毎回まっさらな DB なので 1 から
-    # 始まり、実行順序 (config.order = :random) によって、どの example が
-    # 衝突するかが変わる。実際に main の CI で 1 件落ちた (2026-09-08)。
-    ActiveRecord::Base.connection.execute('ALTER SEQUENCE dojos_id_seq RESTART WITH 100000')
+    ActiveRecord::Base.connection.execute(
+      "ALTER SEQUENCE dojos_id_seq RESTART WITH #{TEST_DOJO_ID_START}"
+    )
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,5 +61,16 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     Rails.application.load_seed
+
+    # テストで作る道場の ID を、実在の道場より大きい値から始める。
+    # DojosController は開催日を共有する道場を ID の即値で束ねているため
+    # (SHARED_EVENT_DATE_DOJOS)、テストの道場がその ID を引き当てると、
+    # 無関係な開催日とリンクが行に混ざる。
+    #
+    # PostgreSQL のシーケンスはトランザクションでロールバックされないので、
+    # 採番はスイート全体で進み続ける。CI は毎回まっさらな DB なので 1 から
+    # 始まり、実行順序 (config.order = :random) によって、どの example が
+    # 衝突するかが変わる。実際に main の CI で 1 件落ちた (2026-09-08)。
+    ActiveRecord::Base.connection.execute('ALTER SEQUENCE dojos_id_seq RESTART WITH 100000')
   end
 end


### PR DESCRIPTION
## 何が起きたか

PR #1918 のマージ後、main の CI で 1 件落ちました。

```
rspec ./spec/requests/dojos_spec.rb:674
  # note date priority handles Japanese date format in note (YYYY年MM月DD日)
```

期待は `2025-08-24` でしたが、実際の行には**別の道場の `2025-03-16`** とそのリンクが入っていました。

**同じコードで PR の CI は通っています。** マージした変更（`/spaces` の削除）とは無関係です。

## 原因

`DojosController#activity` は、開催日を共有する道場を `sync_event_date` に **ID の即値**で渡しています。

```ruby
sync_event_date(36,  35)   # 生駒 ← 奈良
sync_event_date(294, 35)   # 平群 ← 奈良
sync_event_date(112, 23)   # 南柏 ← 柏
sync_event_date(311, 23)   # 柏の葉 ← 柏
sync_event_date(106, 205)  # 宜野湾 ← 浦添
```

**PostgreSQL のシーケンスはトランザクションでロールバックされません。** 行は消えても採番は進み続けます。CI は毎回まっさらな DB なので ID は 1 から始まり、スイート全体で 23〜311 を必ず通過します。

実行順序は `config.order = :random` なので、**どの example のときに ID が 35 に達するかがシードで変わります**。テストが 2 つの道場を作り、その ID が (35, 36) になると、36 の行に 35 の日付が入ります。

ローカルで再現しないのは、test DB のシーケンスが既に大きな値まで進んでいるためで、シードの問題ではありませんでした。

## 直し方

`before(:suite)` で採番の開始値を `TEST_DOJO_ID_START`（100,000）へ進めます。**ID の割り当ては DB のシーケンスに任せたまま**です。

### factory に即値を入れる案は採らなかった

最初 `sequence(:id) { |n| 100_000 + n }` を factory に書きましたが、**別のテストが落ちました**。

```
1) dojos dojos:update_db_by_yaml 単純追加
   ActiveRecord::RecordNotUnique: duplicate key value violates unique constraint "dojos_pkey"
   DETAIL: Key (id)=(100270) already exists.
```

`dojos:update_db_by_yaml` は `postgresql:reset_pk_sequence` を前提タスクとして走らせ、シーケンスを `max(id)` に合わせます。factory が即値で入れた ID がその `max` になるため、後続の採番と重複します。**シーケンスに一本化すれば起きません。**

## 回帰テスト

2 件入れています。**「直ったか」だけでなく「壊れたときに落ちるか」も測りました。**

| 壊し方 | 結果 |
|---|---|
| 開始値を実在の ID より小さくする | **落ちる**（DB の状態によらない） |
| `before(:suite)` を外す・まっさらな DB | **落ちる**（CI 相当） |
| `before(:suite)` を外す・採番が進んだ DB | 落ちない（既知の限界。spec に明記） |

3 つ目の限界があるため、**実質的な関門は毎回まっさらな DB で走る CI** になります。

閾値には実在の最大 ID ではなく開始値を使っています。実在の最大 ID（359）を使うと、**スイートが作る道場の数（329）を上回っている間しか成立せず**、テストが 30 件増えた時点で順序依存になるためです。

## レビューを受けて外したもの

`sync_event_date` の即値を定数に切り出す変更を入れていましたが、**この PR から外しました**。

- `sync_event_date` の挙動を検証する spec が 1 件もない
- テストの修正を目的とした PR で、未検証の本番コードを書き換える形になっていた
- 切り出しの動機だった「テストから参照する」も、開始値そのものを検証する形に変えた時点で不要になった

**この PR は spec だけを変更します。** 切り出し自体は読みやすさの改善として有効なので、必要なら別途扱います。

## 確認したこと

`ALTER SEQUENCE dojos_id_seq RESTART WITH 1` に戻したうえで、4 つのシードで全件実行しました。

| seed | 結果 |
|---|---|
| 1 | 339 examples, 0 failures |
| 47795（CI で落ちたときと同じ） | 339 examples, 0 failures |
| 2026 | 339 examples, 0 failures |
| 555 | 339 examples, 0 failures |

- [x] RED → GREEN を確認した
- [x] 4 つのシードで全件通る
- [x] 修正を外すと再現する
- [x] 回帰テストの検出力を、壊し方 3 通りで測った
