### PR TITLE
fix(kata): 参照できないリンクの整理

### DIFF
--- a/app/views/docs/kata.html.erb
+++ b/app/views/docs/kata.html.erb
@@ -394,10 +394,6 @@
 	    <p>by 若林<small><small>さん</small></small> @ <a href="http://coderdojo-nara-ikoma.github.io/">CoderDojo 奈良・生駒</a></p>
 	  </li>
 	  <li>
-	    <h4 id='learn-scratch-getting-started'><a href="https://web.archive.org/web/20220707103733/https://speakerdeck.com/yu_san_19/lets-getting-started-scratch">Scratch を始めよう！</a></h4>
-	    <p>by 曽我<small><small>さん</small></small> @ <a href="https://www.coderdojo-konan.jp/">CoderDojo 岡山 岡南</a></p>
-	  </li>
-	  <li>
 	    <h4 id='learn-scratch-shooting'><a href="https://coderdojochofu.hatenablog.jp/archive/category/Scratchでシューティングゲームを作ろう！">Scratch でシューティングゲームを作ろう!</a></h4>
 	    <p>by おおやけ<small><small>さん</small></small> @ <a href="https://coderdojochofu.hatenablog.jp/">CoderDojo 調布</a></p>
 	  </li>


### PR DESCRIPTION
## 概要

`/kata` の「Scratch を始めよう！」（by 曽我さん @ CoderDojo 岡山 岡南）を削除します。

Speaker Deck の**アカウントごと消滅**しており、資料の提供元をたどれません。

```
https://speakerdeck.com/yu_san_19/lets-getting-started-scratch   404
https://speakerdeck.com/yu_san_19                                404（アカウント）
```

PR #1923 で保存版に差し替えましたが、掲載自体を終えます。

## 確認したこと

- [x] アンカー `learn-scratch-getting-started` への参照が 0 件
- [x] `<li>` の開閉数が一致（251 / 251）
- [x] `bundle exec rspec spec` — 339 examples, 0 failures
