### PR TITLE
fix: 第三者に渡ったドメインへのリンクを保存版に振り替える

### DIFF
--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -1277,7 +1277,7 @@
   inactivated_at: '2020-08-20'
   name: 高田馬場
   prefecture_id: 13
-  url: http://coderdojo-tdbb.com/
+  url: https://web.archive.org/web/20180106223341/http://coderdojo-tdbb.com/
   logo: "/img/dojos/takadanobaba.webp"
   description: 新宿区高田馬場で毎月開催
   tags:
@@ -1516,7 +1516,7 @@
   inactivated_at: '2023-10-26'
   name: 板橋@桜川
   prefecture_id: 13
-  url: https://coderdojo.sakuragawa.tokyo/
+  url: https://web.archive.org/web/20230529153203/https://coderdojo.sakuragawa.tokyo/
   logo: "/img/dojos/itabashi.webp"
   description: 板橋区で毎月開催
   tags:

--- a/db/dojos.yml
+++ b/db/dojos.yml
@@ -3236,7 +3236,7 @@
   inactivated_at: '2021-07-19'
   name: 柏原
   prefecture_id: 27
-  url: https://www.coderdojo-fujiidera-kashiwara.com
+  url: https://web.archive.org/web/20220930101545/https://www.coderdojo-fujiidera-kashiwara.com/
   logo: "/img/dojos/coderdojo.webp"
   description: 柏原市で毎月開催
   tags:
@@ -3306,7 +3306,7 @@
   inactivated_at: '2021-07-19'
   name: 藤井寺
   prefecture_id: 27
-  url: https://www.coderdojo-fujiidera-kashiwara.com
+  url: https://web.archive.org/web/20220930101545/https://www.coderdojo-fujiidera-kashiwara.com/
   logo: "/img/dojos/coderdojo.webp"
   description: 藤井寺市で毎月開催
   tags:
@@ -3322,7 +3322,7 @@
   note: 2021-07-25 https://coderdojo-fujiidera.localinfo.jp/posts/19955576
   name: 藤井寺・柏原
   prefecture_id: 27
-  url: https://www.coderdojo-fujiidera-kashiwara.com
+  url: https://web.archive.org/web/20220930101545/https://www.coderdojo-fujiidera-kashiwara.com/
   logo: "/img/dojos/fujiidera-kashiwara.webp"
   description: 藤井寺市/柏原市で毎月開催
   tags:

--- a/public/podcasts/2.md
+++ b/public/podcasts/2.md
@@ -18,7 +18,7 @@
 - [CoderDojo 柏の葉](http://coderdojo-kashiwa.com/kashiwanoha/)
 - [CoderDojo 流山](http://www.code-for-nagareyama.org/?cat=11)
 - [CoderDojo 水戸](http://coderdojo-mito.com/)
-- [CoderDojo 高田馬場](http://coderdojo-tdbb.com/)
+- [CoderDojo 高田馬場](https://web.archive.org/web/20180106223341/http://coderdojo-tdbb.com/)
 
 -----------
 

--- a/public/podcasts/5.md
+++ b/public/podcasts/5.md
@@ -26,7 +26,7 @@
 
 --------------
 
-- [CoderDojo 高田馬場](http://coderdojo-tdbb.com/)
+- [CoderDojo 高田馬場](https://web.archive.org/web/20180106223341/http://coderdojo-tdbb.com/)
 - [CoderDojo 中野](https://www.facebook.com/coderdojonakano/)
 - [CoderDojo ひばりヶ丘](http://coderdojo.hanare-hibari.info/)
 

--- a/public/podcasts/8.md
+++ b/public/podcasts/8.md
@@ -28,7 +28,7 @@
 
 - [CoderDojo Kata](https://coderdojo.jp/kata) (日本語)
 - [CoderDojo Kata](http://kata.coderdojo.com/wiki/Home_Page) (英語)
-- [CoderDojo 高田馬場](http://coderdojo-tdbb.com/)
+- [CoderDojo 高田馬場](https://web.archive.org/web/20180106223341/http://coderdojo-tdbb.com/)
 
 ### オマケ: CoderDojo コミュニティの特徴
 


### PR DESCRIPTION
掲載を終了した道場の URL で、ドメインが第三者に渡っていたもの・渡りかけているものを、掲載当時の保存版へ振り替えます。

| Dojo | 状態 | 参照元 |
|---|---|---|
| 高田馬場 (58) | 2025-07-03 に**再登録**。現在は無関係な内容 | `dojos.yml` と番組ノート 3 件 |
| 板橋@桜川 (231) | 2026-07-20 に**再登録**。現在は無関係な内容 | `dojos.yml` |
| 藤井寺 (264) / 柏原 (271) / 藤井寺・柏原 (272) | 2026-07-14 に**失効**し復旧猶予中。NS はパーキング業者 | `dojos.yml` |

**乗っ取り後の保存版を選ばないよう、3 件とも描画して中身を確認しました。**

```
高田馬場    2018-01-06 の保存版（掲載終了は 2020-08-20）
板橋@桜川   2023-05-29 の保存版（掲載終了は 2023-10-26）
藤井寺・柏原 2022-09-30 の保存版（掲載終了は 2021〜2022）
```

## 見つけ方

`db/dojos.yml` の 62 ドメインを RDAP と whois で確認しました。**内容だけを見ても分かりません。**

```
乗っ取り後の高田馬場のページに「coderdojo」が 26 件
→ ドメイン名がページ内に出るため、内容検査を通過してしまう
```

見るべき指標は 1 つではありませんでした。

| 指標 | 検出できるもの |
|---|---|
| `registration` が掲載日より後 | 削除されて**再登録**されたもの（高田馬場・板橋@桜川） |
| `status` が `redemption period` | **失効しかけ**のもの（藤井寺・柏原） |
| ネームサーバーがパーキング業者 | **売りに出ている**もの（同上） |

**`registration` だけでは足りません。** 期限切れオークションでの移転は登録日をリセットしないため、`coderdojo-hiroshima.com`（登録 2016-05-25 のまま、PR #1915 で対処済み）はこの指標に一切かかりません。

## 確認したこと

- [x] 差し替え後の 3 URL が 200 で到達する
- [x] 保存版の中身を描画して確認した
- [x] 保存版以外での参照が 0 件
- [x] 保存版の中に保存版が入る二重の入れ子が 0 件
- [x] `bundle exec rspec spec` — 339 examples, 0 failures
