### PR TITLE
Update outdate domain of CoderDojo 松戸・赤羽

### DIFF
--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -930,7 +930,7 @@
   created_at: '2017-09-06'
   name: 松戸
   prefecture_id: 12
-  url: https://code4matsudo.org/category/coder-dojo-matsudo/
+  url: https://coderdojomatsudo.connpass.com/
   logo: "/img/dojos/default.webp"
   description: 松戸市で隔月開催
   tags:
@@ -1502,7 +1502,7 @@
   created_at: '2018-02-21'
   name: 赤羽
   prefecture_id: 13
-  url: https://coderdojo-akabane.com/
+  url: https://coderdojo-akabane.connpass.com/
   logo: "/img/dojos/akabane.webp"
   description: 北区で毎月開催
   tags:


### PR DESCRIPTION
掲載中の 2 道場で、掲載 URL のドメインが失効していました。connpass のグループ URL に差し替えます。

| Dojo | 変更前 | 変更後 |
|---|---|---|
| 松戸 (114) | `code4matsudo.org/category/coder-dojo-matsudo/` | `coderdojomatsudo.connpass.com/` |
| 赤羽 (130) | `coderdojo-akabane.com/` | `coderdojo-akabane.connpass.com/` |

どちらも connpass では活動が続いています（次回は 9/13 と 9/27）。

- [x] 差し替え後の URL が 200 で到達する
- [x] `bundle exec rspec spec` — 339 examples, 0 failures
