### PR TITLE
Update outdated domains of 7 inactive dojos

### DIFF
--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -953,7 +953,7 @@
   inactivated_at: '2023-10-26'
   name: 野田
   prefecture_id: 12
-  url: https://mamejuku.org/coderdojonoda/
+  url: https://web.archive.org/web/20240915141214/https://mamejuku.org/coderdojonoda/
   logo: "/img/dojos/default.webp"
   description: 野田市で毎月開催
   tags:
@@ -1111,7 +1111,7 @@
   inactivated_at: '2021-06-16'
   name: 酒々井
   prefecture_id: 12
-  url: https://home.omegane-pr.com/coderdojo/
+  url: https://web.archive.org/web/20190818000252/https://home.omegane-pr.com/coderdojo/
   logo: "/img/dojos/shisui.webp"
   description: 印旛郡酒々井町で毎月開催
   tags:
@@ -2647,7 +2647,7 @@
   inactivated_at: '2022-03-16'
   name: 一宮
   prefecture_id: 23
-  url: https://hauska-paikka.jp/event/coderdojo/
+  url: https://coderdojo-ichinomiya.connpass.com/
   logo: "/img/dojos/ichinomiya.webp"
   description: 一宮市新生で月2回開催
   tags:
@@ -3220,7 +3220,7 @@
   inactivated_at: '2023-10-26'
   name: みのお
   prefecture_id: 27
-  url: http://www.coderdojo-minoh.org/
+  url: https://coderdojo-minoh.connpass.com/
   logo: "/img/dojos/minoh.webp"
   description: 箕面市で毎月開催
   tags:
@@ -3504,7 +3504,7 @@
   inactivated_at: '2022-03-16'
   name: あしや
   prefecture_id: 28
-  url: https://coderdojo-ashiya.org/
+  url: https://coderdojo-ashiya.doorkeeper.jp/
   logo: "/img/dojos/ashiya.webp"
   description: 芦屋市で毎月開催
   tags:
@@ -3854,7 +3854,7 @@
   inactivated_at: '2019-04-27'
   name: 吉賀
   prefecture_id: 32
-  url: http://www.coderdojo-yoshika.com/
+  url: https://coderdojo-yoshika.connpass.com/
   logo: "/img/dojos/yoshika.webp"
   description: 鹿足郡吉賀町で不定期開催
   tags:
@@ -4330,7 +4330,7 @@
   inactivated_at: '2023-10-26'
   name: 日吉
   prefecture_id: 40
-  url: https://coderdojo-hiyoshi.com/
+  url: https://coderdojo-hiyoshi.connpass.com/
   logo: "/img/dojos/default.webp"
   description: 久留米市日吉校区で隔月開催
   tags:


### PR DESCRIPTION
## 概要

掲載を終了した 7 道場の掲載 URL で、**ドメインの登録が切れていました**。誰でも取得できる状態のため、行き先を振り替えます。

`/dojos/activity` と `dojos.json` に出ています。

## イベントサービスの登録があるもの（5 件）

| Dojo | 変更後 |
|---|---|
| 吉賀 (78) | `coderdojo-yoshika.connpass.com` |
| みのお (108) | `coderdojo-minoh.connpass.com` |
| 一宮 (214) | `coderdojo-ichinomiya.connpass.com` |
| あしや (220) | `coderdojo-ashiya.doorkeeper.jp` |
| 日吉 (207) | `coderdojo-hiyoshi.connpass.com` |

いずれも `db/dojo_event_services.yml` に登録済みで、200 で到達します。

## 登録が無いもの（2 件）

保存版に振り替えます。

| Dojo | 保存版 |
|---|---|
| 酒々井 (157) | 2019-08-18 |
| 野田 (283) | 2024-09-15 |

**2 件とも描画して中身を確認しました。** 日付だけで選ぶと、失効後に第三者が取得したドメインの保存版を掴むことがあります（PR #1915 で実際に危なかった箇所です）。

```
酒々井  「CoderDojo Shisui」のトップページ
野田    「CoderDojo野田 | NPO法人まめ塾」の案内ページ
```

`url` は `validates :url, presence: true` なので空にはできません。

## 確認したこと

- [x] 差し替え後の 7 URL がすべて 200 で到達する
- [x] 保存版 2 件の中身を描画して確認した
- [x] 保存版の中に保存版が入る二重の入れ子が 0 件
- [x] `bundle exec rspec spec` — 339 examples, 0 failures

## 補足

`db/dojos.yml` を `omegane-pr.com` / `mamejuku.org` で検索すると 1 件ずつ残りますが、**これは保存版 URL の内側にある旧ドメイン**です。`url:` 行が直接それらを指している箇所は 0 件です。

掲載中の松戸・赤羽は PR #1921 で扱っています。
