### PR TITLE
fix: 到達できないリンク 2 件を直す

### DIFF
--- a/app/views/shared/_partners.html.erb
+++ b/app/views/shared/_partners.html.erb
@@ -22,7 +22,7 @@
   <li style="margin: 20px auto 30px;"><%= link_to lazy_image_tag('/partners/techsoup-japan.png', alt: 'TechSoup Japan', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'G Suite などの寄贈申請の支援'), 'https://news.coderdojo.jp/2019/03/03/google-for-nonprofits-via-techsoup-japan/', target: "_blank" %></li>
   <li style="margin: 20px auto 30px;"><%= link_to lazy_image_tag('/partners/progate.png', alt: 'Progate', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'プログラミング学習環境の支援'), 'https://news.coderdojo.jp/2018/10/29/プログラミング学習のprogate、全国のcoderdojoへ法人プラン/', target: "_blank" %></li>
 
-  <li style="margin: 20px auto 30px;"><%= link_to lazy_image_tag('/partners/algolia.png', alt: 'Algolia', data: { toggle: 'tooltip', placement: 'bottom' }, title: '検索エンジン DocSearch の提供'), 'https://community.algolia.com/docsearch/', target: "_blank" %></li>
+  <li style="margin: 20px auto 30px;"><%= link_to lazy_image_tag('/partners/algolia.png', alt: 'Algolia', data: { toggle: 'tooltip', placement: 'bottom' }, title: '検索エンジン DocSearch の提供'), 'https://docsearch.algolia.com/', target: "_blank" %></li>
   <li style="margin: 20px auto 30px;"><%= link_to lazy_image_tag('/partners/github.png', alt: 'GitHub', data: { toggle: 'tooltip', placement: 'bottom' }, title: 'GitHub for Nonprofit の提供'), 'https://news.coderdojo.jp/2019/08/29/github-for-nonprofit/', target: "_blank" %></li>
 
   <li style="margin: 20px auto 30px;"><%= link_to lazy_image_tag('/partners/hackforplay.webp', alt: 'HackforPlay', data: { toggle: 'tooltip', placement: 'bottom' }, title: '法人向け HackforPlay の提供'), 'https://news.coderdojo.jp/2020/04/06/hackforplay-for-team/', target: "_blank" %></li>

--- a/public/podcasts/32.md
+++ b/public/podcasts/32.md
@@ -60,7 +60,7 @@
 00:44:13 作業完了後のふりかえり
 00:44:55 今後の寄贈プロジェクトへの展望
 00:46:02 日本国内での英語版CoderDojoの話
-00:46:35 統計情報の英語対応の話 https://coderdojo.jp/stats/english
+00:46:35 統計情報の英語対応の話 https://coderdojo.jp/english/stats
 00:47:00 CASE Shinjuku の日常にも、国際化の流れ
 00:49:10 CoderDojo 立ち上げ相談（ロボット工場のある町）
 00:54:07 CASE Shinjuku の紹介（1時間500円から利用可能）


### PR DESCRIPTION
## 概要

到達できないリンクを 2 件直します。

### ① パートナー欄の Algolia

`community.algolia.com/docsearch/` は **404** です。現行の `docsearch.algolia.com` へ差し替えます。

**パートナー欄はすべてのページに表示される**ため、露出が広い箇所です。

### ② 番組ノート 32 の自サイト内リンク

`https://coderdojo.jp/stats/english` は **自サイト内で 404** になります。正しくは `/english/stats` です。

```
/stats/english   404
/english/stats   200
```

## 確認したこと

- [x] `docsearch.algolia.com` が 200 で到達する
- [x] `/english/stats` が 200 で到達する
- [x] `bundle exec rspec spec` — 339 examples, 0 failures

画像ファイル名（`public/partners/algolia.png`）は提供元が同じため変更していません。
