### PR TITLE
fix(kata): 到達できないリンク 4 件を、移転先と保存版に振り分ける

### DIFF
--- a/app/views/docs/kata.html.erb
+++ b/app/views/docs/kata.html.erb
@@ -394,7 +394,7 @@
 	    <p>by 若林<small><small>さん</small></small> @ <a href="http://coderdojo-nara-ikoma.github.io/">CoderDojo 奈良・生駒</a></p>
 	  </li>
 	  <li>
-	    <h4 id='learn-scratch-getting-started'><a href="https://speakerdeck.com/yu_san_19/lets-getting-started-scratch">Scratch を始めよう！</a></h4>
+	    <h4 id='learn-scratch-getting-started'><a href="https://web.archive.org/web/20220707103733/https://speakerdeck.com/yu_san_19/lets-getting-started-scratch">Scratch を始めよう！</a></h4>
 	    <p>by 曽我<small><small>さん</small></small> @ <a href="https://www.coderdojo-konan.jp/">CoderDojo 岡山 岡南</a></p>
 	  </li>
 	  <li>
@@ -551,7 +551,7 @@
 	  <li>
 	    <h4 id='learn-basics-chart'><a href="http://tsuyoshioshima.github.io/ninjachart/">まよえるニンジャのための やりたいことさがし</a></h4>
 	    <p>
-	      by とがぞの<small><small>さん</small></small> @ <a href="https://coderdojo-kodaira.github.io/">CoderDojo こだいら</a> (<a href="http://coderdojo-kodaira.blog.jp/archives/59932567.html">データ</a>提供)<br>
+	      by とがぞの<small><small>さん</small></small> @ <a href="https://coderdojo-kodaira.github.io/">CoderDojo こだいら</a> (<a href="https://web.archive.org/web/20251214011446/https://coderdojo-kodaira.blog.jp/archives/59932567.html">データ</a>提供)<br>
 	      by 大島<small><small>さん</small></small> @ <a href="http://coderdojo-saitama.com/">CoderDojo さいたま</a> (ツール提供)
 	    </p>
 	  </li>
@@ -1306,7 +1306,7 @@
 	    <p>by <a href="https://coderdojo-ise.jimdo.com/">CoderDojo 伊勢</a></p>
 	  </li>
 	  <li>
-	    <h4 id='doc-zen-signup'><a href="https://coderdojo-gifu.org/how-to-register">Zen のアカウント作成 & 参加申し込み方法</a></h4>
+	    <h4 id='doc-zen-signup'><a href="https://coderdojo-gifu.org/create-connpass-account">connpass のアカウント作成 & 参加申し込み方法</a></h4>
 	    <p>by <a href="https://coderdojo-gifu.org/">CoderDojo 岐阜</a></p>
 	  </li>
 	  <li>
@@ -1331,7 +1331,7 @@
 	  </li>
 	  <li>
 	    <h4 id='doc-decadojo-in-tokyo'><a href="https://www.yokoyan.net/entry/2018/07/27/181500">でかドージョー in 東京にはじめてメンター参加したらニンジャたちのレベルの高さに衝撃を受けた話</a></h4>
-	    <p>by <a href='https://peraichi.com/landing_pages/view/0vsas/'>DecaDojo in Tokyo メンター</a></p>
+	    <p>by <a href='https://web.archive.org/web/20220516194156/https://peraichi.com/landing_pages/view/0vsas'>DecaDojo in Tokyo メンター</a></p>
 	  </li>
 	  <li>
 	    <h4 id='doc-decadojo-in-fukushima-2023'><a href="https://www.coderdojo-kitakata.com/posts/50710870">「福島でかドージョー2023」スポンサー向け資料の公開</a></h4>


### PR DESCRIPTION
## 概要

`/kata` に残っていた到達できないリンクを、**移転先が見つかったもの**と**保存版で残すもの**に振り分けます。

| リンク | 状態 | 対応 |
|---|---|---|
| Zen のアカウント作成 & 参加申し込み方法 | 404 | **現行ページへ** — 岐阜は connpass に移行済み |
| Scratch を始めよう！ | 404 | 保存版へ — Speaker Deck の**アカウントごと消滅** |
| こだいらのデータ | 404 | 保存版へ — ブログ本体は生きているが記事が消えている |
| DecaDojo in Tokyo メンター | 403 | 保存版へ — 「このページは現在閲覧できません。」 |

## 岐阜のページについて

保存版を見ると、このページは **Zen の後継である CoderDojo Community Platform** の手順に更新されていました。現在の岐阜のサイトを見ると、さらに **connpass** に移行しています。

```
coderdojo-gifu.org/how-to-register          404
coderdojo-gifu.org/create-connpass-account  200  「connpassアカウントの作り方」
```

**見出しの文言も `Zen` から `connpass` に改めました。** Zen 自体が終了しており、リンク先も connpass の手順になっているためです。

**アンカー（`id='doc-zen-signup'`）はそのままにしています。** 変更すると `#doc-zen-signup` への既存の深いリンクが壊れるためです。

## 保存版の選び方

**3 件とも本文を確認しました。** 日付だけで選ぶと、失効後に第三者が取得したドメインの保存版を掴むことがあります（PR #1915 で実際に危なかった箇所です）。

```
Scratch を始めよう！   Speaker Deck のスライドページ
こだいらのデータ       「新しい取り組みの御案内 - 申込み方法の変更…」
DecaDojo in Tokyo     「でかドージョーin東京」
```

## この PR で直せなかったもの（3 件）

### Google Drive の 2 件 — 保存版が使えません

```
CoderDojo メンター用資料      by CoderDojo 伊勢
コーダー道場こだいら 会則      by CoderDojo こだいら
```

どちらも**共有が停止**されています（サインインを求められます）。保存版は存在しますが、**中身は空でした** — Google Drive のビューアは JavaScript で本文を読み込むため、保存されているのは外枠だけです（ヘッドレスブラウザで確認）。

**提供元の 2 道場に再共有をお願いするか、記述ごと外すかの判断が要ります。**

なお、こだいらの資料は保存版のファイル名が `会則.pdf.old_2016` でした。現行版は別にある可能性があります。

### プログラミングスタジアム — 状態が判断できません

```
jcdpgstadium.jp   DNS が解決しない
ドメイン登録       株式会社JTBコミュニケーションデザイン、2027/02 まで有効
保存版             2026-03 のものが残っている（内容は本物）
```

**ドメインは保有されたまま、サイトだけが落ちている**状態です。一時的な停止か、終了かが分かりません。第 4 回（2024 年）以降の開催情報も見つかりませんでした。

保存版に差し替えるか、しばらく様子を見るか、掲載をやめるかの判断が要ります。

## 確認したこと

- [x] 差し替え後の 4 URL がすべて 200 で到達する
- [x] 保存版 3 件の本文が本物であることを確認した
- [x] 保存版の中に保存版が入る二重の入れ子が 0 件
- [x] `bundle exec rspec spec` — 339 examples, 0 failures
