### PR TITLE
fix(podcasts): 到達できないリンクを差し替える

### DIFF
--- a/public/podcasts/10.md
+++ b/public/podcasts/10.md
@@ -42,7 +42,7 @@ For English speakers, <a href="https://twitter.com/CoderDojo/status/107567740441
 - [CoderDojo Tokyo #1 と創始者ジェームズ・ウェルトン氏来日のまとめ](https://tech.a-listers.jp/2012/05/09/coderdojo-tokyo-1-james-whelton-in-japan/)
 - [CoderDojo Foundation](https://speakerdeck.com/helloworldfoundation)
 - [CoderDojo Japan](https://coderdojo.jp/)
-- [UTIPS - 共有しよう、家事のやり方](https://utips.life/)
+- [UTIPS - 共有しよう、家事のやり方](https://jr.mitou.org/projects/2018/utips)
 - [Dojo Hopping](https://coderdojo.com/2017/11/22/coderdojo-and-me/)
 
 ## 👏 Special Thanks 

--- a/public/podcasts/11.md
+++ b/public/podcasts/11.md
@@ -36,7 +36,7 @@
 
 ### 未踏ジュニアクリエータの活躍例
 
-- [Toubans! -LINE上で設定・通知出来る当番通知LINE BOT-](https://www.toubans.com/)
+- [Toubans! -LINE上で設定・通知出来る当番通知LINE BOT-](https://jr.mitou.org/projects/2018/toubans)
 - [Toubans! pitch at SXSW 2019](https://www.youtube.com/watch?v=EZvmIcmtWoE)
 - [SXSW Edu - Student Startup Competition](https://www.sxswedu.com/competitions/student-startup/)
 - [「50センチ革命」の先にあるものとは。未踏ジュニアからLINE BOOT AWARDSグランプリ受賞、SXSW Eduでもピッチをした未踏ジュニアスーパークリエータ - EdTechZine](https://edtechzine.jp/article/detail/1976)

--- a/public/podcasts/5.md
+++ b/public/podcasts/5.md
@@ -41,6 +41,6 @@
 
 - [CoderDojo 札幌](https://www.facebook.com/coderdojo.sapporo/)
 - [CoderDojo 広島](https://web.archive.org/web/20260519005549/https://www.coderdojo-hiroshima.com/)
-- [CoderDojo 岡山 岡南](http://coderdojo-konan.media-interesting.info/)
+- [CoderDojo 岡山 岡南](https://www.coderdojo-konan.jp/)
 
 


### PR DESCRIPTION
紹介先のサービスが終了しているものは、未踏ジュニアのプロジェクトページ (permalink) に振り替えます。道場のリンクは現行の URL に揃えます。
