### PR TITLE
fix(kata): 参照できないリンクの整理

### DIFF
--- a/app/views/docs/kata.html.erb
+++ b/app/views/docs/kata.html.erb
@@ -1318,10 +1318,6 @@
 	    <p>by <a href="https://coderdojoowari.org/">CoderDojo 尾張</a></p>
 	  </li>
 	  <li>
-	    <h4 id='doc-terms-example-in-kodaira'><a href="https://drive.google.com/file/d/0B4RWVH6FrM8aUl9zdldWXzJBWGM/view">コーダー道場こだいら 会則</a></h4>
-	    <p>by <a href="https://coderdojo-kodaira.github.io/">CoderDojo Kodaira</a></p>
-	  </li>
-	  <li>
 	    <h4 id='doc-decadojo'><a href="/podcasts/5">DecaDojo（でかドージョー）とは？</a></h4>
 	    <p>by <%= link_to 'CoderDojo Japan', doc_path('about') %></p>
 	  </li>


### PR DESCRIPTION
## 概要

`/kata` の「コーダー道場こだいら 会則」を削除します。

Google Drive の**共有が停止**しており、開けません。

```
https://drive.google.com/file/d/0B4RWVH6FrM8aUl9zdldWXzJBWGM/view   401（サインイン要求）
```

保存版もありますが、**ビューアの外枠だけで本文が入っていません**（Drive は JavaScript で本文を読み込むため）。ヘッドレスブラウザで確認したところ、真っ黒な画面が表示されました。

なお保存版のファイル名は `会則.pdf.old_2016` でした。現行版は別にある可能性があります。

## 確認したこと

- [x] アンカー `doc-terms-example-in-kodaira` への参照が 0 件
- [x] `<li>` の開閉数が一致（251 / 251）
- [x] `bundle exec rspec spec` — 339 examples, 0 failures
