### PR TITLE
fix(kata): 移転・改称でリンク先が変わった 8 件を差し替える

### DIFF
--- a/app/views/docs/kata.html.erb
+++ b/app/views/docs/kata.html.erb
@@ -386,7 +386,7 @@
 	    <p>by <a href="https://web.archive.org/web/20210115182553/http://www.coderdojo-hiroshima.com/">CoderDojo 紙屋町</a></p>
 	  </li>
 	  <li>
-	    <h4 id='learn-scratch-collect-gems'><a href="https://coderdojo-hommachi.github.io/assets/pdf/collect_gems.pdf">Collect gems - Learn Scratch</a></h4>
+	    <h4 id='learn-scratch-collect-gems'><a href="https://github.com/coderdojo-hommachi/coderdojo-hommachi.github.io/blob/develop/content/pdf/collect_gems.pdf">Collect gems - Learn Scratch</a></h4>
 	    <p>by 尾篭<small><small>さん</small></small> @ <a href="https://coderdojo-hommachi.doorkeeper.jp/">CoderDojo 本町</a></p>
 	  </li>
 	  <li>
@@ -415,11 +415,11 @@
 	  </li>
 	  <li>
 	    <h4 id='learn-scratch-drill'><a href="https://www.dropbox.com/s/po0a9m4wo6fst57/スクラッチドリル.pdf?dl=0">スクラッチドリル</a></h4>
-	    <p>by 岩田<small><small>さん</small></small> @ <a href="https://coderdojo-tempaku.com/">CoderDojo 天白</a></p>
+	    <p>by 岩田<small><small>さん</small></small> @ <a href="https://tempaku.connpass.com/">CoderDojo 天白</a></p>
 	  </li>
 	  <li>
 	    <h4 id='learn-scratch-hackathon'><a href="https://drive.google.com/file/d/1OJ2v05hxlTUA3OhyuGs9wHsSRDjr9_Wa/view">ハッカソンの実施例</a> (<a href="https://hackmd.io/s/Bk5iOvinN">ふりかえり</a>)</h4>
-	    <p>by 岩田<small><small>さん</small></small> @ <a href="https://coderdojo-tempaku.com/">CoderDojo 天白</a></p>
+	    <p>by 岩田<small><small>さん</small></small> @ <a href="https://tempaku.connpass.com/">CoderDojo 天白</a></p>
 	  </li>
 	  <li>
 	    <h4 id='learn-scratch-pair-programming'><a href="https://www.dropbox.com/s/1zz5rl28x5qkxx2/SCRATCH設計図.pdf?dl=0">ペアプログラミング用 Scratch 設計図</a> + <a href="https://www.dropbox.com/s/xz5hzswr10vruao/SCRATCH設計図.jpg?dl=0">利用例</a></h4>
@@ -464,7 +464,7 @@
 	  </li>
 	  <li>
 	    <h4 id='learn-microbit-getting-started'><a href="https://docs.google.com/presentation/d/1PX3geSydvXTEh2M7vwCV_tPIHNjqoHFVtrj09xT6a6Y/edit#slide=id.p">micro:bit をはじめよう</a></h4>
-	    <p>by 松浦<small><small>さん</small></small> @ <a href="https://coderdojo-ise.jimdo.com/">CoderDojo 伊勢</a></p>
+	    <p>by 松浦<small><small>さん</small></small> @ <a href="https://coderdojo-ise.jimdofree.com/">CoderDojo 伊勢</a></p>
 	  </li>
 	  <li>
 	    <h4 id='learn-microbit-game'><a href="https://web.archive.org/web/20210115182531/https://www.coderdojo-hiroshima.com/%E5%AD%A6%E7%BF%92%E3%83%92%E3%83%B3%E3%83%88/microbit%E3%81%A7%E3%82%B2%E3%83%BC%E3%83%A0%E3%82%92%E4%BD%9C%E3%82%8B">micro:bit でゲームを作る</a></h4>
@@ -520,8 +520,8 @@
 	    <p>by あるじ<small><small>さん</small></small> @ <a href="https://coderdojo.hanare-hibari.info/">CoderDojo ひばりヶ丘</a></p>
 	  </li>
 	  <li>
-	    <h4 id='learn-minecraft-cup-report'><a href='https://cd-kamagaya.yukiweb.jp/program/minecraftcup-report/'>マイクラカップ参加に向けた作品制作例</a></h4>
-	    <p>by ゆっきー<small><small>さん</small></small> @ <a href="https://cd-kamagaya.yukiweb.jp/">CoderDojo 鎌ケ谷</a></p>
+	    <h4 id='learn-minecraft-cup-report'><a href='https://cd-kamagaya.com/program/minecraftcup-report/'>マイクラカップ参加に向けた作品制作例</a></h4>
+	    <p>by ゆっきー<small><small>さん</small></small> @ <a href="https://cd-kamagaya.com/">CoderDojo 鎌ケ谷</a></p>
 	  </li>
 	  <li>
 	    <h4 id='learn-minecraft-at-school'><a href='https://tkby.github.io/micra.github.io/'>小学校授業でMinecraft（マインクラフト）</a></h4>
@@ -742,8 +742,8 @@
 	    <p>プログラミング言語「<a href="https://www.ruby-lang.org/ja/">Ruby</a>」に特化したプログラミングコンテストです。「ゲーム部門」と「クリエイティブ部門」などが用意されています。</p>
 	  </li>
 	  <li>
-	    <h4 id='challenge-contests-smalruby-koshien'><a href="https://smalruby-koshien.jp/">スモウルビー甲子園 - Smalruby Programming Koshien</a></h4>
-	    <p>高校生以下を対象としたプログラミング競技会です。Rubyベースのビジュアルプログラミング言語「<a href="https://miraino-manabi.mext.go.jp/content/287">スモウルビー</a>」を使って、ゲーム攻略 AI（人工知能）プログラムを作成し、参加者たちとゲームで対戦しながら頂点を目指します。</p>
+	    <h4 id='challenge-contests-smalruby-koshien'><a href="https://smalruby-koshien.netlab.jp/">スモウルビー甲子園 - Smalruby Programming Koshien</a></h4>
+	    <p>高校生以下を対象としたプログラミング競技会です。Rubyベースのビジュアルプログラミング言語「<a href="https://www.mext.go.jp/miraino_manabi/content/287.html">スモウルビー</a>」を使って、ゲーム攻略 AI（人工知能）プログラムを作成し、参加者たちとゲームで対戦しながら頂点を目指します。</p>
 	  </li>
 	  <li>
 	    <h4 id='challenge-contests-appli-koshien'><a href="https://applikoshien.jp/">アプリ甲子園 - TEENS APPS AWARDS</a></h4>
@@ -813,7 +813,7 @@
 	  </li>
 	  -->
 	  <li>
-	    <h4 id='tobitate-japan'><a href="http://www.tobitate.mext.go.jp/hs/program/tech/index.html">トビタテ！留学JAPAN</a> / <%= link_to raw('CoderDojo 留学'), doc_path('tobitate-japan') %></p></h4>
+	    <h4 id='tobitate-japan'><a href="https://tobitate-mext.jasso.go.jp/">トビタテ！留学JAPAN</a> / <%= link_to raw('CoderDojo 留学'), doc_path('tobitate-japan') %></p></h4>
 	    <p>高校生・高専生・大学生を対象とした文科省主催の留学支援プログラムです。返済不要の奨学金や研修など通して、好きなことで留学できるのが特長です。<b>「CoderDojo 留学」などの採択例</b>もあります。<%= link_to raw('&raquo; 詳細を見る'), doc_path('tobitate-japan') %></p>
 	  </li>
 	  <li>
@@ -845,7 +845,7 @@
 	    <p>個人のソフトウェア研究開発プロジェクトを応援する制度です。ラボユース生に採択された場合、サイボウズ・ラボ社員によるメンタリングや、最大103万円の奨励金などが受けられます。</p>
 	  </li>
 	  <li>
-	    <h4 id='security-camp'><a href="https://www.ipa.go.jp/jinzai/security-camp/about.html">セキュリティ・キャンプ</a></h4>
+	    <h4 id='security-camp'><a href="https://www.ipa.go.jp/jinzai/security-camp/index.html">セキュリティ・キャンプ</a></h4>
 	    <p>IPAが主催する、合宿形式で実践的な技術を習得するプログラムです。22歳以下の学生・生徒が対象。参加費、交通費すべて無料。</p>
 	  </li>
 	  <li>
@@ -1303,7 +1303,7 @@
 	  </li>
 	  <li>
 	    <h4 id='doc-for-mentors-in-ise'><a href="https://drive.google.com/file/d/0B0iP2Y_R2PEEZHcwQjNmSjR3SUk/view">CoderDojo メンター用資料</a></h4>
-	    <p>by <a href="https://coderdojo-ise.jimdo.com/">CoderDojo 伊勢</a></p>
+	    <p>by <a href="https://coderdojo-ise.jimdofree.com/">CoderDojo 伊勢</a></p>
 	  </li>
 	  <li>
 	    <h4 id='doc-zen-signup'><a href="https://coderdojo-gifu.org/how-to-register">Zen のアカウント作成 & 参加申し込み方法</a></h4>


### PR DESCRIPTION
## 概要

`/kata` のリンクのうち、**移転先が判明している 8 件**を差し替えます（11 箇所）。

| リンク | 差し替え先 | 根拠 |
|---|---|---|
| トビタテ！留学JAPAN | `tobitate-mext.jasso.go.jp` | 文科省から JASSO へ移管 |
| スモウルビー甲子園 | `smalruby-koshien.netlab.jp` | 移転先で **2026 年大会を開催中** |
| スモウルビー（未来の学び） | `mext.go.jp/miraino_manabi/content/287.html` | 同じ `content/287` が移転 |
| セキュリティ・キャンプ | `ipa.go.jp/.../security-camp/index.html` | `about.html` は 404 |
| Collect gems (PDF) | GitHub の `blob/develop/content/pdf/` | GitHub Pages から外れたが、リポジトリには現存 |
| CoderDojo 伊勢 ×2 | `coderdojo-ise.jimdofree.com` | `db/dojos.yml` が既にこちら |
| CoderDojo 天白 ×2 | `tempaku.connpass.com` | `db/dojos.yml` が既にこちら |
| CoderDojo 鎌ケ谷 ×2 | `cd-kamagaya.com` | `db/dojos.yml` が既にこちら |

## 後ろの 3 件について

**新しい URL はリポジトリの中にありました。** `db/dojos.yml` は更新済みで、`/kata` だけが古いままでした。

```
伊勢    旧 URL は到達不可（TLS ハンドシェイク失敗）
天白    旧 URL は到達不可（DNS 解決不可）
鎌ケ谷  旧 URL は転送で到達できていた（壊れてはいない）
```

鎌ケ谷は動いていますが、転送は提供元の都合で止まりうるので揃えました。

## 実装上の注意

置換は `href` の**属性値が完全一致**したときだけ行っています。部分文字列で置換すると、短い URL が長い URL の内側にも当たって入れ子になります（PR #1915 で実際に壊しました）。

## 確認したこと

- [x] 差し替え後の URL が 200 で到達する（8 件すべて）
- [x] 旧 URL の残存が 0 件
- [x] 入れ子の箇所数が変更前後とも 13 で増えていない
- [x] `bundle exec rspec spec` — 339 examples, 0 failures

## この PR で扱わないもの

`/kata` には他にも到達できないリンクが残っています。いずれも**移転先が無く、1 件ずつ判断が要る**ため別途扱います。

```
404  Speaker Deck（アカウントごと消滅）、Google Drive 2 件（共有停止）、
     coderdojo-gifu.org（Zen のアカウント作成手順。Zen 自体が終了済み）、
     こだいらのブログ記事
403  peraichi（「このページは現在閲覧できません。」）
000  プログラミングスタジアム、個人ブログ 1 件
```
